### PR TITLE
tweak queue rate

### DIFF
--- a/appengine/queue.yaml
+++ b/appengine/queue.yaml
@@ -17,7 +17,8 @@ queue:
   target: etl-ndt-parser
   # Average rate at which to release tasks to the service.  Default is 5/sec
   # This is actually the rate at which tokens are added to the bucket.
-  rate: 0.5/s
+  # 1.0 allow processing a day's data (about 11K tasks) in 3 to 4 hours.
+  rate: 1.0/s
   # Number of tokens that can accumulate in the bucket.  Default is 5.  This should
   # have very little impact for our environment.
   bucket_size: 10

--- a/appengine/queue.yaml
+++ b/appengine/queue.yaml
@@ -17,7 +17,7 @@ queue:
   target: etl-ndt-parser
   # Average rate at which to release tasks to the service.  Default is 5/sec
   # This is actually the rate at which tokens are added to the bucket.
-  rate: 1.5/s
+  rate: 0.5/s
   # Number of tokens that can accumulate in the bucket.  Default is 5.  This should
   # have very little impact for our environment.
   bucket_size: 10


### PR DESCRIPTION
Since the pipeline is now running concurrently with the scraper, it should be fine to allow it to run more slowly, keeping resource to a minimum.  At this rate, the ingestion takes about 6 hours.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/166)
<!-- Reviewable:end -->
