### PR TITLE
Add NDT support for full schema

### DIFF
--- a/cmd/web100_cli/web100_cli.go
+++ b/cmd/web100_cli/web100_cli.go
@@ -58,7 +58,7 @@ func main() {
 	}
 
 	snapValues := schema.Web100ValueMap{}
-	err = w.SnapValues(snapValues)
+	err = w.SnapshotValues(snapValues)
 	if err != nil {
 		panic(err)
 	}

--- a/etl/globals.go
+++ b/etl/globals.go
@@ -37,7 +37,7 @@ var (
 	// Map from data type to BigQuery table name.
 	// TODO - this should be loaded from a config.
 	DataTypeToTable = map[DataType]string{
-		NDT:     "ndt_test",
+		NDT:     "ndt_test_full_schema",
 		SS:      "ss_test",
 		PT:      "pt_test",
 		SW:      "disco_test",

--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -17,6 +17,10 @@ import (
 	"github.com/m-lab/etl/web100"
 )
 
+var (
+	TmpDir = "/mnt/tmpfs"
+)
+
 type NDTParser struct {
 	inserter etl.Inserter
 	// TODO(prod): eliminate need for tmpfs.
@@ -24,7 +28,7 @@ type NDTParser struct {
 }
 
 func NewNDTParser(ins etl.Inserter) *NDTParser {
-	return &NDTParser{ins, "/mnt/tmpfs"}
+	return &NDTParser{ins, TmpDir}
 }
 
 // ParseAndInsert extracts the last snaplog from the given raw snap log.

--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -204,7 +204,7 @@ func (n *NDTParser) TableName() string {
 
 // fixValues updates web100 log values that need post-processing fix-ups.
 // TODO(dev): does this only apply to NDT or is NPAD also affected?
-func fixValues(r map[string]bigquery.Value) error {
+func fixValues(r map[string]bigquery.Value) map[string]bigquery.Value {
 	// TODO(dev): fix these values.
 	// Fix StartTimeStamp:
 	//  - web100_log_entry.snap.StartTimeStamp: (1000000 * StartTimeStamp + StartTimeUsec)

--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -162,6 +162,7 @@ func (n *NDTParser) ParseAndInsert(meta map[string]bigquery.Value, testName stri
 			tmpFile.Name(), testName, meta["filename"], err)
 		return nil
 	}
+	log.Printf("Inserting values from: %s\n", tmpFile.Name())
 	err = n.inserter.InsertRow(&bq.MapSaver{results})
 
 	if err != nil {

--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -162,7 +162,6 @@ func (n *NDTParser) ParseAndInsert(meta map[string]bigquery.Value, testName stri
 			tmpFile.Name(), testName, meta["filename"], err)
 		return nil
 	}
-	log.Printf("Inserting values from: %s\n", tmpFile.Name())
 	err = n.inserter.InsertRow(&bq.MapSaver{results})
 
 	if err != nil {

--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -149,7 +149,7 @@ func (n *NDTParser) ParseAndInsert(meta map[string]bigquery.Value, testName stri
 		// parse every 10th snapshot.
 		if count%10 == 0 {
 			// Note: read and discard the values by not saving the Web100ValueMap.
-			err := w.SnapValues(schema.Web100ValueMap{})
+			err := w.SnapshotValues(schema.Web100ValueMap{})
 			if err != nil {
 				metrics.TestCount.With(prometheus.Labels{
 					"table": n.TableName(), "type": "values-err"}).Inc()
@@ -162,7 +162,7 @@ func (n *NDTParser) ParseAndInsert(meta map[string]bigquery.Value, testName stri
 	defer metrics.WorkerState.WithLabelValues("parse").Dec()
 
 	snapValues := schema.Web100ValueMap{}
-	err = w.SnapValues(snapValues)
+	err = w.SnapshotValues(snapValues)
 	if err != nil {
 		metrics.TestCount.With(prometheus.Labels{
 			"table": n.TableName(), "type": "values-err"}).Inc()

--- a/parser/ndt_test.go
+++ b/parser/ndt_test.go
@@ -1,6 +1,4 @@
-package parser
-
-// TODO - use parser_test, to force proper package isolation.
+package parser_test
 
 import (
 	"fmt"
@@ -8,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/m-lab/etl/bq"
+	"github.com/m-lab/etl/parser"
 	"github.com/m-lab/etl/schema"
 
 	"github.com/kr/pretty"
@@ -23,7 +22,8 @@ func TestNDTParser(t *testing.T) {
 	}
 
 	ins := &inMemoryInserter{}
-	n := &NDTParser{inserter: ins, tmpDir: "./"}
+	parser.TmpDir = "./"
+	n := parser.NewNDTParser(ins)
 	err = n.ParseAndInsert(nil, "filename.c2s_snaplog", rawData)
 	if err != nil {
 		t.Fatalf(err.Error())

--- a/parser/ndt_test.go
+++ b/parser/ndt_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/m-lab/etl/bq"
 	"github.com/m-lab/etl/parser"
-	"github.com/m-lab/etl/schema"
 
 	"github.com/kr/pretty"
 
@@ -34,7 +33,7 @@ func TestNDTParser(t *testing.T) {
 	}
 
 	// Extract the values saved to the inserter.
-	actualValues := schema.Map(ins.data[0].(*bq.MapSaver).Values)
+	actualValues := ins.data[0].(*bq.MapSaver).Values
 	expectedValues := map[string]bigquery.Value{
 		"web100_log_entry": map[string]bigquery.Value{
 			"version": "2.5.27 201001301335 net100",

--- a/schema/web100.go
+++ b/schema/web100.go
@@ -1,0 +1,55 @@
+package schema
+
+import (
+	"cloud.google.com/go/bigquery"
+)
+
+// Map performs a type conversion on the given value.
+func Map(v bigquery.Value) map[string]bigquery.Value {
+	switch v.(type) {
+	case map[string]bigquery.Value:
+		return v.(map[string]bigquery.Value)
+	default:
+		return nil
+	}
+}
+
+func NewRecord() map[string]bigquery.Value {
+	return map[string]bigquery.Value{
+		"test_id":  "",
+		"log_time": 0,
+		// TODO(prod): parse the *.meta files for this data?
+		// Can this be part of the metadata service?
+		"connection_spec": map[string]bigquery.Value{
+			"server_ip":             "",
+			"server_af":             0,
+			"server_hostname":       "",
+			"server_kernel_version": "",
+			"client_ip":             "",
+			"client_af":             0,
+			"client_hostname":       "",
+			"client_os":             "",
+			"client_kernel_version": "",
+			"client_version":        "",
+			"client_browser":        "",
+			"client_application":    "",
+			"data_direction":        0,
+			// TODO(prod): add geolocation sub-records.
+			//  client_geolocation: record
+			//  server_geolocation: record
+		},
+		"web100_log_entry": map[string]bigquery.Value{
+			"version":  "",
+			"log_time": 0,
+			"connection_spec": map[string]bigquery.Value{
+				"remote_ip":   "",
+				"remote_port": 0,
+				"local_ip":    "",
+				"local_af":    0,
+				"local_port":  0,
+			},
+			"snap": map[string]bigquery.Value{},
+		},
+		// TODO(dev): add paris_traceroute_hop records here or separately?
+	}
+}

--- a/schema/web100.go
+++ b/schema/web100.go
@@ -1,3 +1,5 @@
+// The schema package provides an interface for the flexible map-based full
+// schema for web100 tests.
 package schema
 
 import (
@@ -14,6 +16,7 @@ func Map(v bigquery.Value) map[string]bigquery.Value {
 	}
 }
 
+// NewRecord creates an empty full schema record with nested records already in place.
 func NewRecord() map[string]bigquery.Value {
 	return map[string]bigquery.Value{
 		"test_id":  "",

--- a/web100/web100.go
+++ b/web100/web100.go
@@ -208,7 +208,7 @@ func (w *Web100) snapValues(logValues map[string]bigquery.Value) error {
 	group := C.web100_get_log_group(snaplog)
 	for v := C.web100_var_head(group, &w_errno); v != nil; v = C.web100_var_next(v, &w_errno) {
 		if w_errno != C.WEB100_ERR_SUCCESS {
-			return nil, fmt.Errorf(C.GoString(C.web100_strerror(w_errno)))
+			return fmt.Errorf(C.GoString(C.web100_strerror(w_errno)))
 		}
 
 		name := C.web100_get_var_name(v)

--- a/web100/web100.go
+++ b/web100/web100.go
@@ -128,11 +128,11 @@ func (w *Web100) Next() error {
 
 func (w *Web100) Values() (map[string]bigquery.Value, error) {
 	results := schema.NewRecord()
-	v, err := w.logValues(schema.Map(results["web100_log_entry"]))
+	err := w.logValues(schema.Map(results["web100_log_entry"]))
 	if err != nil {
 		return nil, err
 	}
-	err = w.snapValues(v)
+	err = w.snapValues(schema.Map(results["web100_log_entry"]))
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +164,7 @@ func fixValues(r bigquery.Value) error {
 
 // logValues returns a map of values from the web100 log. IPv6 address
 // connection information is not available and must be set based on a snapshot.
-func (w *Web100) logValues(web100LogEntry map[string]bigquery.Value) (map[string]bigquery.Value, error) {
+func (w *Web100) logValues(web100LogEntry map[string]bigquery.Value) error {
 	snaplog := (*C.web100_log)(w.snaplog)
 	agent := C.web100_get_log_agent(snaplog)
 
@@ -193,7 +193,7 @@ func (w *Web100) logValues(web100LogEntry map[string]bigquery.Value) (map[string
 	// NOTE: legacy values of local_af are: IPv4 = 0, IPv6 = 1.
 	connectionSpec["local_af"] = int64(0)
 
-	return web100LogEntry, nil
+	return nil
 }
 
 // snapValues converts all variables in the latest snap record into a results map.

--- a/web100/web100.go
+++ b/web100/web100.go
@@ -58,7 +58,7 @@ type Web100 struct {
 	// snap is an individual *C.web100_snapshot record read from a snaplog.
 	snap unsafe.Pointer
 
-	// text and data are temporary space for converting web100 variables to strings.
+	// Pointers to C buffers for use in calls to web100 functions.
 	text unsafe.Pointer
 	data unsafe.Pointer
 }

--- a/web100/web100.go
+++ b/web100/web100.go
@@ -21,11 +21,13 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"strconv"
 	"sync"
 	"unsafe"
 
 	"cloud.google.com/go/bigquery"
+	"github.com/m-lab/etl/schema"
 )
 
 var (
@@ -45,6 +47,9 @@ type Web100 struct {
 	// Do not export unsafe pointers.
 	snaplog unsafe.Pointer
 	snap    unsafe.Pointer
+	// temp space for converting web100 variables to string.
+	text unsafe.Pointer
+	data unsafe.Pointer
 
 	// The original filename created by the NDT server.
 	TestId string
@@ -93,6 +98,9 @@ func Open(filename string, legacyNames map[string]string) (*Web100, error) {
 		legacyNames: legacyNames,
 		snaplog:     unsafe.Pointer(snaplog),
 		snap:        unsafe.Pointer(snap),
+		// Pre-allocate space for converting snapshot values.
+		text: C.calloc(2*C.WEB100_VALUE_LEN_MAX, 1),
+		data: C.calloc(C.WEB100_VALUE_LEN_MAX, 1),
 	}
 	return w, nil
 }
@@ -119,98 +127,81 @@ func (w *Web100) Next() error {
 }
 
 func (w *Web100) Values() (map[string]bigquery.Value, error) {
-	v, err := w.logValues()
+	results := schema.NewRecord()
+	v, err := w.logValues(schema.Map(results["web100_log_entry"]))
 	if err != nil {
 		return nil, err
 	}
-	v, err = w.snapValues(v)
+	err = w.snapValues(v)
 	if err != nil {
 		return nil, err
 	}
-	return v, nil
+	// TODO(dev): is NPAD also affected in the same way?
+	err = fixValues(results["web100_log_entry"])
+	if err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+// fixValues updates web100 log values that need post-processing fix-ups.
+// TODO(dev): does this only apply to NDT or is NPAD also affected?
+func fixValues(r bigquery.Value) error {
+	record := schema.Map(r)
+	if record == nil {
+		return fmt.Errorf("Can only fix types of map[string]bigquery.Value")
+	}
+	// TODO(dev): fix these values.
+	// Fix StartTimeStamp:
+	//  - web100_log_entry.snap.StartTimeStamp: (1000000 * StartTimeStamp + StartTimeUsec)
+	// Fix IPv6 addresses in connection_spec:
+	//  - web100_log_entry.connection_spec.local_ip
+	//  - web100_log_entry.connection_spec.remote_ip
+	// Fix local_af:
+	//  - web100_log_entry.connection_spec.local_af: IPv4 = 0, IPv6 = 1.
+	return nil
 }
 
 // logValues returns a map of values from the web100 log. IPv6 address
 // connection information is not available and must be set based on a snapshot.
-func (w *Web100) logValues() (map[string]bigquery.Value, error) {
+func (w *Web100) logValues(web100LogEntry map[string]bigquery.Value) (map[string]bigquery.Value, error) {
 	snaplog := (*C.web100_log)(w.snaplog)
 	agent := C.web100_get_log_agent(snaplog)
 
-	results := map[string]bigquery.Value{
-		"test_id":  w.TestId,
-		"log_time": w.LogTime,
-		"connection_spec": map[string]bigquery.Value{
-			"server_ip":             "",
-			"server_af":             0,
-			"server_hostname":       "",
-			"server_kernel_version": "",
-			"client_ip":             "",
-			"client_af":             0,
-			"client_hostname":       "",
-			"client_os":             "",
-			"client_kernel_version": "",
-			"client_version":        "",
-			"client_browser":        "",
-			"client_application":    "",
-			"data_direction":        0,
-			// TODO(prod): add geolocation sub-records.
-			//  client_geolocation: record
-			//  server_geolocation: record
-		},
-		"web100_log_entry": map[string]bigquery.Value{
-			"version":  C.GoString(C.web100_get_agent_version(agent)),
-			"log_time": int64(C.web100_get_log_time(snaplog)),
-			"connection_spec": map[string]bigquery.Value{
-				"remote_ip":   "",
-				"remote_port": 0,
-				"local_ip":    "",
-				"local_af":    0,
-				"local_port":  0,
-			},
-			"snap": make(map[string]bigquery.Value),
-		},
-	}
+	web100LogEntry["version"] = C.GoString(C.web100_get_agent_version(agent))
+	web100LogEntry["log_time"] = int64(C.web100_get_log_time(snaplog))
 
-	web100LogEntry := results["web100_log_entry"].(map[string]bigquery.Value)
-	connectionSpec := web100LogEntry["connection_spec"].(map[string]bigquery.Value)
 	conn := C.web100_get_log_connection(snaplog)
-	// NOTE: web100_connection_spec_v6 is not filled in by the web100 library.
-	// NOTE: addrtype is always WEB100_ADDRTYPE_UNKNOWN.
-	// NOTE: legacy values for local_af are: IPv4 = 0, IPv6 = 1.
-	connectionSpec["local_af"] = int64(0)
 
+	// NOTE: web100_connection_spec_v6 is never set by the web100 library.
+	// NOTE: conn->addrtype is always WEB100_ADDRTYPE_UNKNOWN.
+	// So, we expect it to be IPv4 and fix local_ip and remote_ip later if
+	// snapshots have IPv6 addresses.
 	var spec C.struct_web100_connection_spec
 	C.web100_get_connection_spec(conn, &spec)
 
-	// TODO(prod): do not use inet_ntoa because it depends on a static internal buffer.
-	/* inet_ntoa(their_addr.sin_addr), */ // IPv4
-	// inet_ntop(AF_INET6, &their_addr.sin6_addr, buf, sizeof(buf)), // IPv6
-
-	addr := C.struct_in_addr{C.in_addr_t(spec.src_addr)}
-	connectionSpec["local_ip"] = C.GoString(C.inet_ntoa(addr))
+	// NOTE: web100_connection_spec only contains IPv4 addresses (4 byte values).
+	// If the connection was IPv6, the IPv4 addresses here will be 0.0.0.0.
+	srcIp := net.IP(C.GoBytes(unsafe.Pointer(&spec.src_addr), 4))
+	dstIp := net.IP(C.GoBytes(unsafe.Pointer(&spec.dst_addr), 4))
+	connectionSpec := schema.Map(web100LogEntry["connection_spec"])
+	connectionSpec["local_ip"] = srcIp.String()
 	connectionSpec["local_port"] = int64(spec.src_port)
-
-	addr = C.struct_in_addr{C.in_addr_t(spec.dst_addr)}
-	connectionSpec["remote_ip"] = C.GoString(C.inet_ntoa(addr))
+	connectionSpec["remote_ip"] = dstIp.String()
 	connectionSpec["remote_port"] = int64(spec.dst_port)
 
-	return results, nil
+	// NOTE: legacy values of local_af are: IPv4 = 0, IPv6 = 1.
+	connectionSpec["local_af"] = int64(0)
+
+	return web100LogEntry, nil
 }
 
 // snapValues converts all variables in the latest snap record into a results map.
-func (w *Web100) snapValues(logValues map[string]bigquery.Value) (map[string]bigquery.Value, error) {
+func (w *Web100) snapValues(logValues map[string]bigquery.Value) error {
 	snaplog := (*C.web100_log)(w.snaplog)
 	snap := (*C.web100_snapshot)(w.snap)
 
-	// TODO(dev): do not re-allocate these buffers on every call.
-	var_text := C.calloc(2*C.WEB100_VALUE_LEN_MAX, 1) // Use a better size.
-	defer C.free(var_text)
-
-	var_data := C.calloc(C.WEB100_VALUE_LEN_MAX, 1)
-	defer C.free(var_data)
-
-	web100log := logValues["web100_log_entry"].(map[string]bigquery.Value)
-	web100snap := web100log["snap"].(map[string]bigquery.Value)
+	web100snap := schema.Map(logValues["snap"])
 
 	// Parses variables from most recent web100_snapshot data.
 	var w_errno C.int = C.WEB100_ERR_SUCCESS
@@ -224,34 +215,33 @@ func (w *Web100) snapValues(logValues map[string]bigquery.Value) (map[string]big
 		var_type := C.web100_get_var_type(v)
 
 		// Read the raw variable data from the snapshot data.
-		errno := C.web100_snap_read(v, snap, var_data)
+		errno := C.web100_snap_read(v, snap, w.data)
 		if errno != C.WEB100_ERR_SUCCESS {
-			return nil, fmt.Errorf(C.GoString(C.web100_strerror(errno)))
+			return fmt.Errorf(C.GoString(C.web100_strerror(errno)))
 		}
 
-		// Convert raw var_data into a string based on var_type.
+		// Convert raw w.data into a string based on var_type.
 		// TODO(prod): reimplement web100_value_to_textn to operate on Go types.
-		C.web100_value_to_textn((*C.char)(var_text), C.WEB100_VALUE_LEN_MAX, (C.WEB100_TYPE)(var_type), var_data)
+		C.web100_value_to_textn((*C.char)(w.text), C.WEB100_VALUE_LEN_MAX,
+			(C.WEB100_TYPE)(var_type), w.data)
 
 		// Use the canonical variable name.
-		var canonicalName string
+		canonicalName := C.GoString(name)
 		if _, ok := w.legacyNames[canonicalName]; ok {
 			canonicalName = w.legacyNames[canonicalName]
-		} else {
-			canonicalName = C.GoString(name)
 		}
 
 		// TODO(dev): are there any cases where we need unsigned int64?
 		// Attempt to convert the current variable to an int64.
-		value, err := strconv.ParseInt(C.GoString((*C.char)(var_text)), 10, 64)
+		value, err := strconv.ParseInt(C.GoString((*C.char)(w.text)), 10, 64)
 		if err != nil {
 			// Leave variable as a string.
-			web100snap[canonicalName] = C.GoString((*C.char)(var_text))
+			web100snap[canonicalName] = C.GoString((*C.char)(w.text))
 		} else {
 			web100snap[canonicalName] = value
 		}
 	}
-	return logValues, nil
+	return nil
 }
 
 // Close releases resources created by Open.
@@ -263,6 +253,14 @@ func (w *Web100) Close() error {
 	err := C.web100_log_close_read(snaplog)
 	if err != C.WEB100_ERR_SUCCESS {
 		return fmt.Errorf(C.GoString(C.web100_strerror(err)))
+	}
+	if w.text != nil {
+		C.free(w.text)
+		w.text = nil
+	}
+	if w.data != nil {
+		C.free(w.data)
+		w.data = nil
 	}
 
 	// Clear pointer after free.

--- a/web100/web100.go
+++ b/web100/web100.go
@@ -113,7 +113,7 @@ func Open(filename string, legacyNames map[string]string) (*Web100, error) {
 }
 
 // Next reads the next C.web100_snapshot record from the web100 snaplog and
-// saves it in an internal buffer. Use SnapValues to read the all values from
+// saves it in an internal buffer. Use SnapshotValues to read the all values from
 // the most recently read snapshot.  If Next reaches EOF or another error, the
 // last snapshot is in an undefined state.
 func (w *Web100) Next() error {
@@ -179,9 +179,9 @@ func (w *Web100) ConnectionSpec(connSpec Saver) error {
 	return nil
 }
 
-// SnapValues saves all values from the most recent C.web100_snapshot read by
-// Next. Next must be called at least once before calling SnapValues.
-func (w *Web100) SnapValues(snapValues Saver) error {
+// SnapshotValues saves all values from the most recent C.web100_snapshot read by
+// Next. Next must be called at least once before calling SnapshotValues.
+func (w *Web100) SnapshotValues(snapValues Saver) error {
 	snaplog := (*C.web100_log)(w.snaplog)
 	snap := (*C.web100_snapshot)(w.snap)
 


### PR DESCRIPTION
This change adds support for a schema that more closely matches the current production web100 schema for NDT.

TODO:
 * Update the table name for testing.
 * implement the fixValues function to support IPv6 and other record fields.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/61)
<!-- Reviewable:end -->
