### PR TITLE
refactor task and parser

### DIFF
--- a/bq/bq_test.go
+++ b/bq/bq_test.go
@@ -57,8 +57,8 @@ func xTestRealPartitionInsert(t *testing.T) {
 		t.Error(err)
 	}
 
-	if in.Count() != 3 {
-		t.Error("Should have inserted three rows")
+	if in.Accepted() != 3 {
+		t.Error("Should have accepted three rows")
 	}
 	in.Flush()
 }
@@ -84,8 +84,8 @@ func TestBasicInsert(t *testing.T) {
 		t.Error(err)
 	}
 
-	if in.Count() != 3 {
-		t.Error("Should have inserted three rows")
+	if in.Accepted() != 3 {
+		t.Error("Should have accepted three rows")
 	}
 	in.Flush()
 }
@@ -119,8 +119,8 @@ func TestBufferingAndFlushing(t *testing.T) {
 	if in.RowsInBuffer() != 0 {
 		t.Error("RowsInBuffer = ", in.RowsInBuffer())
 	}
-	if in.Count() != 3 {
-		t.Error("Count = ", in.Count())
+	if in.Accepted() != 3 {
+		t.Error("Accepted = ", in.Accepted())
 	}
 
 	// Insert two more rows, which should NOT trigger a flush.
@@ -130,8 +130,8 @@ func TestBufferingAndFlushing(t *testing.T) {
 	if in.RowsInBuffer() != 2 {
 		t.Error("RowsInBuffer = ", in.RowsInBuffer())
 	}
-	if in.Count() != 5 {
-		t.Error("Count = ", in.Count())
+	if in.Accepted() != 5 {
+		t.Error("Accepted = ", in.Accepted())
 	}
 
 	// Insert two more rows, which should trigger a flush, and leave one
@@ -142,8 +142,8 @@ func TestBufferingAndFlushing(t *testing.T) {
 	if in.RowsInBuffer() != 1 {
 		t.Error("RowsInBuffer = ", in.RowsInBuffer())
 	}
-	if in.Count() != 7 {
-		t.Error("Count = ", in.Count())
+	if in.Accepted() != 7 {
+		t.Error("Accepted = ", in.Accepted())
 	}
 
 	// Flush the final row.
@@ -151,8 +151,8 @@ func TestBufferingAndFlushing(t *testing.T) {
 	if in.RowsInBuffer() != 0 {
 		t.Error("RowsInBuffer = ", in.RowsInBuffer())
 	}
-	if in.Count() != 7 {
-		t.Error("Count = ", in.Count())
+	if in.Accepted() != 7 {
+		t.Error("Count = ", in.Accepted())
 	}
 
 }
@@ -180,5 +180,5 @@ func TestHandleInsertErrors(t *testing.T) {
 	pme = append(pme, rie)
 	in.(*bq.BQInserter).HandleInsertErrors(pme)
 
-    // TODO - assert something.
+	// TODO - assert something.
 }

--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -175,7 +175,7 @@ func worker(w http.ResponseWriter, r *http.Request) {
 
 	// Create parser, injecting Inserter
 	p := parser.NewParser(dataType, ins)
-	tsk := task.NewTask(fn, tr, p, ins)
+	tsk := task.NewTask(fn, tr, p)
 
 	err = tsk.ProcessAllTests()
 

--- a/etl/etl.go
+++ b/etl/etl.go
@@ -8,7 +8,9 @@ import (
 	"golang.org/x/net/context"
 )
 
-// RowStats should provide the invariants:
+// RowStats interface defines some useful Inserter stats that will also be
+// implemented by Parser.
+// RowStats implementations should provide the invariants:
 //   Accepted == Failed + Committed + RowsInBuffer
 type RowStats interface {
 	// RowsInBuffer returns the count of rows currently in the buffer.
@@ -42,7 +44,7 @@ type Inserter interface {
 	// Dataset name of the BQ dataset containing the table.
 	Dataset() string
 
-	RowStats
+	RowStats // Inserter must implement RowStats
 }
 
 // Params for NewInserter
@@ -74,7 +76,7 @@ type Parser interface {
 	// including $YYYYMMNN, or _YYYYMMNN
 	FullTableName() string
 
-	RowStats
+	RowStats // Parser must implement RowStats
 }
 
 //========================================================================

--- a/etl/etl.go
+++ b/etl/etl.go
@@ -8,6 +8,22 @@ import (
 	"golang.org/x/net/context"
 )
 
+// RowStats should provide the invariants:
+//   Accepted == Failed + Committed + RowsInBuffer
+type RowStats interface {
+	// RowsInBuffer returns the count of rows currently in the buffer.
+	RowsInBuffer() int
+	// Committed returns the count of rows successfully committed to BQ.
+	Committed() int
+	// Accepted returns the count of all rows received through InsertRow(s)
+	Accepted() int
+	// Failed returns the count of all rows that could not be committed.
+	Failed() int
+}
+
+// Inserter is a data sink that writes to BigQuery tables.
+// Inserters should provide the invariants:
+//   After Flush() returns, RowsInBuffer == 0
 type Inserter interface {
 	// InsertRow inserts one row into the insert buffer.
 	InsertRow(data interface{}) error
@@ -15,6 +31,7 @@ type Inserter interface {
 	InsertRows(data []interface{}) error
 	// Flush flushes any rows in the buffer out to bigquery.
 	Flush() error
+
 	// Base Table name of the BQ table that the uploader pushes to.
 	TableBase() string
 	// Table name suffix of the BQ table that the uploader pushes to.
@@ -24,10 +41,8 @@ type Inserter interface {
 	FullTableName() string
 	// Dataset name of the BQ dataset containing the table.
 	Dataset() string
-	// Count returns the count of rows currently in the buffer.
-	Count() int
-	// RowsInBuffer returns the count of rows currently in the buffer.
-	RowsInBuffer() int
+
+	RowStats
 }
 
 // Params for NewInserter
@@ -48,9 +63,18 @@ type Parser interface {
 	// test - binary test data
 	ParseAndInsert(meta map[string]bigquery.Value, testName string, test []byte) error
 
+	// Flush flushes any pending rows.
+	Flush() error
+
 	// The name of the table that this Parser inserts into.
 	// Used for metrics and logging.
 	TableName() string
+
+	// Full table name of the BQ table that the uploader pushes to,
+	// including $YYYYMMNN, or _YYYYMMNN
+	FullTableName() string
+
+	RowStats
 }
 
 //========================================================================

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -23,6 +23,7 @@ func init() {
 	prometheus.MustRegister(TestCount)
 	prometheus.MustRegister(ErrorCount)
 	prometheus.MustRegister(WarningCount)
+	prometheus.MustRegister(BackendFailureCount)
 	prometheus.MustRegister(GCSRetryCount)
 	prometheus.MustRegister(BigQueryInsert)
 	prometheus.MustRegister(DurationHistogram)
@@ -122,6 +123,22 @@ var (
 		},
 		// Parser type, error description.
 		[]string{"table", "filetype", "kind"},
+	)
+
+	// Counts the all bulk backend failures.  This does not count, e.g.
+	// single row errors.
+	//
+	// Provides metrics:
+	//   etl_backend_failure_count{table, kind}
+	// Example usage:
+	//   metrics.BackendFailureCount.WithLabelValues(TableName(), "insert").Inc()
+	BackendFailureCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "etl_backend_failure_count",
+			Help: "Backend failures, whether or not recoverable.",
+		},
+		// Parser type, error description.
+		[]string{"table", "kind"},
 	)
 
 	// Counts the number of retries on GCS read operations.

--- a/parser/disco.go
+++ b/parser/disco.go
@@ -42,10 +42,11 @@ type PortStats struct {
 // TODO(dev) add tests
 type DiscoParser struct {
 	inserter etl.Inserter
+	etl.RowStats
 }
 
 func NewDiscoParser(ins etl.Inserter) etl.Parser {
-	return &DiscoParser{inserter: ins}
+	return &DiscoParser{ins, ins}
 }
 
 // Disco data a JSON representation that should be pushed directly into BigQuery.
@@ -99,6 +100,14 @@ func (dp *DiscoParser) ParseAndInsert(meta map[string]bigquery.Value, testName s
 	return nil
 }
 
+func (dp *DiscoParser) Flush() error {
+	return dp.inserter.Flush()
+}
+
 func (dp *DiscoParser) TableName() string {
 	return dp.inserter.TableBase()
+}
+
+func (dp *DiscoParser) FullTableName() string {
+	return dp.inserter.FullTableName()
 }

--- a/parser/disco.go
+++ b/parser/disco.go
@@ -41,12 +41,14 @@ type PortStats struct {
 
 // TODO(dev) add tests
 type DiscoParser struct {
-	inserter etl.Inserter
-	etl.RowStats
+	inserter     etl.Inserter
+	etl.RowStats // Allows RowStats to be implemented with an embedded struct.
 }
 
 func NewDiscoParser(ins etl.Inserter) etl.Parser {
-	return &DiscoParser{ins, ins}
+	return &DiscoParser{
+		inserter: ins,
+		RowStats: ins} // Delegate RowStats functions to the Inserter.
 }
 
 // Disco data a JSON representation that should be pushed directly into BigQuery.
@@ -100,6 +102,8 @@ func (dp *DiscoParser) ParseAndInsert(meta map[string]bigquery.Value, testName s
 	return nil
 }
 
+// These functions are also required to complete the etl.Parser interface.  For Disco,
+// we just forward the calls to the Inserter.
 func (dp *DiscoParser) Flush() error {
 	return dp.inserter.Flush()
 }

--- a/parser/disco.go
+++ b/parser/disco.go
@@ -42,7 +42,7 @@ type PortStats struct {
 // TODO(dev) add tests
 type DiscoParser struct {
 	inserter     etl.Inserter
-	etl.RowStats // Allows RowStats to be implemented with an embedded struct.
+	etl.RowStats // RowStats implemented for DiscoParser with an embedded struct.
 }
 
 func NewDiscoParser(ins etl.Inserter) etl.Parser {

--- a/parser/disco_test.go
+++ b/parser/disco_test.go
@@ -54,8 +54,8 @@ func TestJSONParsing(t *testing.T) {
 	meta := map[string]bigquery.Value{"filename": "filename", "parsetime": time.Now()}
 	// Should result in two tests sent to inserter, but no call to uploader.
 	err = parser.ParseAndInsert(meta, "testName", test_data)
-	if ins.Count() != 2 {
-		t.Error("Count = ", ins.Count())
+	if ins.Accepted() != 2 {
+		t.Error("Accepted = ", ins.Accepted())
 		t.Fail()
 	}
 
@@ -68,8 +68,8 @@ func TestJSONParsing(t *testing.T) {
 	// Adds two more rows, triggering an upload of 3 rows.
 	err = parser.ParseAndInsert(meta, "testName", test_data)
 
-	if ins.Count() != 6 {
-		t.Error("Count = ", ins.Count())
+	if ins.Accepted() != 6 {
+		t.Error("Accepted = ", ins.Accepted())
 	}
 	if ins.RowsInBuffer() != 0 {
 		t.Error("RowsInBuffer = ", ins.RowsInBuffer())
@@ -77,9 +77,6 @@ func TestJSONParsing(t *testing.T) {
 	if len(uploader.Rows) != 3 {
 		t.Error("Uploader Row Count = ", len(uploader.Rows))
 	}
-
-	log.Printf("%v\n", uploader.Request)
-	// TODO - check something
 
 	if err != nil {
 		log.Printf("%v\n", uploader.Request)
@@ -102,14 +99,14 @@ func xTestRealBackend(t *testing.T) {
 		// Add two more rows, triggering an upload of 3 rows.
 		// Add two more rows, triggering an upload of 3 rows.
 		err = parser.ParseAndInsert(meta, "testName", test_data)
-		if ins.Count() != 2 {
-			t.Error("Count = ", ins.Count())
+		if ins.Accepted() != 2 {
+			t.Error("Accepted = ", ins.Accepted())
 			t.Fail()
 		}
 	}
 
-	if ins.Count() != 6 {
-		t.Error("Count = ", ins.Count())
+	if ins.Accepted() != 6 {
+		t.Error("Accepted = ", ins.Accepted())
 	}
 	if ins.RowsInBuffer() != 0 {
 		t.Error("RowsInBuffer = ", ins.RowsInBuffer())

--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -101,6 +101,7 @@ type fileInfoAndData struct {
 
 type NDTParser struct {
 	inserter etl.Inserter
+	etl.RowStats
 
 	timestamp string // The unique timestamp common across all files in current batch.
 	time      time.Time
@@ -112,7 +113,7 @@ type NDTParser struct {
 }
 
 func NewNDTParser(ins etl.Inserter) *NDTParser {
-	return &NDTParser{inserter: ins}
+	return &NDTParser{inserter: ins, RowStats: ins}
 }
 
 // ParseAndInsert extracts the last snaplog from the given raw snap log.
@@ -402,8 +403,16 @@ func (n *NDTParser) getAndInsertValues(taskFileName string, test *fileInfoAndDat
 	}
 }
 
+func (n *NDTParser) Flush() error {
+	return n.inserter.Flush()
+}
+
 func (n *NDTParser) TableName() string {
 	return n.inserter.TableBase()
+}
+
+func (n *NDTParser) FullTableName() string {
+	return n.inserter.FullTableName()
 }
 
 // fixValues updates web100 log values that need post-processing fix-ups.

--- a/parser/ndt_test.go
+++ b/parser/ndt_test.go
@@ -188,7 +188,8 @@ func compare(t *testing.T, actual schema.Web100ValueMap, expected schema.Web100V
 }
 
 type inMemoryInserter struct {
-	data []interface{}
+	data      []interface{}
+	committed int
 }
 
 func (in *inMemoryInserter) InsertRow(data interface{}) error {
@@ -200,6 +201,8 @@ func (in *inMemoryInserter) InsertRows(data []interface{}) error {
 	return nil
 }
 func (in *inMemoryInserter) Flush() error {
+	in.committed += len(in.data)
+	in.data = make([]interface{}, 0)
 	return nil
 }
 func (in *inMemoryInserter) TableBase() string {
@@ -217,6 +220,12 @@ func (in *inMemoryInserter) Dataset() string {
 func (in *inMemoryInserter) RowsInBuffer() int {
 	return len(in.data)
 }
-func (in *inMemoryInserter) Count() int {
-	return len(in.data)
+func (in *inMemoryInserter) Accepted() int {
+	return len(in.data) + in.committed
+}
+func (in *inMemoryInserter) Committed() int {
+	return in.committed
+}
+func (in *inMemoryInserter) Failed() int {
+	return 0
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -3,8 +3,6 @@
 package parser
 
 import (
-	"log"
-
 	"cloud.google.com/go/bigquery"
 
 	"github.com/m-lab/etl/bq"
@@ -31,8 +29,25 @@ func NewParser(dt etl.DataType, ins etl.Inserter) etl.Parser {
 //=====================================================================================
 //                       Parser implementations
 //=====================================================================================
+type FakeRowStats struct {
+}
+
+func (s *FakeRowStats) RowsInBuffer() int {
+	return 0
+}
+func (s *FakeRowStats) Accepted() int {
+	return 0
+}
+func (s *FakeRowStats) Committed() int {
+	return 0
+}
+func (s *FakeRowStats) Failed() int {
+	return 0
+}
+
 type NullParser struct {
 	etl.Parser
+	FakeRowStats
 }
 
 func (np *NullParser) ParseAndInsert(meta map[string]bigquery.Value, testName string, test []byte) error {
@@ -50,15 +65,15 @@ func (np *NullParser) TableName() string {
 // TODO add tests
 type TestParser struct {
 	inserter etl.Inserter
+	etl.RowStats
 }
 
 func NewTestParser(ins etl.Inserter) etl.Parser {
-	return &TestParser{ins}
+	return &TestParser{ins, &FakeRowStats{}}
 }
 
 func (tp *TestParser) ParseAndInsert(meta map[string]bigquery.Value, testName string, test []byte) error {
 	metrics.TestCount.WithLabelValues("table", "test", "ok").Inc()
-	log.Printf("Parsing %s", testName)
 	values := make(map[string]bigquery.Value, len(meta)+1)
 	// TODO is there a better way to do this?
 	for k, v := range meta {
@@ -68,6 +83,12 @@ func (tp *TestParser) ParseAndInsert(meta map[string]bigquery.Value, testName st
 	return tp.inserter.InsertRow(bq.MapSaver{values})
 }
 
+func (tp *TestParser) Flush() error {
+	return nil
+}
 func (tp *TestParser) TableName() string {
+	return "test-table"
+}
+func (tp *TestParser) FullTableName() string {
 	return "test-table"
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -29,6 +29,8 @@ func NewParser(dt etl.DataType, ins etl.Inserter) etl.Parser {
 //=====================================================================================
 //                       Parser implementations
 //=====================================================================================
+
+// FakeRowStats provides trivial implementation of RowStats interface.
 type FakeRowStats struct {
 }
 
@@ -64,12 +66,14 @@ func (np *NullParser) TableName() string {
 // "testname":"..."
 // TODO add tests
 type TestParser struct {
-	inserter etl.Inserter
-	etl.RowStats
+	inserter     etl.Inserter
+	etl.RowStats // Allows RowStats to be implemented through an embedded struct.
 }
 
 func NewTestParser(ins etl.Inserter) etl.Parser {
-	return &TestParser{ins, &FakeRowStats{}}
+	return &TestParser{
+		ins,
+		&FakeRowStats{}} // Use a FakeRowStats to provide the RowStats functions.
 }
 
 func (tp *TestParser) ParseAndInsert(meta map[string]bigquery.Value, testName string, test []byte) error {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -48,7 +48,6 @@ func (s *FakeRowStats) Failed() int {
 }
 
 type NullParser struct {
-	etl.Parser
 	FakeRowStats
 }
 
@@ -87,6 +86,7 @@ func (tp *TestParser) ParseAndInsert(meta map[string]bigquery.Value, testName st
 	return tp.inserter.InsertRow(bq.MapSaver{values})
 }
 
+// These functions are also required to complete the etl.Parser interface.
 func (tp *TestParser) Flush() error {
 	return nil
 }

--- a/parser/pt.go
+++ b/parser/pt.go
@@ -44,6 +44,7 @@ func (f *PTFileName) GetDate() (string, bool) {
 
 type PTParser struct {
 	inserter etl.Inserter
+	etl.RowStats
 }
 
 type Node struct {
@@ -64,7 +65,7 @@ const IPv4_AF int32 = 2
 const IPv6_AF int32 = 10
 
 func NewPTParser(ins etl.Inserter) *PTParser {
-	return &PTParser{ins}
+	return &PTParser{ins, ins}
 }
 
 // ProcessAllNodes take the array of the Nodes, and generate one ParisTracerouteHop entry from each node.
@@ -160,6 +161,14 @@ func GetLogtime(filename PTFileName) int64 {
 
 func (pt *PTParser) TableName() string {
 	return pt.inserter.TableBase()
+}
+
+func (pt *PTParser) FullTableName() string {
+	return pt.inserter.FullTableName()
+}
+
+func (pt *PTParser) Flush() error {
+	return pt.inserter.Flush()
 }
 
 func CreateTestId(fn string) string {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -32,8 +32,8 @@ type TarReader interface {
 }
 
 type ETLSource struct {
-	TarReader
-	io.Closer
+	TarReader // TarReader interface provided by an embedded struct.
+	io.Closer // Closer interface to be provided by an embedded struct.
 }
 
 // Retrieve next file header.

--- a/task/task.go
+++ b/task/task.go
@@ -19,9 +19,12 @@ import (
 
 // TODO(dev) Add unit tests for meta data.
 type Task struct {
-	*storage.ETLSource                           // Source from which to read tests.
-	etl.Parser                                   // Parser to parse the tests.
-	meta               map[string]bigquery.Value // Metadata about this task.
+	// ETLSource and Parser are both embedded, so their interfaces are delegated
+	// to the component structs.
+	*storage.ETLSource // Source from which to read tests.
+	etl.Parser         // Parser to parse the tests.
+
+	meta map[string]bigquery.Value // Metadata about this task.
 }
 
 // NewTask constructs a task, injecting the source and the parser.

--- a/task/task.go
+++ b/task/task.go
@@ -21,18 +21,17 @@ import (
 type Task struct {
 	*storage.ETLSource                           // Source from which to read tests.
 	etl.Parser                                   // Parser to parse the tests.
-	etl.Inserter                                 // provides InsertRows(...)
 	meta               map[string]bigquery.Value // Metadata about this task.
 }
 
 // NewTask constructs a task, injecting the source and the parser.
-func NewTask(filename string, src *storage.ETLSource, prsr etl.Parser, inserter etl.Inserter) *Task {
+func NewTask(filename string, src *storage.ETLSource, prsr etl.Parser) *Task {
 	// TODO - should the meta data be a nested type?
 	meta := make(map[string]bigquery.Value, 3)
 	meta["filename"] = filename
 	meta["parse_time"] = time.Now()
 	meta["attempt"] = 1
-	t := Task{src, prsr, inserter, meta}
+	t := Task{src, prsr, meta}
 	return &t
 }
 
@@ -63,7 +62,7 @@ func (tt *Task) ProcessAllTests() error {
 				time.Since(tt.meta["parse_time"].(time.Time)), err)
 
 			metrics.TestCount.WithLabelValues(
-				tt.Inserter.TableBase(), "unknown", "unrecovered").Inc()
+				tt.Parser.TableName(), "unknown", "unrecovered").Inc()
 			break
 		}
 		if data == nil {
@@ -92,7 +91,8 @@ func (tt *Task) ProcessAllTests() error {
 		log.Printf("%v", err)
 	}
 	// TODO - make this debug or remove
-	log.Printf("Processed %d files, %d nil data, %d rows from %s into %s",
-		files, nilData, tt.Count(), tt.meta["filename"], tt.FullTableName())
+	log.Printf("Processed %d files, %d nil data, %d rows committed, %d failed, from %s into %s",
+		files, nilData, tt.Parser.Committed(), tt.Parser.Failed(),
+		tt.meta["filename"], tt.Parser.FullTableName())
 	return err
 }

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -11,7 +11,6 @@ import (
 
 	"cloud.google.com/go/bigquery"
 
-	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/parser"
 	"github.com/m-lab/etl/storage" // TODO - would be better not to have this.
 	"github.com/m-lab/etl/task"
@@ -81,12 +80,10 @@ func (tp *TestParser) ParseAndInsert(meta map[string]bigquery.Value, testName st
 func TestTarFileInput(t *testing.T) {
 	rdr := MakeTestSource(t)
 
-	var prsr etl.Parser
-	prsr = &TestParser{}
-	var tp = prsr.(*TestParser)
+	tp := &TestParser{}
 
-	// TODO - in := bq.NullInserter{}
-	tt := task.NewTask("filename", rdr, prsr)
+	// Among other things, this requires that tp implements etl.Parser.
+	tt := task.NewTask("filename", rdr, tp)
 	fn, bb, err := tt.NextTest()
 	if err != nil {
 		t.Error(err)
@@ -112,7 +109,7 @@ func TestTarFileInput(t *testing.T) {
 	// Reset the tar reader and create new task, to test the ProcessAllTests behavior.
 	rdr = MakeTestSource(t)
 
-	tt = task.NewTask("filename", rdr, prsr)
+	tt = task.NewTask("filename", rdr, tp)
 	tt.ProcessAllTests()
 
 	if len(tp.files) != 2 {


### PR DESCRIPTION
Currently, task embeds both Parser and Inserter.  This exposes more of the Inserter interface than is perhaps healthy.
To improve handling of .meta file data in NDT tests, I want to have Parser also implement Flush.  With both Parser and Inserter embedded, this would confuse the interfaces.

This PR:
  1. Modifies the stats reported by Inserter, and bundles them into new RowStats interface.
  2. removes embedded Inserter from Task
  3. exposes the RowStats, Flush, and FullTableName through Parser.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/124)
<!-- Reviewable:end -->
