### PR TITLE
Use date partitions

### DIFF
--- a/etl/etl.go
+++ b/etl/etl.go
@@ -31,6 +31,7 @@ type InserterParams struct {
 	// These specify the google cloud dataset/table to write to.
 	Dataset    string
 	Table      string
+	Suffix     string        // Table name suffix for templated tables.
 	Timeout    time.Duration // max duration of backend calls.  (for context)
 	BufferSize int           // Number of rows to buffer before writing to backend.
 }

--- a/etl/etl.go
+++ b/etl/etl.go
@@ -15,8 +15,13 @@ type Inserter interface {
 	InsertRows(data []interface{}) error
 	// Flush flushes any rows in the buffer out to bigquery.
 	Flush() error
-	// TableName name of the BQ table that the uploader pushes to.
-	TableName() string
+	// Base Table name of the BQ table that the uploader pushes to.
+	TableBase() string
+	// Table name suffix of the BQ table that the uploader pushes to.
+	TableSuffix() string
+	// Full table name of the BQ table that the uploader pushes to,
+	// including $YYYYMMNN, or _YYYYMMNN
+	FullTableName() string
 	// Dataset name of the BQ dataset containing the table.
 	Dataset() string
 	// Count returns the count of rows currently in the buffer.
@@ -29,9 +34,10 @@ type Inserter interface {
 type InserterParams struct {
 	// The project comes from os.GetEnv("GCLOUD_PROJECT")
 	// These specify the google cloud dataset/table to write to.
-	Dataset    string
-	Table      string
-	Suffix     string        // Table name suffix for templated tables.
+	Dataset string
+	Table   string
+	// Suffix may be an actual _YYYYMMDD or partition $YYYYMMDD
+	Suffix     string        // Table name suffix for templated tables or partitions.
 	Timeout    time.Duration // max duration of backend calls.  (for context)
 	BufferSize int           // Number of rows to buffer before writing to backend.
 }

--- a/etl/globals.go
+++ b/etl/globals.go
@@ -8,7 +8,7 @@ import (
 const start = `^gs://(?P<prefix>.*)/(?P<exp>[^/]*)/`
 const datePath = `(?P<datepath>\d{4}/[01]\d/[0123]\d)/`
 const dateTime = `(\d{4}[01]\d[0123]\d)T000000Z`
-const mlabN_podNN = `-(mlab\d)-([[:alpha:]]{3}\d{2}-)`
+const mlabN_podNN = `-(mlab\d)-([[:alpha:]]{3}\d[0-9t]-)`
 const exp_NNNN = `(.*)-(\d{4})`
 const suffix = `(?:\.tar|\.tar.gz|\.tgz)$`
 
@@ -95,7 +95,7 @@ var (
 	// Map from data type to BigQuery table name.
 	// TODO - this should be loaded from a config.
 	DataTypeToTable = map[DataType]string{
-		NDT:     "ndt_test_full_schema",
+		NDT:     "ndt_test_daily",
 		SS:      "ss_test",
 		PT:      "pt_test",
 		SW:      "disco_test",

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -81,7 +81,8 @@ var (
 	// Provides metrics:
 	//   etl_test_count{type}
 	// Example usage:
-	//   metrics.TaskCount.WithLabelValues("s2c").Inc()
+	// metrics.TestCount.WithLabelValues(
+	//	tt.Inserter.TableName(), "s2c", "ok").Inc()
 	TestCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "etl_test_count",

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -82,14 +82,14 @@ var (
 	//   etl_test_count{type}
 	// Example usage:
 	// metrics.TestCount.WithLabelValues(
-	//	tt.Inserter.TableName(), "s2c", "ok").Inc()
+	//	tt.Inserter.TableBase(), tt.Inserter.TableSuffix(), "s2c", "ok").Inc()
 	TestCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "etl_test_count",
 			Help: "Number of tests processed.",
 		},
 		// ndt/pt/ss, s2c/c2s/meta, ok/reject/error/
-		[]string{"table", "filetype", "status"},
+		[]string{"table", "suffix", "filetype", "status"},
 	)
 
 	// Counts the number of retries on GCS read operations.

--- a/parser/disco.go
+++ b/parser/disco.go
@@ -73,7 +73,9 @@ func (dp *DiscoParser) ParseAndInsert(meta map[string]bigquery.Value, testName s
 		ps.Meta = ms
 		err := dec.Decode(&ps)
 		if err != nil {
-			metrics.TestCount.WithLabelValues(dp.TableName(), "disco", "Decode").Inc()
+			metrics.TestCount.WithLabelValues(
+				dp.TableName(), dp.inserter.TableSuffix(),
+				"disco", "Decode").Inc()
 			// TODO(dev) Should accumulate errors, instead of aborting?
 			return err
 		}
@@ -83,21 +85,24 @@ func (dp *DiscoParser) ParseAndInsert(meta map[string]bigquery.Value, testName s
 			case bigquery.PutMultiError:
 				// TODO improve error handling??
 				metrics.TestCount.WithLabelValues(
-					dp.TableName(), "disco", "insert-multi").Inc()
+					dp.TableName(), dp.inserter.TableSuffix(),
+					"disco", "insert-multi").Inc()
 				log.Printf("%v\n", t[0].Error())
 			default:
 				metrics.TestCount.WithLabelValues(
-					dp.TableName(), "disco", "insert-other").Inc()
+					dp.TableName(), dp.inserter.TableSuffix(),
+					"disco", "insert-other").Inc()
 			}
 			// TODO(dev) Should accumulate errors, instead of aborting?
 			return err
 		}
 	}
-	metrics.TestCount.WithLabelValues(dp.TableName(), "disco", "ok").Inc()
+	metrics.TestCount.WithLabelValues(dp.TableName(), dp.inserter.TableSuffix(),
+		"disco", "ok").Inc()
 
 	return nil
 }
 
 func (dp *DiscoParser) TableName() string {
-	return dp.inserter.TableName()
+	return dp.inserter.TableBase()
 }

--- a/parser/disco_test.go
+++ b/parser/disco_test.go
@@ -47,7 +47,7 @@ func TestJSONParsing(t *testing.T) {
 	// This creates a real inserter, with a fake uploader, for local testing.
 	uploader := fake.FakeUploader{}
 	ins, err := bq.NewBQInserter(etl.InserterParams{
-		"mlab_sandbox", "disco_test", 10 * time.Second, 3}, &uploader)
+		"mlab_sandbox", "disco_test", "", 10 * time.Second, 3}, &uploader)
 
 	var parser etl.Parser = parser.NewDiscoParser(ins)
 
@@ -92,7 +92,7 @@ func TestJSONParsing(t *testing.T) {
 // DISABLED
 // This tests insertion into a test table in the cloud.  Should not normally be executed.
 func xTestRealBackend(t *testing.T) {
-	ins, err := bq.NewInserter("mlab_sandbox", etl.SW)
+	ins, err := bq.NewInserter("mlab_sandbox", etl.SW, time.Now())
 	var parser etl.Parser = parser.NewDiscoParser(ins)
 
 	meta := map[string]bigquery.Value{"filename": "filename", "parsetime": time.Now()}

--- a/parser/ndt_test.go
+++ b/parser/ndt_test.go
@@ -189,7 +189,13 @@ func (in *inMemoryInserter) InsertRows(data []interface{}) error {
 func (in *inMemoryInserter) Flush() error {
 	return nil
 }
-func (in *inMemoryInserter) TableName() string {
+func (in *inMemoryInserter) TableBase() string {
+	return "ndt_test"
+}
+func (in *inMemoryInserter) TableSuffix() string {
+	return ""
+}
+func (in *inMemoryInserter) FullTableName() string {
 	return "ndt_test"
 }
 func (in *inMemoryInserter) Dataset() string {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -36,7 +36,7 @@ type NullParser struct {
 }
 
 func (np *NullParser) ParseAndInsert(meta map[string]bigquery.Value, testName string, test []byte) error {
-	metrics.TestCount.WithLabelValues("table", "null", "ok").Inc()
+	metrics.TestCount.WithLabelValues("table", "suffix", "null", "ok").Inc()
 	return nil
 }
 
@@ -57,7 +57,7 @@ func NewTestParser(ins etl.Inserter) etl.Parser {
 }
 
 func (tp *TestParser) ParseAndInsert(meta map[string]bigquery.Value, testName string, test []byte) error {
-	metrics.TestCount.WithLabelValues("table", "test", "ok").Inc()
+	metrics.TestCount.WithLabelValues("table", "suffix", "test", "ok").Inc()
 	log.Printf("Parsing %s", testName)
 	values := make(map[string]bigquery.Value, len(meta)+1)
 	// TODO is there a better way to do this?

--- a/parser/pt.go
+++ b/parser/pt.go
@@ -162,7 +162,7 @@ func GetLogtime(filename PTFileName) int64 {
 }
 
 func (pt *PTParser) TableName() string {
-	return pt.inserter.TableName()
+	return pt.inserter.TableBase()
 }
 
 func CreateTestId(fn string) string {

--- a/task/task.go
+++ b/task/task.go
@@ -63,7 +63,8 @@ func (tt *Task) ProcessAllTests() error {
 				time.Since(tt.meta["parse_time"].(time.Time)), err)
 
 			metrics.TestCount.WithLabelValues(
-				tt.Inserter.TableName(), "unknown", "unrecovered").Inc()
+				tt.Inserter.TableBase(), tt.Inserter.TableSuffix(),
+				"unknown", "unrecovered").Inc()
 			break
 		}
 		if data == nil {


### PR DESCRIPTION
Add handling of bigquery partitions.
BQ allows streaming into partitions up to 30 days in the past, and 7 days into the future.  Outside that range, we use template table creation to write into a separate table with an _YYYYMMDD suffix.

Also updates the metrics

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/76)
<!-- Reviewable:end -->
