### PR TITLE
Prod config

### DIFF
--- a/bq/insert.go
+++ b/bq/insert.go
@@ -28,6 +28,7 @@ import (
 )
 
 // TODO(dev) Use a more thoughtful setting for buffer size.
+// TODO(P3) Include the project name in the parameters.
 // For now, 10K per row times 100 results is 1MB, which is an order of
 // magnitude below our 10MB max, so 100 might not be such a bad
 // default.
@@ -85,7 +86,7 @@ func MustGetClient(timeout time.Duration) *bigquery.Client {
 	// when we actually want to access the bigquery backend.
 	clientOnce.Do(func() {
 		ctx, _ := context.WithTimeout(context.Background(), timeout)
-		project, ok := os.LookupEnv("BIGQUERY_DATASET")
+		project, ok := os.LookupEnv("BIGQUERY_PROJECT")
 		if !ok {
 			project = os.Getenv("GCLOUD_PROJECT")
 		}

--- a/bq/insert.go
+++ b/bq/insert.go
@@ -85,10 +85,15 @@ func MustGetClient(timeout time.Duration) *bigquery.Client {
 	// when we actually want to access the bigquery backend.
 	clientOnce.Do(func() {
 		ctx, _ := context.WithTimeout(context.Background(), timeout)
-		log.Printf("Using project: %s\n", os.Getenv("GCLOUD_PROJECT"))
+		project, ok := os.LookupEnv("BIGQUERY_DATASET")
+		if !ok {
+			project = os.Getenv("GCLOUD_PROJECT")
+		}
+
+		log.Printf("Using project: %s\n", project)
 		// Heavyweight!
 		var err error
-		bqClient, err = bigquery.NewClient(ctx, os.Getenv("GCLOUD_PROJECT"))
+		bqClient, err = bigquery.NewClient(ctx, project)
 		if err != nil {
 			panic(err.Error())
 		}

--- a/cmd/etl_worker/app-ndt-prod.yaml
+++ b/cmd/etl_worker/app-ndt-prod.yaml
@@ -36,6 +36,6 @@ network:
     - 9090/tcp
 
 env_variables:
-        BIGQUERY_PROJECT: 'measurement-lab'
-        BIGQUERY_DATASET: 'public'
-        # TODO add custom service-account, instead of using default credentials.
+  BIGQUERY_PROJECT: 'measurement-lab'
+  BIGQUERY_DATASET: 'public'
+  # TODO add custom service-account, instead of using default credentials.

--- a/cmd/etl_worker/app-ndt-prod.yaml
+++ b/cmd/etl_worker/app-ndt-prod.yaml
@@ -1,0 +1,41 @@
+runtime: custom
+env: flex
+service: etl-ndt-parser
+
+# Resource and scaling options. For more background, see:
+#   https://cloud.google.com/appengine/docs/flexible/go/configuring-your-app-with-app-yaml
+
+# TODO(dev): adjust CPU and memory based on actual requirements.
+resources:
+  cpu: 2
+  # Instances support between [(cpu * 0.9) - 0.4, (cpu * 6.5) - 0.4]
+  # Actual memory available is exposed via GAE_MEMORY_MB environment variable.
+  memory_gb: 6
+
+  # TODO - Adjust once we understand requirements.
+  disk_size_gb: 10
+
+automatic_scaling:
+  # We expect fairly steady load, so a modest minimum will rarely cost us anything.
+  min_num_instances: 2
+  max_num_instances: 20
+  cool_down_period_sec: 300
+  # We don't care much about latency, so a high utilization is desireable.
+  cpu_utilization:
+    target_utilization: 0.85
+
+# Note: add a public port for GCE auto discovery by prometheus.
+# TODO(dev): are any values redundant or irrelevant?
+network:
+  instance_tag: etl-parser
+  name: default
+  # Forward port 9090 on the GCE instance address to the same port in the
+  # container address. Only forward TCP traffic.
+  # Note: the default AppEngine container port 8080 cannot be forwarded.
+  forwarded_ports:
+    - 9090/tcp
+
+env_variables:
+        BIGQUERY_PROJECT: 'measurement-lab'
+        BIGQUERY_DATASET: 'public'
+        # TODO add custom service-account, instead of using default credentials.

--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"runtime"
 	"strconv"
 	"sync/atomic"
@@ -180,7 +181,11 @@ func worker(w http.ResponseWriter, r *http.Request) {
 	dateFormat := "20060102"
 	date, err := time.Parse(dateFormat, data.PackedDate)
 
-	ins, err := bq.NewInserter("mlab_sandbox", dataType, date)
+	dataset, ok := os.LookupEnv("BIGQUERY_DATASET")
+	if !ok {
+		dataset = "mlab_sandbox"
+	}
+	ins, err := bq.NewInserter(dataset, dataType, date)
 	if err != nil {
 		metrics.TaskCount.WithLabelValues(string(dataType), "NewInserterError").Inc()
 		log.Printf("Error creating BQ Inserter:  %v", err)


### PR DESCRIPTION
Use environment variables to specify the destination table project/dataset.  This allows the same binary to be configured for sandbox, staging, or prod.  Production pipeline runs in mlab-oti, but writes to tables in measurement-lab, so we can't just use GCLOUD_PROJECT.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/152)
<!-- Reviewable:end -->
