### PR TITLE
Fix NDT server_hostname when missing from connSpec

### DIFF
--- a/etl/globals.go
+++ b/etl/globals.go
@@ -11,6 +11,7 @@ const dateTime = `(\d{4}[01]\d[0123]\d)T000000Z`
 const mlabN_podNN = `-(mlab\d)-([[:alpha:]]{3}\d[0-9t])-`
 const exp_NNNN = `(.*)-(\d{4})`
 const suffix = `(?:\.tar|\.tar.gz|\.tgz)$`
+const MlabDomain = `measurement-lab.org`
 
 // These are here to facilitate use across queue-pusher and parsing components.
 var (


### PR DESCRIPTION
This change addresses the problem of "when no_meta, the `server_hostname` is missing entirely" from https://github.com/m-lab/etl/issues/168

The `server_hostname` is reconstructed from the archive filename. This requires hard-coding the `measurement-lab.org` domain suffix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/170)
<!-- Reviewable:end -->
