### PR TITLE
Shorten time that web100Lock is held.

### DIFF
--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -36,6 +36,9 @@ func (n *NDTParser) ParseAndInsert(meta map[string]bigquery.Value, testName stri
 		return nil
 	}
 
+	// NOTE: this file size threshold and the number of simultaneous workers
+	// defined in etl_worker.go must guarantee that all files written to
+	// /mnt/tmpfs will fit.
 	if len(rawSnapLog) > 10*1024*1024 {
 		metrics.TestCount.With(prometheus.Labels{
 			"table": n.TableName(), "type": "oversize"}).Inc()


### PR DESCRIPTION
This change shortens the time that `web100.Open` holds the web100Lock.

The lock was held until close because we were seeing some very large snaplog files in production.

However, now that we are filtering unusually large files there is almost no risk of filling the tmpfs directory as long as we continue to limit the number of simultaneous tasks and average snaplog size to fit in the tmpfs directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/53)
<!-- Reviewable:end -->
