### PR TITLE
Clean up gcf functions for initial prod deployment.

### DIFF
--- a/appengine/queue_pusher/queue_pusher.go
+++ b/appengine/queue_pusher/queue_pusher.go
@@ -100,6 +100,7 @@ func receiver(w http.ResponseWriter, r *http.Request) {
 		log.Println(err)
 		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprintf(w, `{"message": "Invalid filename."}`)
+		return
 	}
 	// determine correct queue based on file name.
 	queuename, ok := queueForType[fn_data.GetDataType()]

--- a/functions/README.md
+++ b/functions/README.md
@@ -3,15 +3,27 @@ build the initial version and then moved to the [storage triggers
 tutorial](https://cloud.google.com/functions/docs/tutorials/storage) to refine
 things.
 
-To deploy this cloud function to mlab-sandbox, try:
+Note that for different deployments there are 4 things to change...
+createXXXTask..., stage-bucket, trigger-bucket, and project.
+
+To deploy this cloud function to sandbox, use:
 ```bash
-gcloud beta functions deploy fileNotification \
-    --stage-bucket=parser-functions-sandbox \
+gcloud beta functions deploy createSandboxTaskOnFileNotification \
+    --stage-bucket=functions-mlab-sandbox \
     --trigger-bucket=m-lab-sandbox \
     --project=mlab-sandbox
 ```
+To deploy this cloud function to production, use:
+```bash
+gcloud beta functions deploy createProdTaskOnFileNotification \
+    --stage-bucket=functions-mlab-oti \
+    --trigger-bucket=archive-mlab-oti \
+    --project=mlab-oti
+```
 
-To install all the dependencies:
+---------------------------------------------------------------
+
+To install all the dependencies on local machine:
 ```bash
 npm install .
 ```
@@ -20,3 +32,4 @@ To run the unit tests:
 ```bash
 npm test
 ```
+

--- a/functions/embargo/transfer.js
+++ b/functions/embargo/transfer.js
@@ -135,15 +135,9 @@ exports.makeMoveWithAuth = function (file, done) {
  * @param {object} file The file under consideration
  */
 exports.shouldEmbargo = function (file) {
-    // All ndt files can bypass embargo.
-    if (file.name.substring(0, 4) === 'ndt/') {
-        return false;
-    }
-    // Allow test/ for testing purposes.
-    if (file.name.substring(0, 5) === 'test/') {
-        return false;
-    }
-    return true;
+    // Only sidestream files need to be embargoed.  All others can be
+    // transferred.
+    return (file.name.substring(0, 11) === 'sidestream/');
 };
 
 /**

--- a/functions/embargo/transfer.js
+++ b/functions/embargo/transfer.js
@@ -4,22 +4,21 @@
  * determine whether a new file needs to be embargoed, and if not, moves
  * the file to the archive bucket.
  *
- * It currently supports two hard coded destination buckets, archive-mlab-oti, for GCF
- * deployed in mlab-oti (production), and destination-mlab-sandbox for any other
- * deployment (though the destination may fail for projects other than
- * mlab-sandbox).
+ * The destination bucket, archive-mlab-oti, is hard coded, though the trigger
+ * bucket and the project are both determined by the deployment command.  Tried
+ * using projectId to determine destination bucket, but that is unreliable.
  *
  * To deploy this cloud function to mlab-oti (until we get autodeploy set up):
 
  * // Create the buckets
- * gsutil mb -p mlab-oti archive-mlab-oti
- * gsutil mb -p mlab-oti scraper-mlab-oti
- * gsutil mb -p mlab-oti functions-mlab-oti
- * // Deploy the functions.
- * gcloud beta functions deploy transferOnFileNotification \
- *   --stage-bucket=functions-mlab-oti \
- *   --trigger-bucket=scraper-mlab-oti \
- *   --project=mlab-oti
+   gsutil mb -p mlab-oti archive-mlab-oti
+   gsutil mb -p mlab-oti scraper-mlab-oti
+   gsutil mb -p mlab-oti functions-mlab-oti
+   // Deploy the functions.
+   gcloud beta functions deploy transferOnFileNotification \
+     --stage-bucket=functions-mlab-oti \
+     --trigger-bucket=scraper-mlab-oti \
+     --project=mlab-oti
  */
 
 'use strict';
@@ -73,17 +72,9 @@ exports.executeWithAuth = function (func, fail) {
  */
 exports.makeMoveWithAuth = function (file, done) {
     return function (authClient, projectId) {
-        // Choose the destination bucket, based on projectId.
         var destBucket, storage;
 
-        if (projectId === 'mlab-oti') {
-            destBucket = 'archive-mlab-oti';
-        } else {
-            // For projects other than mlab-oti, write files elsewhere.
-            console.log('projectId: ', projectId);
-            destBucket = 'destination-mlab-sandbox';
-        }
-
+        destBucket = 'archive-mlab-oti';
         storage = google.storage(
             {"version": "v1", "auth": authClient, "project": projectId}
         );
@@ -148,6 +139,7 @@ exports.shouldEmbargo = function (file) {
     if (file.name.substring(0, 4) === 'ndt/') {
         return false;
     }
+    // Allow test/ for testing purposes.
     if (file.name.substring(0, 5) === 'test/') {
         return false;
     }

--- a/functions/enqueue.js
+++ b/functions/enqueue.js
@@ -18,6 +18,7 @@ exports.queueForFile = function (filename) {
         "sidestream": "etl-sidestream-queue",
         "paris-traceroute": "etl-paris-traceroute-queue"
     };
+    // TODO - fix this.
     for (key in experiment_to_task_queue) {
         re = new RegExp("^" + key + "/\\d{4}/\\d{2}/\\d{2}/[0-9a-z_a-z:.-]+");
         if (re.test(filename)) {


### PR DESCRIPTION
projectId is unreliable, so don't use it.
project is hard coded into enqueue functions, so clone them for different projects.
fix a bug in queue_pusher to prevent panics.
fix some jslint complaints.
adjust readme doc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/165)
<!-- Reviewable:end -->
