### PR TITLE
Add support for personalized service deployments

### DIFF
--- a/.personalize_deploy.sh
+++ b/.personalize_deploy.sh
@@ -13,7 +13,7 @@ BASEDIR=${4:?Please provide the base directory containing app.yaml}
 
 if [[ -f ${BASEDIR}/app.yaml ]] ; then
   if [[ -n "${TRAVIS_BRANCH}" ]] ; then
-    if [[ condition: $TRAVIS_BRANCH == sandbox-* ]] ; then
+    if [[ ${TRAVIS_BRANCH} == sandbox-* ]] ; then
       user=${TRAVIS_BRANCH##sandbox-}
       sed -i -e 's/^service: \(.*\)/service: \1-'${user}'/' \
           cmd/etl_worker/app.yaml

--- a/.personalize_deploy.sh
+++ b/.personalize_deploy.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Modifies the appengine app.yaml service to include the sandbox user name. If
+# this is not on a sandbox branch, then no action is taken.
+
+set -x
+set -e
+
+SCRIPT=${1:?Please provide the deployment script}
+PROJECT=${2:?Please provide the GCP project id}
+KEYFILE=${3:?Please provide the service account key file}
+BASEDIR=${4:?Please provide the base directory containing app.yaml}
+
+if [[ -f ${BASEDIR}/app.yaml ]] ; then
+  if [[ -n "${TRAVIS_BRANCH}" ]] ; then
+    if [[ condition: $TRAVIS_BRANCH == sandbox-* ]] ; then
+      user=${TRAVIS_BRANCH##sandbox-}
+      sed -i -e 's/^service: \(.*\)/service: \1-'${user}'/' \
+          cmd/etl_worker/app.yaml
+    fi
+  fi
+fi
+
+# Call actual script to deploy service.
+"${SCRIPT}" "${PROJECT}" "${KEYFILE}" "${BASEDIR}"

--- a/.personalize_deploy.sh
+++ b/.personalize_deploy.sh
@@ -16,7 +16,7 @@ if [[ -f ${BASEDIR}/app.yaml ]] ; then
     if [[ ${TRAVIS_BRANCH} == sandbox-* ]] ; then
       user=${TRAVIS_BRANCH##sandbox-}
       sed -i -e 's/^service: \(.*\)/service: \1-'${user}'/' \
-          cmd/etl_worker/app.yaml
+          "${BASEDIR}/app.yaml"
     fi
   fi
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,4 +54,6 @@ deploy:
     # "all_branches" is false, and the condition is ignored.
     all_branches: true
     # A bash-style 'if' condition, matching branches with a "sandbox-" prefix.
-    condition: $TRAVIS_BRANCH == sandbox-*
+    # Sandbox branches will be deployed to personalized service names.
+    # Integration branch will not use decorated service names.
+    condition: $TRAVIS_BRANCH == sandbox-* || $TRAVIS_BRANCH == integration

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,8 @@ script:
 deploy:
 # SANDBOX: before code review for development code in a specific branch.
 - provider: script
-  script: $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-sandbox
+  script: $TRAVIS_BUILD_DIR/.personalize_deploy.sh
+    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-sandbox
     /tmp/mlab-sandbox.json $TRAVIS_BUILD_DIR/cmd/etl_worker
   skip_cleanup: true
   on:


### PR DESCRIPTION
This change adds personalized service names for deployments from sandbox-<username>.

The "etl-parser" service is decorated with the username as "etl-parser-<username". This will allow parallel experimentation with the appengine flexible environment service.

As well, the "integration" branch is recognized for deployment as well, but this will not decorate the service name. As a result, the integration branch can be our canonical reliable service between reviews.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/6)
<!-- Reviewable:end -->
