### PR TITLE
Count the files collected daily per host and rsync module

### DIFF
--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -197,7 +197,12 @@ func worker(w http.ResponseWriter, r *http.Request) {
 	p := parser.NewParser(dataType, ins)
 	tsk := task.NewTask(fn, tr, p)
 
-	err = tsk.ProcessAllTests()
+	files, err := tsk.ProcessAllTests()
+
+	// Count the files processed per-host-module per-weekday.
+	metrics.FileCount.WithLabelValues(
+		data.Host+"-"+data.Pod+"-"+data.Experiment,
+		date.Weekday().String()).Add(float64(files))
 
 	metrics.WorkerState.WithLabelValues("finish").Inc()
 	defer metrics.WorkerState.WithLabelValues("finish").Dec()

--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -200,6 +200,7 @@ func worker(w http.ResponseWriter, r *http.Request) {
 	files, err := tsk.ProcessAllTests()
 
 	// Count the files processed per-host-module per-weekday.
+	// TODO(soltesz): evaluate separating hosts and pods as separate metrics.
 	metrics.FileCount.WithLabelValues(
 		data.Host+"-"+data.Pod+"-"+data.Experiment,
 		date.Weekday().String()).Add(float64(files))

--- a/etl/globals.go
+++ b/etl/globals.go
@@ -8,7 +8,7 @@ import (
 const start = `^gs://(?P<prefix>.*)/(?P<exp>[^/]*)/`
 const datePath = `(?P<datepath>\d{4}/[01]\d/[0123]\d)/`
 const dateTime = `(\d{4}[01]\d[0123]\d)T000000Z`
-const mlabN_podNN = `-(mlab\d)-([[:alpha:]]{3}\d[0-9t]-)`
+const mlabN_podNN = `-(mlab\d)-([[:alpha:]]{3}\d[0-9t])-`
 const exp_NNNN = `(.*)-(\d{4})`
 const suffix = `(?:\.tar|\.tar.gz|\.tgz)$`
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -19,6 +19,7 @@ func init() {
 	// Register the metrics defined with Prometheus's default registry.
 	prometheus.MustRegister(WorkerCount)
 	prometheus.MustRegister(WorkerState)
+	prometheus.MustRegister(FileCount)
 	prometheus.MustRegister(TaskCount)
 	prometheus.MustRegister(TestCount)
 	prometheus.MustRegister(ErrorCount)
@@ -65,6 +66,20 @@ var (
 	},
 		// Worker state, e.g. create task, read, parse, insert
 		[]string{"state"},
+	)
+
+	// Counts the number of files processed by machine, rsync module, and day.
+	//
+	// Provides metrics:
+	//   etl_files_processed{rsync_host_module, day_of_week}
+	// Example usage:
+	//   metrics.FileCount.WithLabelValues("mlab1-atl01-ndt", "Sunday").Inc()
+	FileCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "etl_files_processed",
+			Help: "Number of files processed.",
+		},
+		[]string{"rsync_host_module", "day_of_week"},
 	)
 
 	// Counts the number of tasks processed by the pipeline.

--- a/task/task.go
+++ b/task/task.go
@@ -39,8 +39,9 @@ func NewTask(filename string, src *storage.ETLSource, prsr etl.Parser) *Task {
 }
 
 // ProcessAllTests loops through all the tests in a tar file, calls the
-// injected parser to parse them, and inserts them into bigquery (not yet implemented).
-func (tt *Task) ProcessAllTests() error {
+// injected parser to parse them, and inserts them into bigquery. Returns the
+// number of files processed.
+func (tt *Task) ProcessAllTests() (int, error) {
 	metrics.WorkerState.WithLabelValues("task").Inc()
 	defer metrics.WorkerState.WithLabelValues("task").Dec()
 	files := 0
@@ -97,5 +98,5 @@ func (tt *Task) ProcessAllTests() error {
 	log.Printf("Processed %d files, %d nil data, %d rows committed, %d failed, from %s into %s",
 		files, nilData, tt.Parser.Committed(), tt.Parser.Failed(),
 		tt.meta["filename"], tt.Parser.FullTableName())
-	return err
+	return files, err
 }

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -110,8 +110,13 @@ func TestTarFileInput(t *testing.T) {
 	rdr = MakeTestSource(t)
 
 	tt = task.NewTask("filename", rdr, tp)
-	tt.ProcessAllTests()
-
+	fc, err := tt.ProcessAllTests()
+	if err != nil {
+		t.Error("Expected nil error, but got %v", err)
+	}
+	if fc != len(tp.files) {
+		t.Error("Number of files counted (%s) does not match files parsed", fc, len(tp.files))
+	}
 	if len(tp.files) != 2 {
 		t.Error("Too few files ", len(tp.files))
 	}


### PR DESCRIPTION
This PR adds minimal support for reconciling the number of files uploaded per day by scraper with the number of files processed per day by the etl workers. This PR is a companion to https://github.com/m-lab/scraper/pull/72

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/148)
<!-- Reviewable:end -->
