### PR TITLE
separate sandbox targets, add ndt-staging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,8 @@ deploy:
     # Integration branch will not use decorated service names.
     condition: $TRAVIS_BRANCH == ndt-sandbox-*
 
-# INTEGRATION: before code review for development code in a specific branch.
+# INTEGRATION: Reviewed code, merged to integration branch, will trigger
+# deployment to "standard" mlab-sandbox.
 - provider: script
   script: $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-sandbox
     /tmp/mlab-sandbox.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt.yaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ before_install:
 - travis/decrypt.sh "$encrypted_ee3c81e2a61e_key" "$encrypted_ee3c81e2a61e_iv"
   keys/service-accounts.tar.enc /tmp/service-accounts.tar /tmp
 
-
 # These directories will be cached on successful "script" builds, and restored,
 # if available, to save time on future builds.
 cache:
@@ -43,8 +42,9 @@ script:
 # Deploy steps never trigger on a new Pull Request. Deploy steps will trigger
 # after a merge with matching "on:" conditions.
 deploy:
-# SANDBOX: before code review for development code in a specific branch.
+######################################################################
 ## Service: etl-disco-parser -- AppEngine Flexible Environment.
+# SANDBOX: before code review for development code in a specific branch.
 - provider: script
   script: $TRAVIS_BUILD_DIR/.personalize_deploy.sh
     $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-sandbox
@@ -58,9 +58,11 @@ deploy:
     # A bash-style 'if' condition, matching branches with a "sandbox-" prefix.
     # Sandbox branches will be deployed to personalized service names.
     # Integration branch will not use decorated service names.
-    condition: $TRAVIS_BRANCH == sandbox-*
+    condition: $TRAVIS_BRANCH == disco-sandbox-*
 
+######################################################################
 ## Service: etl-ndt-parser -- AppEngine Flexible Environment.
+# PERSONAL SANDBOX: before code review for development code in a specific branch.
 - provider: script
   script: $TRAVIS_BUILD_DIR/.personalize_deploy.sh
     $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-sandbox
@@ -74,9 +76,32 @@ deploy:
     # A bash-style 'if' condition, matching branches with a "sandbox-" prefix.
     # Sandbox branches will be deployed to personalized service names.
     # Integration branch will not use decorated service names.
-    condition: $TRAVIS_BRANCH == sandbox-*
+    condition: $TRAVIS_BRANCH == ndt-sandbox-*
 
+# INTEGRATION: before code review for development code in a specific branch.
+- provider: script
+  script: $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-sandbox
+    /tmp/mlab-sandbox.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt.yaml
+  skip_cleanup: true
+  on:
+    repo: m-lab/etl
+    branch: integration
+
+# STAGING: Should be used AFTER code review and commit to dev branch.  Triggers
+# when branch is tagged with ndt-staging-*'
+- provider: script
+  script: $TRAVIS_BUILD_DIR/.personalize_deploy.sh
+    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
+    /tmp/mlab-staging.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt.yaml
+  skip_cleanup: true
+  on:
+    repo: m-lab/etl
+    tag: true
+    condition: $TRAVIS_TAG == ndt-staging-*
+
+######################################################################
 ## Service: etl-sidestream-parser -- AppEngine Flexible Environment.
+# SANDBOX: before code review for development code in a specific branch.
 - provider: script
   script: $TRAVIS_BUILD_DIR/.personalize_deploy.sh
     $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-sandbox
@@ -90,9 +115,11 @@ deploy:
     # A bash-style 'if' condition, matching branches with a "sandbox-" prefix.
     # Sandbox branches will be deployed to personalized service names.
     # Integration branch will not use decorated service names.
-    condition: $TRAVIS_BRANCH == sandbox-*
+    condition: $TRAVIS_BRANCH == ss-sandbox-*
 
+######################################################################
 ## Service: etl-traceroute-parser -- AppEngine Flexible Environment.
+# SANDBOX: before code review for development code in a specific branch.
 - provider: script
   script: $TRAVIS_BUILD_DIR/.personalize_deploy.sh
     $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-sandbox
@@ -106,9 +133,11 @@ deploy:
     # A bash-style 'if' condition, matching branches with a "sandbox-" prefix.
     # Sandbox branches will be deployed to personalized service names.
     # Integration branch will not use decorated service names.
-    condition: $TRAVIS_BRANCH == sandbox-*
+    condition: $TRAVIS_BRANCH == pt-sandbox-*
 
+######################################################################
 ## Service: queue-pusher -- AppEngine Standard Environment.
+# SANDBOX: before code review for development code in a specific branch.
 - provider: script
   script: $TRAVIS_BUILD_DIR/.personalize_deploy.sh
     $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-sandbox
@@ -119,7 +148,7 @@ deploy:
     # Consider all branches and match using the condition. By default
     # "all_branches" is false, and the condition is ignored.
     all_branches: true
-    condition: $TRAVIS_BRANCH == sandbox-*
+    condition: $TRAVIS_BRANCH == qp-sandbox-*
 
 # NOTE: Cloud functions only support primitive IAM roles: Owner, Editor, Viewer.
 # See: https://cloud.google.com/functions/docs/concepts/iam


### PR DESCRIPTION
Clean up handling of different targets in sandbox deployments.
Add standard standbox deployment for NDT only on integration branch.
Add staging branch deployment for NDT only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/133)
<!-- Reviewable:end -->
