### PR TITLE
Add Snapshot Deltas

### DIFF
--- a/appengine/queue.yaml
+++ b/appengine/queue.yaml
@@ -17,12 +17,12 @@ queue:
   target: etl-ndt-parser
   # Average rate at which to release tasks to the service.  Default is 5/sec
   # This is actually the rate at which tokens are added to the bucket.
-  rate: 5/s
+  rate: 2/s
   # Number of tokens that can accumulate in the bucket.  Default is 5.  This should
   # have very little impact for our environment.
   bucket_size: 10
   # Maximum number of concurrent requests.
-  max_concurrent_requests: 180
+  max_concurrent_requests: 360
 
 - name: etl-traceroute-queue
   target: etl-traceroute-parser

--- a/bq/insert.go
+++ b/bq/insert.go
@@ -85,7 +85,7 @@ func MustGetClient(timeout time.Duration) *bigquery.Client {
 	// when we actually want to access the bigquery backend.
 	clientOnce.Do(func() {
 		ctx, _ := context.WithTimeout(context.Background(), timeout)
-		log.Printf("Using client: %s\n", os.Getenv("GCLOUD_PROJECT"))
+		log.Printf("Using project: %s\n", os.Getenv("GCLOUD_PROJECT"))
 		// Heavyweight!
 		var err error
 		bqClient, err = bigquery.NewClient(ctx, os.Getenv("GCLOUD_PROJECT"))

--- a/cmd/etl_worker/app-ndt.yaml
+++ b/cmd/etl_worker/app-ndt.yaml
@@ -15,15 +15,6 @@ resources:
   # TODO - Adjust once we understand requirements.
   disk_size_gb: 10
 
-  # The tmpfs space is allocated from memory_gb.
-  volumes:
-  # Define a tmpfs disk for NDT snapshot files.
-  # Mounted under: /mnt/tmpfs
-  # TODO - get rid of this now.
-  - name: tmpfs
-    volume_type: tmpfs
-    size_gb: 1.0
-
 automatic_scaling:
   # We expect fairly steady load, so a modest minimum will rarely cost us anything.
   min_num_instances: 2

--- a/cmd/etl_worker/app-ndt.yaml
+++ b/cmd/etl_worker/app-ndt.yaml
@@ -10,7 +10,7 @@ resources:
   cpu: 2
   # Instances support between [(cpu * 0.9) - 0.4, (cpu * 6.5) - 0.4]
   # Actual memory available is exposed via GAE_MEMORY_MB environment variable.
-  memory_gb: 12
+  memory_gb: 6
 
   # TODO - Adjust once we understand requirements.
   disk_size_gb: 10
@@ -19,6 +19,7 @@ resources:
   volumes:
   # Define a tmpfs disk for NDT snapshot files.
   # Mounted under: /mnt/tmpfs
+  # TODO - get rid of this now.
   - name: tmpfs
     volume_type: tmpfs
     size_gb: 1.0
@@ -30,7 +31,7 @@ automatic_scaling:
   cool_down_period_sec: 300
   # We don't care much about latency, so a high utilization is desireable.
   cpu_utilization:
-    target_utilization: 0.95
+    target_utilization: 0.85
 
 # Note: add a public port for GCE auto discovery by prometheus.
 # TODO(dev): are any values redundant or irrelevant?

--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -69,7 +69,7 @@ var inFlight int32
 // For now, assuming:
 //    MC: 180,  MI: 20, MW: 10
 func shouldThrottle() bool {
-	if atomic.AddInt32(&inFlight, 1) > 10 {
+	if atomic.AddInt32(&inFlight, 1) > 20 {
 		atomic.AddInt32(&inFlight, -1)
 		return true
 	}

--- a/cmd/web100_cli/web100_cli.go
+++ b/cmd/web100_cli/web100_cli.go
@@ -61,8 +61,7 @@ func main() {
 
 	results := schema.NewWeb100MinimalRecord(
 		snaplog.Version, int64(snaplog.LogTime),
-		(map[string]bigquery.Value)(nestedConnSpec),
-		(map[string]bigquery.Value)(snapValues))
+		nestedConnSpec, snapValues, nil)
 
 	prettyPrint(results)
 }

--- a/etl/globals.go
+++ b/etl/globals.go
@@ -95,7 +95,7 @@ var (
 	// Map from data type to BigQuery table name.
 	// TODO - this should be loaded from a config.
 	DataTypeToTable = map[DataType]string{
-		NDT:     "ndt_test_daily",
+		NDT:     "ndt_nested",
 		SS:      "ss_test",
 		PT:      "pt_test",
 		SW:      "disco_test",

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -26,6 +26,9 @@ func init() {
 	prometheus.MustRegister(BackendFailureCount)
 	prometheus.MustRegister(GCSRetryCount)
 	prometheus.MustRegister(BigQueryInsert)
+	prometheus.MustRegister(RowSizeHistogram)
+	prometheus.MustRegister(DeltaNumFieldsHistogram)
+	prometheus.MustRegister(EntryFieldCountHistogram)
 	prometheus.MustRegister(DurationHistogram)
 	prometheus.MustRegister(InsertionHistogram)
 	prometheus.MustRegister(FileSizeHistogram)
@@ -172,6 +175,44 @@ var (
 		[]string{"table", "status"},
 	)
 
+	RowSizeHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "etl_row_json_size",
+			Help: "Row json size distributions.",
+			Buckets: []float64{
+				100, 200, 400, 800, 1600, 3200, 6400, 10000, 20000,
+				40000, 80000, 160000, 320000, 500000, 600000, 700000,
+				800000, 900000, 1000000, 1200000, 5000000, 10000000, 20000000,
+			},
+		},
+		[]string{"table"},
+	)
+
+	DeltaNumFieldsHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "etl_delta_num_field",
+			Help: "Number of fields in delta distribution.",
+			Buckets: []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+				14, 16, 18, 20, 22, 24, 28, 32, 36, 40, 50, 60,
+			},
+		},
+		[]string{"table"},
+	)
+
+	EntryFieldCountHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "etl_entry_field_count",
+			Help: "total snapshot field count distributions.",
+			Buckets: []float64{10, 12, 14, 16, 20, 24,
+				28, 32, 40, 48, 64, 72, 80, 88, 96, 102, 110, 118, 126,
+				132, 150, 200, 250, 300, 350, 400, 500, 600, 700, 800, 900, 1000,
+				1250, 1500, 1750, 2000, 2500, 3000, 3500, 4000, 5000, 6000, 8000,
+				10000, 15000, 20000, 30000, 40000, 50000, 70000,
+				100000, 200000, 300000, 400000, 500000,
+			},
+		},
+		[]string{"table"},
+	)
 	// A histogram of bigquery insertion times. The buckets should use
 	// periods that are intuitive for people.
 	//

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -175,6 +175,17 @@ var (
 		[]string{"table", "status"},
 	)
 
+	// A histogram of bq row json sizes.  It is intended primarily for
+	// NDT, so the bins are fairly large.  NDT average json is around 200K
+	//
+	// Provides metrics:
+	//   etl_row_json_size_bucket{table="...", le="..."}
+	//   ...
+	//   etl_row_json_size_sum{table="...", le="..."}
+	//   etl_row_json_size_count{table="...", le="..."}
+	// Usage example:
+	//   metrics.RowSizeHistogram.WithLabelValues(
+	//           "ndt").Observe(len(json))
 	RowSizeHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "etl_row_json_size",
@@ -182,37 +193,62 @@ var (
 			Buckets: []float64{
 				100, 200, 400, 800, 1600, 3200, 6400, 10000, 20000,
 				40000, 80000, 160000, 320000, 500000, 600000, 700000,
-				800000, 900000, 1000000, 1200000, 5000000, 10000000, 20000000,
+				800000, 900000, 1000000, 1200000, 1500000, 2000000, 5000000,
 			},
 		},
 		[]string{"table"},
 	)
 
+	// A histogram of snapshot delta field counts.  It is intended primarily for
+	// NDT.  Typical is about 13, but max might be up to 120 or so.
+	//
+	// Provides metrics:
+	//   etl_delta_num_field_bucket{table="...", le="..."}
+	//   ...
+	//   etl_delta_num_field_sum{table="...", le="..."}
+	//   etl_delta_num_field_count{table="...", le="..."}
+	// Usage example:
+	//   metrics.DeltaNumFieldsHistogram.WithLabelValues(
+	//           "ndt").Observe(fieldCount)
 	DeltaNumFieldsHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "etl_delta_num_field",
 			Help: "Number of fields in delta distribution.",
 			Buckets: []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
-				14, 16, 18, 20, 22, 24, 28, 32, 36, 40, 50, 60,
+				14, 16, 18, 20, 22, 24, 28, 32, 36, 40, 50, 60, 70, 80, 90,
+				100, 110, 120, 150,
 			},
 		},
 		[]string{"table"},
 	)
 
+	// A histogram of (approximate) row field counts.  It is intended primarily for
+	// NDT, so the bins are fairly large.  NDT snapshots typically total about 10k
+	// fields, 99th percentile around 35k fields, and occasionally as many as 50k.
+	// Smaller field count bins included so that it is possibly useful for other
+	// parsers.
+	//
+	// Provides metrics:
+	//   etl_entry_field_count_bucket{table="...", le="..."}
+	//   ...
+	//   etl_entry_field_count_sum{table="...", le="..."}
+	//   etl_entry_field_count_count{table="...", le="..."}
+	// Usage example:
+	//   metrics.EntryFieldCountHistogram.WithLabelValues(
+	//           "ndt").Observe(fieldCount)
 	EntryFieldCountHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "etl_entry_field_count",
 			Help: "total snapshot field count distributions.",
-			Buckets: []float64{10, 12, 14, 16, 20, 24,
-				28, 32, 40, 48, 64, 72, 80, 88, 96, 102, 110, 118, 126,
-				132, 150, 200, 250, 300, 350, 400, 500, 600, 700, 800, 900, 1000,
-				1250, 1500, 1750, 2000, 2500, 3000, 3500, 4000, 5000, 6000, 8000,
-				10000, 15000, 20000, 30000, 40000, 50000, 70000,
-				100000, 200000, 300000, 400000, 500000,
+			Buckets: []float64{100, 120, 150, 200, 240, 300, 400, 480, 600, 800,
+				1000, 1200, 1500, 2000, 2400, 3000, 4000, 4800, 6000, 8000,
+				10000, 12000, 15000, 20000, 24000, 30000, 40000, 48000, 60000, 80000,
+				100000, 120000, 150000, 200000, 240000, 300000, 400000, 480000,
 			},
 		},
 		[]string{"table"},
 	)
+
 	// A histogram of bigquery insertion times. The buckets should use
 	// periods that are intuitive for people.
 	//

--- a/schema/README.md
+++ b/schema/README.md
@@ -6,11 +6,14 @@ It has been ordered for easy comparison against the new schema.
 
 ndt.json contains the initial schema for the NDT tables.  It can be used to
 create a new table by invoking (while logged in to the appropriate project):
+    bq mk --time_partitioning_type=DAY --schema schema/ndt.json -t mlab_sandbox.ndt_test_daily
 
-    bq mk --time_partitioning_type=DAY --schema ndt.json -t mlab_sandbox.ndt_test_daily
+repeated.json contains another NDT schema, including a repeated "delta" field,
+intended to contain snapshot deltas.  To create a new table:
+    bq mk --time_partitioning_type=DAY --schema schema/repeated.json -t measurement-lab:public.ndt_delta
 
-or
-    bq mk --time_partitioning_type=DAY --schema pt.json -t mlab_sandbox.pt_test
+pt.json contains the schema for paris traceroute tables.  To create a new table:
+    bq mk --time_partitioning_type=DAY --schema schema/pt.json -t mlab_sandbox.pt_test
 
-As of May 2017, there are differences between the legacy and NDT schema that may
+As of May 2017, there are (still) differences between the legacy and NDT schema that may
 need to be addressed.

--- a/schema/ndt.json
+++ b/schema/ndt.json
@@ -3,14 +3,14 @@
       { "name": "task_filename", "type": "STRING"},
       { "name": "parse_time", "type": "TIMESTAMP"},
       { "name": "log_time", "type": "TIMESTAMP"},
-      { "name": "blacklist_flags", "type": "INTEGER", "description": "Deprecated.  Use flag in anomolies record instead."},
+      { "name": "blacklist_flags", "type": "INTEGER", "description": "Deprecated.  Use flag in anomalies record instead."},
       {
         "fields": [
           { "name": "no_meta", "type": "BOOLEAN"},
           { "name": "snaplog_error", "type": "BOOLEAN"},
           { "name": "num_snaps", "type": "INTEGER"},
           { "name": "blacklist_flags", "type": "INTEGER"}
-        ], "name": "anomolies", "type": "RECORD", "description": "Anomolies associated with test"},
+        ], "name": "anomalies", "type": "RECORD", "description": "Anomalies associated with test"},
       {
         "fields": [
           { "name": "client_af", "type": "INTEGER"},

--- a/schema/web100.go
+++ b/schema/web100.go
@@ -140,8 +140,12 @@ func NewWeb100FullRecord(version string, logTime int64, connSpec, snapValues map
 	}
 }
 
+func EmptySnap10() Web100ValueMap {
+	return make(Web100ValueMap, 10)
+}
+
 func EmptySnap() Web100ValueMap {
-	return make(Web100ValueMap, 150)
+	return make(Web100ValueMap, 120)
 }
 
 // NewWeb100Skeleton creates the tree structure, with no leaf fields.
@@ -204,13 +208,14 @@ func EmptyGeolocation() Web100ValueMap {
 
 // NewWeb100MinimalRecord creates a web100 value map with only the given fields.
 // All undefined fields will be set to null after a BQ insert.
-func NewWeb100MinimalRecord(version string, logTime int64, connSpec, snapValues Web100ValueMap) Web100ValueMap {
+func NewWeb100MinimalRecord(version string, logTime int64, connSpec, snapValues Web100ValueMap, deltas []Web100ValueMap) Web100ValueMap {
 	return Web100ValueMap{
 		"web100_log_entry": Web100ValueMap{
 			"version":         version,
 			"log_time":        logTime,
 			"connection_spec": connSpec, // TODO - deprecate connection_spec here.
 			"snap":            snapValues,
+			"deltas":          deltas,
 		},
 	}
 }

--- a/web100/web100.go
+++ b/web100/web100.go
@@ -551,3 +551,24 @@ func (snap *Snapshot) SnapshotValues(snapValues Saver) error {
 	}
 	return nil
 }
+
+// SnapshotValues writes changed values into the provided Saver.
+func (snap *Snapshot) SnapshotDeltas(other *Snapshot, snapValues Saver) error {
+	if snap.raw == nil {
+		return errors.New("Empty/Invalid Snaplog")
+	}
+	if other.raw == nil {
+		// If other is empty, return full snapshot
+		return snap.SnapshotValues(snapValues)
+	}
+	var field variable
+	for _, field = range snap.fields.Fields {
+		// Interpret and save the web100 field value.
+		a := other.raw[field.Offset : field.Offset+field.Size]
+		b := snap.raw[field.Offset : field.Offset+field.Size]
+		if bytes.Compare(a, b) != 0 {
+			field.Save(b, snapValues)
+		}
+	}
+	return nil
+}

--- a/web100/web100_test.go
+++ b/web100/web100_test.go
@@ -2,7 +2,7 @@ package web100_test
 
 // TODO - consider adding selected tests from
 // gs://m-lab/ndt/2016/11/01/20161101T000000Z-mlab1-syd01-ndt-0002.tgz
-// to test some of the anomoly cases.
+// to test some of the anomaly cases.
 
 import (
 	"encoding/json"


### PR DESCRIPTION
Adds "delta" snapshots to the schema.  Only fields that change are reported, and all other fields are null, indicating that their value is same as previous delta.

Adds web100.SnapshotDeltas, which records delta snapshot into a Saver.

Adds delta handling in NDT parser, along with useful metrics.

Updates etl_worker, queues, etc., to maintain appropriate pacing and scaling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/128)
<!-- Reviewable:end -->
