### PR TITLE
fix personalize_deploy to work with arbitrary yaml

### DIFF
--- a/.personalize_deploy.sh
+++ b/.personalize_deploy.sh
@@ -16,11 +16,11 @@ if [[ -f ${BASEDIR}/${YAML} ]] ; then
   if [[ -n "${TRAVIS_BRANCH}" ]] ; then
     if [[ ${TRAVIS_BRANCH} == sandbox-* ]] ; then
       user=${TRAVIS_BRANCH##sandbox-}
-      sed -e 's/^service: \(.*\)/service: \1-'${user}'/' \
-          "${BASEDIR}/${YAML}" > "${BASEDIR}/app.yaml"
+      sed -i -e 's/^service: \(.*\)/service: \1-'${user}'/' \
+          "${BASEDIR}/${YAML}"
     fi
   fi
 fi
 
 # Call actual script to deploy service.
-"${SCRIPT}" "${PROJECT}" "${KEYFILE}" "${BASEDIR}"
+"${SCRIPT}" "${PROJECT}" "${KEYFILE}" "${BASEDIR} ${YAML}"

--- a/.personalize_deploy.sh
+++ b/.personalize_deploy.sh
@@ -8,8 +8,9 @@ set -e
 
 SCRIPT=${1:?Please provide the deployment script}
 PROJECT=${2:?Please provide the GCP project id}
-BASEDIR=${3:?Please provide the base directory containing yaml file}
-YAML=${4:?Please provide yaml file name, e.g. app-ndt.yaml}
+KEYFILE=${3:?Please provide the service account key file}
+BASEDIR=${4:?Please provide the base directory containing yaml file}
+YAML=${5:?Please provide yaml file name, e.g. app-ndt.yaml}
 
 if [[ -f ${BASEDIR}/${YAML} ]] ; then
   if [[ -n "${TRAVIS_BRANCH}" ]] ; then

--- a/.personalize_deploy.sh
+++ b/.personalize_deploy.sh
@@ -8,15 +8,15 @@ set -e
 
 SCRIPT=${1:?Please provide the deployment script}
 PROJECT=${2:?Please provide the GCP project id}
-KEYFILE=${3:?Please provide the service account key file}
-BASEDIR=${4:?Please provide the base directory containing app.yaml}
+BASEDIR=${3:?Please provide the base directory containing yaml file}
+YAML=${4:?Please provide yaml file name, e.g. app-ndt.yaml}
 
-if [[ -f ${BASEDIR}/app.yaml ]] ; then
+if [[ -f ${BASEDIR}/${YAML} ]] ; then
   if [[ -n "${TRAVIS_BRANCH}" ]] ; then
     if [[ ${TRAVIS_BRANCH} == sandbox-* ]] ; then
       user=${TRAVIS_BRANCH##sandbox-}
-      sed -i -e 's/^service: \(.*\)/service: \1-'${user}'/' \
-          "${BASEDIR}/app.yaml"
+      sed -e 's/^service: \(.*\)/service: \1-'${user}'/' \
+          "${BASEDIR}/${YAML}" > "${BASEDIR}/app.yaml"
     fi
   fi
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 # project referenced in the "deploy" section. These keys authenticate the
 # gcloud deploy operations.
 
-- travis/decrypt.sh "$encrypted_ee3c81e2a61e_iv" "$encrypted_ee3c81e2a61e_key"
+- travis/decrypt.sh "$encrypted_ee3c81e2a61e_key" "$encrypted_ee3c81e2a61e_iv"
   keys/service-accounts.tar.enc /tmp/service-accounts.tar /tmp
 
 


### PR DESCRIPTION
Looks like .personalize_deploy.sh has a bug that we haven't noticed, because we disabled the base deployment some time ago.

I think I got this right, but can't test, so please read carefully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/132)
<!-- Reviewable:end -->
