### PR TITLE
Fix check for server_hostname

### DIFF
--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -562,13 +562,17 @@ func (n *NDTParser) fixValues(r schema.Web100ValueMap) {
 	}
 
 	// If there is no meta file then the server hostname will not be set.
-	if connSpec["server_hostname"] == "" {
+	// We must check for presence and an empty value.
+	hn, ok := connSpec["server_hostname"]
+	if !ok || hn == "" {
 		data, err := etl.ValidateTestPath(n.taskFileName)
 		if err != nil {
-			log.Println("WARNING: taskFileName is unexpectedly invalid.")
+			// The current filename is ambiguous, but the timestamp should help.
+			log.Printf("WARNING: taskFileName is unexpectedly invalid: %s %s: %q",
+				n.taskFileName, n.timestamp, err)
 		} else {
-			connSpec["server_hostname"] = fmt.Sprintf(
-				"%s.%s.%s", data.Host, data.Pod, etl.MlabDomain)
+			connSpec.SetString("server_hostname", fmt.Sprintf(
+				"%s.%s.%s", data.Host, data.Pod, etl.MlabDomain))
 		}
 	}
 

--- a/parser/ndt_test.go
+++ b/parser/ndt_test.go
@@ -71,7 +71,8 @@ func TestNDTParser(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 
-	meta := map[string]bigquery.Value{"filename": "tarfile.tgz"}
+	// Use a valid archive name.
+	meta := map[string]bigquery.Value{"filename": "gs://mlab-test-bucket/ndt/2017/06/13/20170613T000000Z-mlab3-vie01-ndt-0186.tgz"}
 	err = n.ParseAndInsert(meta, s2cName+".gz", s2cData)
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -100,6 +101,9 @@ func TestNDTParser(t *testing.T) {
 	// Extract the values saved to the inserter.
 	actualValues := ins.data[0].(*bq.MapSaver).Values
 	expectedValues := schema.Web100ValueMap{
+		"connection_spec": schema.Web100ValueMap{
+			"server_hostname": "mlab3.vie01.measurement-lab.org",
+		},
 		"web100_log_entry": schema.Web100ValueMap{
 			"version": "2.5.27 201001301335 net100",
 			"snap": schema.Web100ValueMap{


### PR DESCRIPTION
Since the connSpec is a `map[string]bigquery.Value` the empty value is `nil` if `server_hostname` is not present. So this change explicitly checks whether `server_hostname` is present and if it is that it is not empty. If it is missing or empty, the value is constructed and set.

Addresses issue from: https://github.com/m-lab/etl/issues/168

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/185)
<!-- Reviewable:end -->
