### PR TITLE
Add separate listening port for prometheus metrics.

### DIFF
--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -181,12 +181,17 @@ func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	// Define a custom serve mux for prometheus to listen on a separate port.
+	// We listen on a separate port so we can forward this port on the host VM.
+	// We cannot forward port 8080 because it is used by AppEngine.
+	mux := http.NewServeMux()
+	// Assign the default prometheus handler to the standard exporter path.
+	mux.Handle("/metrics", promhttp.Handler())
+	go http.ListenAndServe(":9090", mux)
+
 	http.HandleFunc("/", handler)
 	http.HandleFunc("/worker", metrics.DurationHandler("generic", worker))
 	http.HandleFunc("/_ah/health", healthCheckHandler)
-
-	// Assign the default prometheus handler to the standard exporter path.
-	http.Handle("/metrics", promhttp.Handler())
 	http.ListenAndServe(":8080", nil)
 }
 

--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -192,6 +192,11 @@ func main() {
 	http.HandleFunc("/", handler)
 	http.HandleFunc("/worker", metrics.DurationHandler("generic", worker))
 	http.HandleFunc("/_ah/health", healthCheckHandler)
+
+	// We also setup another prometheus handler on a non-standard path. This
+	// path name will be accessible through the AppEngine service address,
+	// however it will be served by a random instance.
+	http.Handle("/random-metrics", promhttp.Handler())
 	http.ListenAndServe(":8080", nil)
 }
 


### PR DESCRIPTION
This change adds a new listening port on port 9090 for the prometheus metrics exporter for the etl-parser service.

We need a separate service since AppEngine does not support forwarding the port used for the main service (8080 by default). The change needed to app.yaml is already in place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/35)
<!-- Reviewable:end -->
