### PR TITLE
refactoring and regexp parsing

### DIFF
--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -46,7 +46,7 @@ type testInfo struct {
 	Suffix  string // The filename suffix
 }
 
-func parseNDTFileName(path string) (*testInfo, error) {
+func ParseNDTFileName(path string) (*testInfo, error) {
 	fields := testFilePattern.FindStringSubmatch(path)
 
 	if fields == nil {
@@ -84,7 +84,7 @@ func (n *NDTParser) ParseAndInsert(meta map[string]bigquery.Value, testName stri
 	// together.  If we detect another prefix before getting all three, we should
 	// process the subset that we have.
 
-	info, err := parseNDTFileName(testName)
+	info, err := ParseNDTFileName(testName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This does some straightforward refactoring (without much cleanup) in preparation for handling .meta files.
Also adds a regex parser for the test file names, which will aid in the meta file handling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/71)
<!-- Reviewable:end -->
