### PR TITLE
Fixes to timeouts, busy-loops, stack-smash SIGSEGV

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ deploy:
     # A bash-style 'if' condition, matching branches with a "sandbox-" prefix.
     # Sandbox branches will be deployed to personalized service names.
     # Integration branch will not use decorated service names.
-    condition: $TRAVIS_BRANCH == sandbox-* || $TRAVIS_BRANCH == integration
+    condition: $TRAVIS_BRANCH == sandbox-*
 
 ## Service: queue-pusher -- AppEngine Standard Environment.
 - provider: script
@@ -71,7 +71,7 @@ deploy:
     # Consider all branches and match using the condition. By default
     # "all_branches" is false, and the condition is ignored.
     all_branches: true
-    condition: $TRAVIS_BRANCH == sandbox-* || $TRAVIS_BRANCH == integration
+    condition: $TRAVIS_BRANCH == sandbox-*
 
 # NOTE: Cloud functions only support primitive IAM roles: Owner, Editor, Viewer.
 # See: https://cloud.google.com/functions/docs/concepts/iam

--- a/bq/insert.go
+++ b/bq/insert.go
@@ -33,7 +33,7 @@ import (
 func NewInserter(dataset string, dt etl.DataType) (etl.Inserter, error) {
 	return NewBQInserter(
 		etl.InserterParams{dataset, etl.DataTypeToTable[dt],
-			60 * time.Second, 500}, nil)
+			600 * time.Second, 500}, nil)
 }
 
 // TODO - improve the naming between here and NewInserter.

--- a/bq/insert.go
+++ b/bq/insert.go
@@ -33,7 +33,7 @@ import (
 func NewInserter(dataset string, dt etl.DataType) (etl.Inserter, error) {
 	return NewBQInserter(
 		etl.InserterParams{dataset, etl.DataTypeToTable[dt],
-			600 * time.Second, 500}, nil)
+			10 * time.Minute, 500}, nil)
 }
 
 // TODO - improve the naming between here and NewInserter.

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -100,7 +100,7 @@ func NewETLSource(client *http.Client, uri string) (*ETLSource, error) {
 		return nil, errors.New("not tar or tgz: " + uri)
 	}
 
-	obj, err := getObject(client, bucket, fn, 60*time.Second)
+	obj, err := getObject(client, bucket, fn, 600*time.Second)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -100,7 +100,7 @@ func NewETLSource(client *http.Client, uri string) (*ETLSource, error) {
 		return nil, errors.New("not tar or tgz: " + uri)
 	}
 
-	obj, err := getObject(client, bucket, fn, 600*time.Second)
+	obj, err := getObject(client, bucket, fn, 10*time.Minute)
 	if err != nil {
 		return nil, err
 	}

--- a/task/task.go
+++ b/task/task.go
@@ -48,8 +48,9 @@ func (tt *Task) ProcessAllTests() error {
 				break
 			}
 			// TODO(dev) Handle this error properly!
-			log.Printf("%v", err)
-			continue
+			log.Printf("filename:%s files:%d duration:%v err:%v",
+				tt.meta["filename"], files, time.Since(tt.meta["parse_time"].(time.Time)), err)
+			break
 		}
 		if data == nil {
 			// TODO(dev) Handle directories (expected) and other

--- a/web100/web100.go
+++ b/web100/web100.go
@@ -57,6 +57,7 @@ func Open(filename string, legacyNames map[string]string) (*Web100, error) {
 	// TODO(prod): do not require reading from a file. Accept a byte array.
 	snaplog := C.web100_log_open_read(c_filename)
 	if snaplog == nil {
+		web100Lock.Unlock()
 		return nil, fmt.Errorf(C.GoString(C.web100_strerror(C.web100_errno)))
 	}
 
@@ -65,7 +66,7 @@ func Open(filename string, legacyNames map[string]string) (*Web100, error) {
 
 	w := &Web100{
 		legacyNames: legacyNames,
-		snaplog:         unsafe.Pointer(snaplog),
+		snaplog:     unsafe.Pointer(snaplog),
 		snap:        unsafe.Pointer(snap),
 	}
 	return w, nil


### PR DESCRIPTION
This change includes increases to timeouts for BQ inserts, and GCS downloads.

As well, this change includes three fixes to web100.c observed to cause runtime failures with historical ndt snaplog files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/47)
<!-- Reviewable:end -->
