### PR TITLE
Add push-queue AppEngine SE service

### DIFF
--- a/appengine/push_queue/README.md
+++ b/appengine/push_queue/README.md
@@ -1,0 +1,21 @@
+# Deploy push-queue service
+
+
+## Dependencies
+
+Install the Google Cloud SDK, i.e. `gcloud`.
+
+```
+  $ gcloud components install app-engine-go
+  $ gcloud components install beta
+```
+
+## Deploy
+
+From the `appengine/push_queue` directory:
+```
+$ gcloud beta app deploy
+```
+
+At the time of writing, `gcloud app deploy` does not work correctly with go
+import paths.

--- a/appengine/push_queue/app.yaml
+++ b/appengine/push_queue/app.yaml
@@ -1,6 +1,6 @@
 runtime: go
 api_version: go1
-service: push-queue
+service: queue-pusher
 
 handlers:
 - url: /.*

--- a/appengine/push_queue/app.yaml
+++ b/appengine/push_queue/app.yaml
@@ -1,0 +1,7 @@
+runtime: go
+api_version: go1
+service: push-queue
+
+handlers:
+- url: /.*
+  script: _go_app

--- a/appengine/push_queue/push_queue.go
+++ b/appengine/push_queue/push_queue.go
@@ -1,0 +1,102 @@
+// A microservice that accepts HTTP requests, creates a Task from given
+// parameters, and adds the Task to a Push TaskQueue.
+package pushqueue
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"google.golang.org/appengine"
+	"google.golang.org/appengine/taskqueue"
+)
+
+const defaultMessage = "<html><body>This is not the app you're looking for.</body></html>"
+
+// Requests can only add tasks to one of these whitelisted queue names.
+var queueWhitelist = map[string]bool{
+	"etl-parser-queue":           true,
+	"etl-ndt-queue":              true,
+	"etl-sidestream-queue":       true,
+	"etl-paris-traceroute-queue": true,
+}
+
+func init() {
+	http.HandleFunc("/", defaultHandler)
+	http.HandleFunc("/receiver", receiver)
+	http.HandleFunc("/stats", queueStats)
+}
+
+// A default handler for root path.
+func defaultHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	fmt.Fprintf(w, defaultMessage)
+}
+
+// queueStats provides statistics for a given queue.
+func queueStats(w http.ResponseWriter, r *http.Request) {
+	queuename := r.FormValue("queuename")
+
+	if queuename == "" {
+		http.Error(w, `{"message": "Bad request parameters"}`, http.StatusBadRequest)
+		return
+	}
+
+	if _, ok := queueWhitelist[queuename]; !ok {
+		// TODO(dev): return the queueWhitelist to client.
+		http.Error(w, `{"message": "Given queue name is not acceptable"}`, http.StatusNotAcceptable)
+		return
+	}
+
+	// Get stats.
+	ctx := appengine.NewContext(r)
+	stats, err := taskqueue.QueueStats(ctx, []string{queuename})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Return stats to client.
+	b, err := json.Marshal(stats)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	fmt.Fprintf(w, string(b))
+}
+
+// receiver accepts a GET request, and transforms the given parameters into a TaskQueue Task.
+func receiver(w http.ResponseWriter, r *http.Request) {
+	// TODO(dev): require a POST instead of a GET.
+	if r.Method != http.MethodGet {
+		http.Error(w, `{"message": "Method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+
+	filename := r.FormValue("filename")
+	queuename := r.FormValue("queuename")
+
+	if filename == "" || queuename == "" {
+		http.Error(w, `{"message": "Bad request parameters"}`, http.StatusBadRequest)
+		return
+	}
+
+	if _, ok := queueWhitelist[queuename]; !ok {
+		// TODO(dev): return the queueWhitelist to client.
+		http.Error(w, `{"message": "Given queue name is not acceptable"}`, http.StatusNotAcceptable)
+		return
+	}
+
+	ctx := appengine.NewContext(r)
+	params := url.Values{"filename": []string{filename}}
+	t := taskqueue.NewPOSTTask("/worker", params)
+	if _, err := taskqueue.Add(ctx, t, queuename); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}

--- a/appengine/push_queue/push_queue.go
+++ b/appengine/push_queue/push_queue.go
@@ -79,16 +79,12 @@ func receiver(w http.ResponseWriter, r *http.Request) {
 	}
 
 	filename := r.FormValue("filename")
-	queuename := r.FormValue("queuename")
 
-	if filename == "" || queuename == "" {
+	// TODO(dev): determine correct queue based on file type.
+	queuename := "etl-parser-queue"
+
+	if filename == "" {
 		http.Error(w, `{"message": "Bad request parameters"}`, http.StatusBadRequest)
-		return
-	}
-
-	if _, ok := queueWhitelist[queuename]; !ok {
-		// TODO(dev): return the queueWhitelist to client.
-		http.Error(w, `{"message": "Given queue name is not acceptable"}`, http.StatusNotAcceptable)
 		return
 	}
 

--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -39,10 +39,16 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 func worker(w http.ResponseWriter, r *http.Request) {
 	r.ParseForm()
+	// Log request data.
 	for key, value := range r.Form {
-		log.Printf("%q == %q\n", key, value)
+		log.Printf("Form:   %q == %q\n", key, value)
+	}
+	// Log headers.
+	for key, value := range r.Header {
+		log.Printf("Header: %q == %q\n", key, value)
 	}
 
+	// TODO(dev): log the originating task queue name from headers.
 	log.Printf("Received filename: %q\n", r.FormValue("filename"))
 
 	// TODO(dev): Remove fake delay.

--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -48,7 +48,7 @@ func worker(w http.ResponseWriter, r *http.Request) {
 	// TODO(dev): Remove fake delay.
 	t := 10 * rand.ExpFloat64()
 	log.Printf("Simulating work by sleeping for %f seconds\n", t)
-	time.Sleep(t)
+	time.Sleep(time.Duration(t))
 
 	fmt.Fprintf(w, `{"message": "Success"}`)
 }

--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -3,7 +3,10 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"math/rand"
 	"net/http"
+	"time"
 
 	"github.com/m-lab/etl/metrics"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -35,7 +38,19 @@ func handler(w http.ResponseWriter, r *http.Request) {
 }
 
 func worker(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, `{"message": "Hello world!"}`)
+	r.ParseForm()
+	for key, value := range r.Form {
+		log.Printf("%q == %q\n", key, value)
+	}
+
+	log.Printf("Received filename: %q\n", r.FormValue("filename"))
+
+	// TODO(dev): Remove fake delay.
+	t := 10 * rand.ExpFloat64()
+	log.Printf("Simulating work by sleeping for %f seconds\n", t)
+	time.Sleep(t)
+
+	fmt.Fprintf(w, `{"message": "Success"}`)
 }
 
 func healthCheckHandler(w http.ResponseWriter, r *http.Request) {

--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -48,7 +48,7 @@ func worker(w http.ResponseWriter, r *http.Request) {
 	// TODO(dev): Remove fake delay.
 	t := 10 * rand.ExpFloat64()
 	log.Printf("Simulating work by sleeping for %f seconds\n", t)
-	time.Sleep(time.Duration(t))
+	time.Sleep(time.Duration(t) * time.Second)
 
 	fmt.Fprintf(w, `{"message": "Success"}`)
 }

--- a/functions/enqueue.js
+++ b/functions/enqueue.js
@@ -27,7 +27,7 @@ exports.enqueueFileTask = function (bucket, filename, queue, callback) {
   var http = require('http');
   var gsFilename = "gs://" + bucket + "/" + filename;
   var safeFilename = new Buffer(gsFilename).toString("base64");
-  http.get('http://push-queue-dot-mlab-sandbox.appspot.com/receiver?queuename=etl-parser-queue&filename=' + safeFilename,
+  http.get('http://push-queue-dot-mlab-sandbox.appspot.com/receiver?filename=' + safeFilename,
       function (res) {
         res.on('data', function (data) {});
         res.on('end',

--- a/functions/enqueue.js
+++ b/functions/enqueue.js
@@ -27,7 +27,7 @@ exports.enqueueFileTask = function (bucket, filename, queue, callback) {
   var http = require('http');
   var gsFilename = "gs://" + bucket + "/" + filename;
   var safeFilename = new Buffer(gsFilename).toString("base64");
-  http.get('http://etl-parser-dot-mlab-sandbox.appspot.com/worker?filename=' + safeFilename,
+  http.get('http://push-queue-dot-mlab-sandbox.appspot.com/receiver?queuename=etl-parser-queue&filename=' + safeFilename,
       function (res) {
         res.on('data', function (data) {});
         res.on('end',
@@ -36,7 +36,7 @@ exports.enqueueFileTask = function (bucket, filename, queue, callback) {
                  callback();
                });
       });
-  /* 
+  /*
     // If you want things to be authenticated, then put them inside the callback
     // here.
     google.auth.getApplicationDefault(function (err, authClient, projectId) {


### PR DESCRIPTION
This change adds a microservice to run in AppEngine Standard Environment that accepts requests and creates a Task to add to a Push queue using the given parameters.

The push-queue service is necessary because the Push taskqueue API is only supported (apparently) by AppEngine SE packages. The public REST API does not appear to support push queues.

This change also adds psuedo-processing in the `etl_worker` push queue target.

This change updates the cloud function to issue a request to the new push-queue receiver. This change is not yet deployed.

TODOs:

 * automate deployment of the push-queue SE app.
 * automate deployment of the cloud functions.
 * identify the correct way to load prometheus metrics per- flex instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/15)
<!-- Reviewable:end -->
