### PR TITLE
Add MAX_CONCURRENT_REQUESTS environment variable

### DIFF
--- a/cmd/etl_worker/app-ndt-prod.yaml
+++ b/cmd/etl_worker/app-ndt-prod.yaml
@@ -36,6 +36,7 @@ network:
     - 9090/tcp
 
 env_variables:
+  MAX_CONCURRENT_REQUESTS: 20
   BIGQUERY_PROJECT: 'measurement-lab'
   BIGQUERY_DATASET: 'public'
   # TODO add custom service-account, instead of using default credentials.

--- a/cmd/etl_worker/app-ndt-prod.yaml
+++ b/cmd/etl_worker/app-ndt-prod.yaml
@@ -36,7 +36,7 @@ network:
     - 9090/tcp
 
 env_variables:
-  MAX_CONCURRENT_REQUESTS: 20
+  MAX_WORKERS: 20
   BIGQUERY_PROJECT: 'measurement-lab'
   BIGQUERY_DATASET: 'public'
   # TODO add custom service-account, instead of using default credentials.

--- a/cmd/etl_worker/app-ndt.yaml
+++ b/cmd/etl_worker/app-ndt.yaml
@@ -34,3 +34,9 @@ network:
   # Note: the default AppEngine container port 8080 cannot be forwarded.
   forwarded_ports:
     - 9090/tcp
+
+env_variables:
+  MAX_CONCURRENT_REQUESTS: 20
+  BIGQUERY_PROJECT: 'mlab-sandbox'
+  BIGQUERY_DATASET: 'mlab_sandbox'
+  # TODO add custom service-account, instead of using default credentials.

--- a/cmd/etl_worker/app-ndt.yaml
+++ b/cmd/etl_worker/app-ndt.yaml
@@ -36,7 +36,7 @@ network:
     - 9090/tcp
 
 env_variables:
-  MAX_CONCURRENT_REQUESTS: 20
+  MAX_WORKERS: 20
   BIGQUERY_PROJECT: 'mlab-sandbox'
   BIGQUERY_DATASET: 'mlab_sandbox'
   # TODO add custom service-account, instead of using default credentials.

--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -53,8 +53,10 @@ func handler(w http.ResponseWriter, r *http.Request) {
 }
 
 // Basic throttling to restrict the number of tasks in flight.
-var maxInFlight = 20 // Max number of concurrent workers (and tasks in flight).
-var inFlight int32   // Current number of tasks in flight.
+const defaultMaxInFlight = 20
+
+var maxInFlight int32 // Max number of concurrent workers (and tasks in flight).
+var inFlight int32    // Current number of tasks in flight.
 
 // Returns true if request should be rejected.
 // If the max concurrency (MC) exceeds (or matches) the instances*workers, then
@@ -264,7 +266,7 @@ func main() {
 	maxInFlight, ok := os.LookupEnv("MAX_CONCURRENT_REQUESTS")
 	if !ok {
 		log.Println("MAX_CONCURRENT_REQUESTS not configured.  Using 20.")
-		maxInFlight := 20
+		maxInFlight := defaultMaxInFlight
 	}
 
 	// We also setup another prometheus handler on a non-standard path. This

--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -241,17 +241,17 @@ func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func setMaxInFlight() {
-	maxInFlightString, ok := os.LookupEnv("MAX_CONCURRENT_REQUESTS")
+	maxInFlightString, ok := os.LookupEnv("MAX_WORKERS")
 	if ok {
 		maxInFlightInt, err := strconv.Atoi(maxInFlightString)
 		if err == nil {
 			maxInFlight = int32(maxInFlightInt)
 		} else {
-			log.Println("MAX_CONCURRENT_REQUESTS not configured.  Using 20.")
+			log.Println("MAX_WORKERS not configured.  Using 20.")
 			maxInFlight = defaultMaxInFlight
 		}
 	} else {
-		log.Println("MAX_CONCURRENT_REQUESTS not configured.  Using 20.")
+		log.Println("MAX_WORKERS not configured.  Using 20.")
 		maxInFlight = defaultMaxInFlight
 	}
 }

--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -353,7 +353,7 @@ func (n *NDTParser) getAndInsertValues(test *fileInfoAndData, testType string) {
 	valid := true
 	err = snaplog.ValidateSnapshots()
 	if err != nil {
-		log.Printf("ValidateSnapshots failed for %s, when processing: %s\n%s\n",
+		log.Printf("ValidateSnapshots failed for %s, when processing: %s (%s)\n",
 			test.fn, n.taskFileName, err)
 		metrics.WarningCount.WithLabelValues(
 			n.TableName(), testType, "validate failed").Inc()


### PR DESCRIPTION
This adds a yaml configured environment variable to specify the max number of workers (MAX_CONCURRENT_REQUESTS), and code in etl_worker.go to use it.

This allows tuning of each individual pipeline for best performance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/167)
<!-- Reviewable:end -->
