### PR TITLE
Add max file size, and clean up error handling

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -107,7 +107,7 @@ func (rr *ETLSource) nextData(h *tar.Header, trial int) ([]byte, bool, error) {
 
 // Next reads the next test object from the tar file.
 // Returns io.EOF when there are no more tests.
-func (rr *ETLSource) NextTest() (string, []byte, error) {
+func (rr *ETLSource) NextTest(maxSize int64) (string, []byte, error) {
 	metrics.WorkerState.WithLabelValues("read").Inc()
 	defer metrics.WorkerState.WithLabelValues("read").Dec()
 
@@ -136,28 +136,33 @@ func (rr *ETLSource) NextTest() (string, []byte, error) {
 		time.Sleep(delay)
 	}
 
-	// Only process regular files.
-	if h.Typeflag == tar.TypeReg {
-		trial = 0
-		delay = 16 * time.Millisecond
-		for {
-			trial++
-			var retry bool
-			data, retry, err = rr.nextData(h, trial)
-			if err == nil {
-				break
-			}
-			if !retry || trial >= 10 {
-				// FYI, it appears that stream errors start in the
-				// nextData phase of reading, but then persist on
-				// the next call to nextHeader.
-				break
-			}
-			// For each trial, increase backoff delay by 2x.
-			delay *= 2
-			time.Sleep(delay)
+	if h.Size > maxSize {
+		return h.Name, data, errors.New("Oversize file")
+	}
 
+	// Only process regular files.
+	if h.Typeflag != tar.TypeReg {
+		return h.Name, data, nil
+	}
+
+	trial = 0
+	delay = 16 * time.Millisecond
+	for {
+		trial++
+		var retry bool
+		data, retry, err = rr.nextData(h, trial)
+		if err == nil {
+			break
 		}
+		if !retry || trial >= 10 {
+			// FYI, it appears that stream errors start in the
+			// nextData phase of reading, but then persist on
+			// the next call to nextHeader.
+			break
+		}
+		// For each trial, increase backoff delay by 2x.
+		delay *= 2
+		time.Sleep(delay)
 	}
 
 	return h.Name, data, nil

--- a/task/task.go
+++ b/task/task.go
@@ -17,9 +17,10 @@ import (
 	"github.com/m-lab/etl/storage"
 )
 
-// Impose 200MB max size for a single file.  Larger than this risks an OOM if there are
+// Impose 200MiB max size for a single file.  Larger than this risks an OOM if there are
 // multiple large files at on multiple tasks.
-const MAX_FILE_SIZE = 200000000
+// This can be overridden with SetMaxFileSize()
+const MAX_FILE_SIZE = 20 * 1024 * 1024
 
 // TODO(dev) Add unit tests for meta data.
 type Task struct {
@@ -28,7 +29,8 @@ type Task struct {
 	*storage.ETLSource // Source from which to read tests.
 	etl.Parser         // Parser to parse the tests.
 
-	meta map[string]bigquery.Value // Metadata about this task.
+	meta        map[string]bigquery.Value // Metadata about this task.
+	maxFileSize int64  // Max file size to avoid OOM.
 }
 
 // NewTask constructs a task, injecting the source and the parser.
@@ -38,8 +40,12 @@ func NewTask(filename string, src *storage.ETLSource, prsr etl.Parser) *Task {
 	meta["filename"] = filename
 	meta["parse_time"] = time.Now()
 	meta["attempt"] = 1
-	t := Task{src, prsr, meta}
+	t := Task{src, prsr, meta, MAX_FILE_SIZE}
 	return &t
+}
+
+func (tt *Task) SetMaxFileSize(max int64) {
+	tt.maxFileSize = max
 }
 
 // ProcessAllTests loops through all the tests in a tar file, calls the
@@ -55,27 +61,40 @@ func (tt *Task) ProcessAllTests() (int, error) {
 	var err error
 	// Read each file from the tar
 
-	for testname, data, err = tt.NextTest(MAX_FILE_SIZE); err != io.EOF; testname, data, err = tt.NextTest(MAX_FILE_SIZE) {
+	for testname, data, err = tt.NextTest(tt.maxFileSize); err != io.EOF; testname, data, err = tt.NextTest(tt.maxFileSize) {
 		files++
 		if err != nil {
-			if err == io.EOF {
+			switch {
+			case err == io.EOF:
+				break
+			case err == storage.OVERSIZE_FILE:
+				log.Printf("filename:%s testname:%s files:%d, duration:%v err:%v",
+					tt.meta["filename"], testname, files,
+					time.Since(tt.meta["parse_time"].(time.Time)), err)
+				metrics.TestCount.WithLabelValues(
+					tt.Parser.TableName(), "unknown", "oversize file").Inc()
+				continue
+			default:
+				// We are seeing several of these per hour, a little more than
+				// one in one thousand files.  duration varies from 10 seconds
+				// up to several minutes.
+				// Example:
+				// filename:
+				// gs://m-lab-sandbox/ndt/2016/04/10/20160410T000000Z-mlab1-ord02-ndt-0002.tgz
+				// files:666 duration:1m47.571825351s
+				// err:stream error: stream ID 801; INTERNAL_ERROR
+				// Because of the break, this error is passed up, and counted at
+				// the Task level.
+				log.Printf("filename:%s testname:%s files:%d, duration:%v err:%v",
+					tt.meta["filename"], testname, files,
+					time.Since(tt.meta["parse_time"].(time.Time)), err)
+
+				metrics.TestCount.WithLabelValues(
+					tt.Parser.TableName(), "unknown", "unrecovered").Inc()
+				// Since we don't understand these errors, safest thing to do is
+				// stop processing the tar file (and task).
 				break
 			}
-			// We are seeing several of these per hour, a little more than
-			// one in one thousand files.  duration varies from 10 seconds up to several
-			// minutes.
-			// Example:
-			// filename:gs://m-lab-sandbox/ndt/2016/04/10/20160410T000000Z-mlab1-ord02-ndt-0002.tgz
-			// files:666 duration:1m47.571825351s
-			// err:stream error: stream ID 801; INTERNAL_ERROR
-			// Because of the break, this error is passed up, and counted at the Task level.
-			log.Printf("filename:%s testname:%s files:%d, duration:%v err:%v",
-				tt.meta["filename"], testname, files,
-				time.Since(tt.meta["parse_time"].(time.Time)), err)
-
-			metrics.TestCount.WithLabelValues(
-				tt.Parser.TableName(), "unknown", "unrecovered").Inc()
-			break
 		}
 		if data == nil {
 			// TODO(dev) Handle directories (expected) and other

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -84,7 +84,7 @@ func TestTarFileInput(t *testing.T) {
 
 	// Among other things, this requires that tp implements etl.Parser.
 	tt := task.NewTask("filename", rdr, tp)
-	fn, bb, err := tt.NextTest()
+	fn, bb, err := tt.NextTest(1000)
 	if err != nil {
 		t.Error(err)
 	}
@@ -95,7 +95,7 @@ func TestTarFileInput(t *testing.T) {
 		t.Error("Expected biscuits but got ", string(bb))
 	}
 
-	fn, bb, err = tt.NextTest()
+	fn, bb, err = tt.NextTest(1000)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
We occasionally see a 2 GB single test file.  This causes OOM, which causes reprocessing of any tasks partially completed by other workers.
Also, since the task was not successful, the task queue keeps resubmitting it, causing additional OOMs.

This PR restricts the max single test size to 200MB, (200 times the nominal test size).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/195)
<!-- Reviewable:end -->
