### PR TITLE
Reduce ndt and pt rate, and remove obsolete queue

### DIFF
--- a/appengine/README.md
+++ b/appengine/README.md
@@ -2,7 +2,13 @@
 To deploy:
   gcloud auth login ...
   gcloud config set project mlab-sandbox
+  gcloud deploy sandbox-queue.yaml
+
+Or:
+  gcloud auth login ...
+  gcloud config set project mlab-oti
   gcloud deploy queue.yaml
+
 
 Task queues may be observed in cloud console.
 

--- a/appengine/sandbox-queue.yaml
+++ b/appengine/sandbox-queue.yaml
@@ -5,8 +5,7 @@ queue:
   target: etl-ndt-parser
   # Average rate at which to release tasks to the service.  Default is 5/sec
   # This is actually the rate at which tokens are added to the bucket.
-  # 1.0 allow processing a day's data (about 11K tasks) in 3 to 4 hours.
-  rate: 1.0/s
+  rate: 0.2/s
   # Number of tokens that can accumulate in the bucket.  Default is 5.  This should
   # have very little impact for our environment.
   bucket_size: 10


### PR DESCRIPTION
Adjusting ndt queue rate so that there is a trickle all day.  This will facilitate annotation service development.

Also adjusting PT queue rate to avoid bigquery insert quota problems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/194)
<!-- Reviewable:end -->
