### PR TITLE
new group deferal strategy and collision handling

### DIFF
--- a/parser/ndt_meta_test.go
+++ b/parser/ndt_meta_test.go
@@ -1,0 +1,37 @@
+package parser_test
+
+import (
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/m-lab/etl/parser"
+)
+
+// Not complete, but verifies basic functionality.
+func TestMetaParser(t *testing.T) {
+	metaName := `20170509T13:45:13.590210000Z_eb.measurementlab.net:53000.meta`
+	metaData, err := ioutil.ReadFile(`testdata/` + metaName)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	meta := parser.ProcessMetaFile("ndt", "suffix", metaName, metaData)
+
+	if meta == nil {
+		t.Error("metaFile has not been populated.")
+	}
+	timestamp, _ := time.Parse("20060102T15:04:05.999999999Z", "20170509T13:45:13.59021Z")
+	if meta.DateTime != timestamp {
+		t.Error("Incorrect time: ", meta.DateTime)
+	}
+	if meta.Tls {
+		t.Error("Incorrect TLS: ", meta.Tls)
+	}
+	if !meta.Websockets {
+		t.Error("Incorrect Websockets: ", meta.Websockets)
+	}
+	if meta.Fields["server hostname"] != "mlab3.vie01.measurement-lab.org" {
+		t.Error("Incorrect hostname: ", meta.Fields["hostname"])
+	}
+}


### PR DESCRIPTION
Previously, c2s and s2c tests were processed and forwarded to the inserter as soon as a meta file was available.  If a new test came in before .meta file, the tests were processed without the meta file.

This lead to orphaned tests if the tests at the end of a tar file had no meta file.

This restructures the handling of test groups, and allows explicitly processing the last group at the end of the tar file, in the Flush() function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/127)
<!-- Reviewable:end -->
