### PR TITLE
Move NextTest to storage package.  Improve names

### DIFF
--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -92,7 +92,7 @@ func worker(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tr, err := storage.NewGCSTarReader(client, filename)
+	tr, err := storage.NewETLSource(client, filename)
 	if err != nil {
 		log.Printf("%v", err)
 		fmt.Fprintf(w, `{"message": "Problem opening file."}`)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -107,7 +107,7 @@ func NewETLSource(client *http.Client, uri string) (*ETLSource, error) {
 
 	rdr := obj.Body
 	var closer io.Closer = obj.Body
-	// Is it a tar.gz or tgz file?
+	// Handle .tar.gz, .tgz files.
 	if strings.HasSuffix(strings.ToLower(fn), "gz") {
 		// TODO add unit test
 		// NB: This must not be :=, or it creates local rdr.

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -10,13 +10,15 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"errors"
-	"golang.org/x/net/context"
-	"golang.org/x/oauth2/google"
-	storage "google.golang.org/api/storage/v1"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
+
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2/google"
+	storage "google.golang.org/api/storage/v1"
 )
 
 type TarReader interface {
@@ -24,32 +26,60 @@ type TarReader interface {
 	Read(b []byte) (int, error)
 }
 
-type TarReaderCloser struct {
+type ETLSource struct {
 	TarReader
+	io.Closer
+}
+
+// Next reads the next test object from the tar file.
+// Returns io.EOF when there are no more tests.
+func (rr *ETLSource) NextTest() (string, []byte, error) {
+	h, err := rr.Next()
+	if err != nil {
+		return "", nil, err
+	}
+	if h.Typeflag != tar.TypeReg {
+		return h.Name, nil, nil
+	}
+	var data []byte
+	if strings.HasSuffix(strings.ToLower(h.Name), "gz") {
+		// TODO add unit test
+		zipReader, err := gzip.NewReader(rr)
+		if err != nil {
+			return h.Name, nil, err
+		}
+		defer zipReader.Close()
+		data, err = ioutil.ReadAll(zipReader)
+	} else {
+		data, err = ioutil.ReadAll(rr)
+	}
+	if err != nil {
+		return h.Name, nil, err
+	}
+	return h.Name, data, nil
+}
+
+// Compound closer, for use with gzip files.
+type Closer struct {
 	zipper io.Closer // Must be non-null
 	body   io.Closer // Must be non-null
 }
 
-// Implement io.Closer
-func (t *TarReaderCloser) Close() error {
+func (t *Closer) Close() error {
 	err := t.zipper.Close()
 	t.body.Close()
 	return err
 }
 
-type NullCloser struct{}
-
-func (c *NullCloser) Close() error { return nil }
-
 var errNoClient = errors.New("client should be non-null")
-var nullCloser io.Closer = new(NullCloser)
 
-// Create a tar.Reader suitable for injecting into Task.
+// Create a ETLSource suitable for injecting into Task.
 // Caller is responsible for calling Close on the returned object.
 //
 // uri should be of form gs://bucket/filename.tar or gs://bucket/filename.tgz
 // FYI Using a persistent client saves about 80 msec, and 220 allocs, totalling 70kB.
-func NewGCSTarReader(client *http.Client, uri string) (*TarReaderCloser, error) {
+// TODO(now) rename
+func NewGCSTarReader(client *http.Client, uri string) (*ETLSource, error) {
 	if client == nil {
 		return nil, errNoClient
 	}
@@ -75,10 +105,8 @@ func NewGCSTarReader(client *http.Client, uri string) (*TarReaderCloser, error) 
 		return nil, err
 	}
 
-	// Default nullCloser, if we don't need a gzip reader.
-	zc := nullCloser
-
 	rdr := obj.Body
+	var closer io.Closer = obj.Body
 	// Is it a tar.gz or tgz file?
 	if strings.HasSuffix(strings.ToLower(fn), "gz") {
 		// TODO add unit test
@@ -89,11 +117,11 @@ func NewGCSTarReader(client *http.Client, uri string) (*TarReaderCloser, error) 
 			return nil, err
 		}
 
-		zc = rdr
+		closer = &Closer{rdr, obj.Body}
 	}
 	tarReader := tar.NewReader(rdr)
 
-	return &TarReaderCloser{tarReader, zc, obj.Body}, nil
+	return &ETLSource{tarReader, closer}, nil
 }
 
 // Create a storage reader client.

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -79,7 +79,7 @@ var errNoClient = errors.New("client should be non-null")
 // uri should be of form gs://bucket/filename.tar or gs://bucket/filename.tgz
 // FYI Using a persistent client saves about 80 msec, and 220 allocs, totalling 70kB.
 // TODO(now) rename
-func NewGCSTarReader(client *http.Client, uri string) (*ETLSource, error) {
+func NewETLSource(client *http.Client, uri string) (*ETLSource, error) {
 	if client == nil {
 		return nil, errNoClient
 	}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -16,12 +16,12 @@ func TestGetObject(t *testing.T) {
 }
 
 func TestNewTarReader(t *testing.T) {
-	reader, err := NewGCSTarReader(client, "gs://m-lab-sandbox/test.tar")
+	src, err := NewETLSource(client, "gs://m-lab-sandbox/test.tar")
 	if err != nil {
 		t.Fatal(err)
 	}
 	count := 0
-	for _, _, err := reader.NextTest(); err != io.EOF; _, _, err = reader.NextTest() {
+	for _, _, err := src.NextTest(); err != io.EOF; _, _, err = src.NextTest() {
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -30,16 +30,16 @@ func TestNewTarReader(t *testing.T) {
 	if count != 3 {
 		t.Error("Wrong number of files: ", count)
 	}
-	reader.Close()
+	src.Close()
 }
 
 func TestNewTarReaderGzip(t *testing.T) {
-	reader, err := NewGCSTarReader(client, "gs://m-lab-sandbox/test.tgz")
+	src, err := NewETLSource(client, "gs://m-lab-sandbox/test.tgz")
 	if err != nil {
 		t.Fatal(err)
 	}
 	count := 0
-	for _, _, err := reader.NextTest(); err != io.EOF; _, _, err = reader.NextTest() {
+	for _, _, err := src.NextTest(); err != io.EOF; _, _, err = src.NextTest() {
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -48,7 +48,7 @@ func TestNewTarReaderGzip(t *testing.T) {
 	if count != 3 {
 		t.Error("Wrong number of files: ", count)
 	}
-	reader.Close()
+	src.Close()
 }
 
 // Using a persistent client saves about 80 msec, and 220 allocs, totalling 70kB.
@@ -64,16 +64,16 @@ func init() {
 
 func BenchmarkNewTarReader(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		reader, _ := NewGCSTarReader(client, "gs://m-lab-sandbox/test.tar")
+		src, _ := NewETLSource(client, "gs://m-lab-sandbox/test.tar")
 		// Omitting the Close doesn't seem to cause any problems.  Is that really true?
-		reader.Close()
+		src.Close()
 	}
 }
 
 func BenchmarkNewTarReaderGzip(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		reader, _ := NewGCSTarReader(client, "gs://m-lab-sandbox/test.tgz")
+		src, _ := NewETLSource(client, "gs://m-lab-sandbox/test.tgz")
 		// Omitting the Close doesn't seem to cause any problems.  Is that really true?
-		reader.Close()
+		src.Close()
 	}
 }

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -20,6 +20,8 @@ func TestNewTarReader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer src.Close()
+
 	count := 0
 	for _, _, err := src.NextTest(); err != io.EOF; _, _, err = src.NextTest() {
 		if err != nil {
@@ -30,7 +32,6 @@ func TestNewTarReader(t *testing.T) {
 	if count != 3 {
 		t.Error("Wrong number of files: ", count)
 	}
-	src.Close()
 }
 
 func TestNewTarReaderGzip(t *testing.T) {
@@ -38,6 +39,8 @@ func TestNewTarReaderGzip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer src.Close()
+
 	count := 0
 	for _, _, err := src.NextTest(); err != io.EOF; _, _, err = src.NextTest() {
 		if err != nil {
@@ -48,7 +51,6 @@ func TestNewTarReaderGzip(t *testing.T) {
 	if count != 3 {
 		t.Error("Wrong number of files: ", count)
 	}
-	src.Close()
 }
 
 // Using a persistent client saves about 80 msec, and 220 allocs, totalling 70kB.
@@ -64,16 +66,18 @@ func init() {
 
 func BenchmarkNewTarReader(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		src, _ := NewETLSource(client, "gs://m-lab-sandbox/test.tar")
-		// Omitting the Close doesn't seem to cause any problems.  Is that really true?
-		src.Close()
+		src, err := NewETLSource(client, "gs://m-lab-sandbox/test.tar")
+		if err == nil {
+			src.Close()
+		}
 	}
 }
 
 func BenchmarkNewTarReaderGzip(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		src, _ := NewETLSource(client, "gs://m-lab-sandbox/test.tgz")
-		// Omitting the Close doesn't seem to cause any problems.  Is that really true?
-		src.Close()
+		src, err := NewETLSource(client, "gs://m-lab-sandbox/test.tgz")
+		if err == nil {
+			src.Close()
+		}
 	}
 }

--- a/task/task.go
+++ b/task/task.go
@@ -19,21 +19,21 @@ import (
 
 // TODO(dev) Add unit tests for meta data.
 type Task struct {
-	*storage.ETLSource                           // Tar reader from which to read tests.
+	*storage.ETLSource                           // Source from which to read tests.
 	parser.Parser                                // Parser to parse the tests.
 	bq.Inserter                                  // provides InsertRows(...)
 	table              string                    // The table to insert rows into, INCLUDING the partition!
 	meta               map[string]bigquery.Value // Metadata about this task.
 }
 
-// NewTask constructs a task, injecting the tar reader and the parser.
-func NewTask(filename string, rdr *storage.ETLSource, prsr parser.Parser, inserter bq.Inserter, table string) *Task {
+// NewTask constructs a task, injecting the source and the parser.
+func NewTask(filename string, src *storage.ETLSource, prsr parser.Parser, inserter bq.Inserter, table string) *Task {
 	// TODO - should the meta data be a nested type?
 	meta := make(map[string]bigquery.Value, 3)
 	meta["filename"] = filename
 	meta["parse_time"] = time.Now()
 	meta["attempt"] = 1
-	t := Task{rdr, prsr, inserter, table, meta}
+	t := Task{src, prsr, inserter, table, meta}
 	return &t
 }
 


### PR DESCRIPTION
Some general cleanup.
Move NextTest to storage.
Rename TarReaderCloser to ETLSource.
Simplify Closer handling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/24)
<!-- Reviewable:end -->
