### PR TITLE
Extracting geo code to separate package.

### DIFF
--- a/annotation/geo_structs.go
+++ b/annotation/geo_structs.go
@@ -1,4 +1,4 @@
-package geo
+package annotation
 
 // TODO - merge this into annotation.go
 

--- a/geo/annotation_structs.go
+++ b/geo/annotation_structs.go
@@ -1,4 +1,6 @@
-package schema
+package geo
+
+// TODO - merge this into annotation.go
 
 import "time"
 

--- a/parser/metadata.go
+++ b/parser/metadata.go
@@ -16,7 +16,7 @@ import (
 
 	"cloud.google.com/go/bigquery"
 
-	"github.com/m-lab/etl/geo"
+	"github.com/m-lab/etl/annotation"
 	"github.com/m-lab/etl/metrics"
 	"github.com/m-lab/etl/schema"
 	"github.com/prometheus/client_golang/prometheus"
@@ -60,15 +60,15 @@ var BatchURL = AnnotatorURL + "/batch_annotate"
 // same length. It will then make a call to the batch annotator, using
 // the ip addresses and the timestamp. Then, it uses that data to fill
 // in the structs pointed to by the slice of GeolocationIP pointers.
-func FetchGeoAnnotations(ips []string, timestamp time.Time, geoDest []*geo.GeolocationIP) {
-	reqData := make([]geo.RequestData, 0, len(ips))
+func FetchGeoAnnotations(ips []string, timestamp time.Time, geoDest []*annotation.GeolocationIP) {
+	reqData := make([]annotation.RequestData, 0, len(ips))
 	for _, ip := range ips {
 		if ip == "" {
 			metrics.AnnotationErrorCount.With(prometheus.
 				Labels{"source": "Empty IP Address!!!"}).Inc()
 			continue
 		}
-		reqData = append(reqData, geo.RequestData{ip, 0, timestamp})
+		reqData = append(reqData, annotation.RequestData{ip, 0, timestamp})
 	}
 	annotationData := GetBatchMetaData(BatchURL, reqData)
 	timeString := strconv.FormatInt(timestamp.Unix(), 36)
@@ -103,7 +103,7 @@ func AddMetaDataSSConnSpec(spec *schema.Web100ConnectionSpecification, timestamp
 	}(timerStart)
 
 	ipSlice := []string{spec.Local_ip, spec.Remote_ip}
-	geoSlice := []*geo.GeolocationIP{&spec.Local_geolocation, &spec.Remote_geolocation}
+	geoSlice := []*annotation.GeolocationIP{&spec.Local_geolocation, &spec.Remote_geolocation}
 	FetchGeoAnnotations(ipSlice, timestamp, geoSlice)
 }
 
@@ -125,7 +125,7 @@ func AddMetaDataPTConnSpec(spec *schema.MLabConnectionSpecification, timestamp t
 			Observe(float64(time.Since(tStart).Nanoseconds()))
 	}(timerStart)
 	ipSlice := []string{spec.Server_ip, spec.Client_ip}
-	geoSlice := []*geo.GeolocationIP{&spec.Server_geolocation, &spec.Client_geolocation}
+	geoSlice := []*annotation.GeolocationIP{&spec.Server_geolocation, &spec.Client_geolocation}
 	FetchGeoAnnotations(ipSlice, timestamp, geoSlice)
 }
 
@@ -148,7 +148,7 @@ func AddMetaDataPTHopBatch(hops []*schema.ParisTracerouteHop, timestamp time.Tim
 // AnnotatePTHops takes a slice of hop pointers, the annotation data
 // mapping ip addresses to metadata and a timestamp. It will then use
 // these to attach the appropriate metadata to the PT hops.
-func AnnotatePTHops(hops []*schema.ParisTracerouteHop, annotationData map[string]geo.MetaData, timestamp time.Time) {
+func AnnotatePTHops(hops []*schema.ParisTracerouteHop, annotationData map[string]annotation.MetaData, timestamp time.Time) {
 	if annotationData == nil {
 		return
 	}
@@ -178,8 +178,8 @@ func AnnotatePTHops(hops []*schema.ParisTracerouteHop, annotationData map[string
 // and the associate timestamp. From those, it will create a slice of
 // requests to send to the annotation service, removing duplicates
 // along the way.
-func CreateRequestDataFromPTHops(hops []*schema.ParisTracerouteHop, timestamp time.Time) []geo.RequestData {
-	hopMap := map[string]geo.RequestData{}
+func CreateRequestDataFromPTHops(hops []*schema.ParisTracerouteHop, timestamp time.Time) []annotation.RequestData {
+	hopMap := map[string]annotation.RequestData{}
 	for _, hop := range hops {
 		if hop == nil {
 			metrics.AnnotationErrorCount.With(prometheus.
@@ -187,21 +187,21 @@ func CreateRequestDataFromPTHops(hops []*schema.ParisTracerouteHop, timestamp ti
 			continue
 		}
 		if hop.Src_ip != "" {
-			hopMap[hop.Src_ip] = geo.RequestData{hop.Src_ip, 0, timestamp}
+			hopMap[hop.Src_ip] = annotation.RequestData{hop.Src_ip, 0, timestamp}
 		} else {
 			metrics.AnnotationErrorCount.With(prometheus.
 				Labels{"source": "PT Hop was missing an IP!!!"}).Inc()
 		}
 
 		if hop.Dest_ip != "" {
-			hopMap[hop.Dest_ip] = geo.RequestData{hop.Dest_ip, 0, timestamp}
+			hopMap[hop.Dest_ip] = annotation.RequestData{hop.Dest_ip, 0, timestamp}
 		} else {
 			metrics.AnnotationErrorCount.With(prometheus.
 				Labels{"source": "PT Hop was missing an IP!!!"}).Inc()
 		}
 	}
 
-	requestSlice := make([]geo.RequestData, 0, len(hopMap))
+	requestSlice := make([]annotation.RequestData, 0, len(hopMap))
 	for _, req := range hopMap {
 		requestSlice = append(requestSlice, req)
 	}
@@ -243,7 +243,7 @@ func AddMetaDataPTHop(hop *schema.ParisTracerouteHop, timestamp time.Time) {
 // timestamp. It will connect to the annotation service, get the
 // metadata, and insert the metadata into the reigion pointed to by
 // the schema.GeolocationIP pointer.
-func GetAndInsertGeolocationIPStruct(geo *geo.GeolocationIP, ip string, timestamp time.Time) {
+func GetAndInsertGeolocationIPStruct(geo *annotation.GeolocationIP, ip string, timestamp time.Time) {
 	url := BaseURL + "ip_addr=" + url.QueryEscape(ip) +
 		"&since_epoch=" + strconv.FormatInt(timestamp.Unix(), 10)
 	annotationData := GetMetaData(url)
@@ -326,7 +326,7 @@ func CopyStructToMap(sourceStruct interface{}, destinationMap map[string]bigquer
 // ParseJSONMetaDataResponse to query the annotator service and return
 // the corresponding MetaData if it can, or a nil pointer if it
 // encounters any error and cannot get the data for any reason
-func GetMetaData(url string) *geo.MetaData {
+func GetMetaData(url string) *annotation.MetaData {
 	// Query the service and grab the response safely
 	annotatorResponse, err := QueryAnnotationService(url)
 	if err != nil {
@@ -377,8 +377,8 @@ func QueryAnnotationService(url string) ([]byte, error) {
 // the JSON from the annotator service and parses it into a MetaData
 // struct, for easy manipulation. It returns a pointer to the struct on
 // success and an error if an error occurs.
-func ParseJSONMetaDataResponse(jsonBuffer []byte) (*geo.MetaData, error) {
-	parsedJSON := &geo.MetaData{}
+func ParseJSONMetaDataResponse(jsonBuffer []byte) (*annotation.MetaData, error) {
+	parsedJSON := &annotation.MetaData{}
 	err := json.Unmarshal(jsonBuffer, parsedJSON)
 	if err != nil {
 		return nil, err
@@ -393,15 +393,15 @@ func GetAndInsertTwoSidedMetaIntoNDTConnSpec(spec schema.Web100ValueMap, timesta
 	// TODO(JM): Make metrics for sok and cok failures. And double check metrics for cleanliness.
 	cip, cok := spec.GetString([]string{"client_ip"})
 	sip, sok := spec.GetString([]string{"server_ip"})
-	reqData := []geo.RequestData{}
+	reqData := []annotation.RequestData{}
 	if cok {
-		reqData = append(reqData, geo.RequestData{IP: cip, Timestamp: timestamp})
+		reqData = append(reqData, annotation.RequestData{IP: cip, Timestamp: timestamp})
 	} else {
 		metrics.AnnotationErrorCount.With(prometheus.
 			Labels{"source": "Missing client side IP."}).Inc()
 	}
 	if sok {
-		reqData = append(reqData, geo.RequestData{IP: sip, Timestamp: timestamp})
+		reqData = append(reqData, annotation.RequestData{IP: sip, Timestamp: timestamp})
 	} else {
 		metrics.AnnotationErrorCount.With(prometheus.
 			Labels{"source": "Missing server side IP."}).Inc()
@@ -438,7 +438,7 @@ func GetAndInsertTwoSidedMetaIntoNDTConnSpec(spec schema.Web100ValueMap, timesta
 // query the annotator service and return the corresponding map of
 // ip-timestamp strings to schema.MetaData structs, or a nil map if it
 // encounters any error and cannot get the data for any reason
-func GetBatchMetaData(url string, data []geo.RequestData) map[string]geo.MetaData {
+func GetBatchMetaData(url string, data []annotation.RequestData) map[string]annotation.MetaData {
 	// Query the service and grab the response safely
 	annotatorResponse, err := BatchQueryAnnotationService(url, data)
 	if err != nil {
@@ -463,7 +463,7 @@ func GetBatchMetaData(url string, data []geo.RequestData) map[string]geo.MetaDat
 // a slice of schema.RequestDatas to be sent in the body in a JSON
 // format. It will copy the response into a []byte and return it to
 // the user, returning an error if any occurs
-func BatchQueryAnnotationService(url string, data []geo.RequestData) ([]byte, error) {
+func BatchQueryAnnotationService(url string, data []annotation.RequestData) ([]byte, error) {
 	encodedData, err := json.Marshal(data)
 	if err != nil {
 		metrics.AnnotationErrorCount.
@@ -494,11 +494,11 @@ func BatchQueryAnnotationService(url string, data []geo.RequestData) ([]byte, er
 
 // BatchParseJSONMetaDataResponse takes a byte slice containing the
 // text of the JSON from the annoator service's batch request endpoint
-// and parses it into a map of strings to geo.MetaData structs, for
+// and parses it into a map of strings to annotation.MetaData structs, for
 // easy manipulation. It returns a pointer to the struct on success
 // and an error if one occurs.
-func BatchParseJSONMetaDataResponse(jsonBuffer []byte) (map[string]geo.MetaData, error) {
-	parsedJSON := make(map[string]geo.MetaData)
+func BatchParseJSONMetaDataResponse(jsonBuffer []byte) (map[string]annotation.MetaData, error) {
+	parsedJSON := make(map[string]annotation.MetaData)
 	err := json.Unmarshal(jsonBuffer, &parsedJSON)
 	if err != nil {
 		return nil, err

--- a/parser/metadata.go
+++ b/parser/metadata.go
@@ -239,10 +239,10 @@ func AddMetaDataPTHop(hop *schema.ParisTracerouteHop, timestamp time.Time) {
 }
 
 // GetAndInsertGeolocationIPStruct takes a NON-NIL pointer to a
-// pre-allocated schema.GeolocationIP struct, an IP address, and a
+// pre-allocated annotation.GeolocationIP struct, an IP address, and a
 // timestamp. It will connect to the annotation service, get the
 // metadata, and insert the metadata into the reigion pointed to by
-// the schema.GeolocationIP pointer.
+// the annotation.GeolocationIP pointer.
 func GetAndInsertGeolocationIPStruct(geo *annotation.GeolocationIP, ip string, timestamp time.Time) {
 	url := BaseURL + "ip_addr=" + url.QueryEscape(ip) +
 		"&since_epoch=" + strconv.FormatInt(timestamp.Unix(), 10)
@@ -436,7 +436,7 @@ func GetAndInsertTwoSidedMetaIntoNDTConnSpec(spec schema.Web100ValueMap, timesta
 // GetBatchMetaData combines the functionality of
 // BatchQueryAnnotationService and BatchParseJSONMetaDataResponse to
 // query the annotator service and return the corresponding map of
-// ip-timestamp strings to schema.MetaData structs, or a nil map if it
+// ip-timestamp strings to annotation.MetaData structs, or a nil map if it
 // encounters any error and cannot get the data for any reason
 func GetBatchMetaData(url string, data []annotation.RequestData) map[string]annotation.MetaData {
 	// Query the service and grab the response safely
@@ -460,7 +460,7 @@ func GetBatchMetaData(url string, data []annotation.RequestData) map[string]anno
 }
 
 // BatchQueryAnnotationService takes a url to POST the request to and
-// a slice of schema.RequestDatas to be sent in the body in a JSON
+// a slice of annotation.RequestDatas to be sent in the body in a JSON
 // format. It will copy the response into a []byte and return it to
 // the user, returning an error if any occurs
 func BatchQueryAnnotationService(url string, data []annotation.RequestData) ([]byte, error) {

--- a/parser/metadata_test.go
+++ b/parser/metadata_test.go
@@ -13,6 +13,7 @@ import (
 
 	"cloud.google.com/go/bigquery"
 
+	"github.com/m-lab/etl/geo"
 	p "github.com/m-lab/etl/parser"
 	"github.com/m-lab/etl/schema"
 )
@@ -23,27 +24,27 @@ func TestFetchGeoAnnotations(t *testing.T) {
 	tests := []struct {
 		ips       []string
 		timestamp time.Time
-		geoDest   []*schema.GeolocationIP
-		res       []*schema.GeolocationIP
+		geoDest   []*geo.GeolocationIP
+		res       []*geo.GeolocationIP
 	}{
 		{
 			ips:       []string{},
 			timestamp: epoch,
-			geoDest:   []*schema.GeolocationIP{},
-			res:       []*schema.GeolocationIP{},
+			geoDest:   []*geo.GeolocationIP{},
+			res:       []*geo.GeolocationIP{},
 		},
 		{
 			ips:       []string{"", "127.0.0.1", "2.2.2.2"},
 			timestamp: epoch,
-			geoDest: []*schema.GeolocationIP{
-				&schema.GeolocationIP{},
-				&schema.GeolocationIP{},
-				&schema.GeolocationIP{},
+			geoDest: []*geo.GeolocationIP{
+				&geo.GeolocationIP{},
+				&geo.GeolocationIP{},
+				&geo.GeolocationIP{},
 			},
-			res: []*schema.GeolocationIP{
-				&schema.GeolocationIP{},
-				&schema.GeolocationIP{Postal_code: "10583"},
-				&schema.GeolocationIP{},
+			res: []*geo.GeolocationIP{
+				&geo.GeolocationIP{},
+				&geo.GeolocationIP{Postal_code: "10583"},
+				&geo.GeolocationIP{},
 			},
 		},
 	}
@@ -79,7 +80,7 @@ func TestAddMetaDataSSConnSpec(t *testing.T) {
 			url:       "/src",
 			res: schema.Web100ConnectionSpecification{
 				Local_ip:          "127.0.0.1",
-				Local_geolocation: schema.GeolocationIP{Postal_code: "10583"},
+				Local_geolocation: geo.GeolocationIP{Postal_code: "10583"},
 			},
 		},
 		{
@@ -88,7 +89,7 @@ func TestAddMetaDataSSConnSpec(t *testing.T) {
 			url:       "/dest",
 			res: schema.Web100ConnectionSpecification{
 				Remote_ip:          "127.0.0.1",
-				Remote_geolocation: schema.GeolocationIP{Postal_code: "10583"},
+				Remote_geolocation: geo.GeolocationIP{Postal_code: "10583"},
 			},
 		},
 		{
@@ -97,9 +98,9 @@ func TestAddMetaDataSSConnSpec(t *testing.T) {
 			url:       "/both",
 			res: schema.Web100ConnectionSpecification{
 				Local_ip:           "127.0.0.1",
-				Local_geolocation:  schema.GeolocationIP{Postal_code: "10583"},
+				Local_geolocation:  geo.GeolocationIP{Postal_code: "10583"},
 				Remote_ip:          "127.0.0.2",
-				Remote_geolocation: schema.GeolocationIP{Postal_code: "10584"},
+				Remote_geolocation: geo.GeolocationIP{Postal_code: "10584"},
 			},
 		},
 	}
@@ -135,7 +136,7 @@ func TestAddMetaDataPTConnSpec(t *testing.T) {
 			url:       "/src",
 			res: schema.MLabConnectionSpecification{
 				Server_ip:          "127.0.0.1",
-				Server_geolocation: schema.GeolocationIP{Postal_code: "10583"},
+				Server_geolocation: geo.GeolocationIP{Postal_code: "10583"},
 			},
 		},
 		{
@@ -144,7 +145,7 @@ func TestAddMetaDataPTConnSpec(t *testing.T) {
 			url:       "/dest",
 			res: schema.MLabConnectionSpecification{
 				Client_ip:          "127.0.0.1",
-				Client_geolocation: schema.GeolocationIP{Postal_code: "10583"},
+				Client_geolocation: geo.GeolocationIP{Postal_code: "10583"},
 			},
 		},
 		{
@@ -153,9 +154,9 @@ func TestAddMetaDataPTConnSpec(t *testing.T) {
 			url:       "/both",
 			res: schema.MLabConnectionSpecification{
 				Server_ip:          "127.0.0.1",
-				Server_geolocation: schema.GeolocationIP{Postal_code: "10583"},
+				Server_geolocation: geo.GeolocationIP{Postal_code: "10583"},
 				Client_ip:          "127.0.0.2",
-				Client_geolocation: schema.GeolocationIP{Postal_code: "10584"},
+				Client_geolocation: geo.GeolocationIP{Postal_code: "10584"},
 			},
 		},
 	}
@@ -191,9 +192,9 @@ func TestAddMetaDataPTHopBatch(t *testing.T) {
 			res: []*schema.ParisTracerouteHop{
 				&schema.ParisTracerouteHop{
 					Src_ip:           "127.0.0.1",
-					Src_geolocation:  schema.GeolocationIP{Area_code: 10583},
+					Src_geolocation:  geo.GeolocationIP{Area_code: 10583},
 					Dest_ip:          "1.0.0.127",
-					Dest_geolocation: schema.GeolocationIP{Area_code: 10584},
+					Dest_geolocation: geo.GeolocationIP{Area_code: 10584},
 				},
 			},
 		},
@@ -214,7 +215,7 @@ func TestAddMetaDataPTHopBatch(t *testing.T) {
 func TestAnnotatePTHops(t *testing.T) {
 	tests := []struct {
 		hops           []*schema.ParisTracerouteHop
-		annotationData map[string]schema.MetaData
+		annotationData map[string]geo.MetaData
 		timestamp      time.Time
 		res            []*schema.ParisTracerouteHop
 	}{
@@ -226,25 +227,25 @@ func TestAnnotatePTHops(t *testing.T) {
 		},
 		{
 			hops:           []*schema.ParisTracerouteHop{nil},
-			annotationData: map[string]schema.MetaData{},
+			annotationData: map[string]geo.MetaData{},
 			timestamp:      epoch,
 			res:            []*schema.ParisTracerouteHop{nil},
 		},
 		{
 			hops: []*schema.ParisTracerouteHop{&schema.ParisTracerouteHop{Src_ip: "127.0.0.1"}},
-			annotationData: map[string]schema.MetaData{"127.0.0.10": schema.MetaData{
-				Geo: &schema.GeolocationIP{}, ASN: nil}},
+			annotationData: map[string]geo.MetaData{"127.0.0.10": geo.MetaData{
+				Geo: &geo.GeolocationIP{}, ASN: nil}},
 			timestamp: epoch,
 			res: []*schema.ParisTracerouteHop{&schema.ParisTracerouteHop{Src_ip: "127.0.0.1",
-				Src_geolocation: schema.GeolocationIP{}}},
+				Src_geolocation: geo.GeolocationIP{}}},
 		},
 		{
 			hops: []*schema.ParisTracerouteHop{&schema.ParisTracerouteHop{Dest_ip: "1.0.0.127"}},
-			annotationData: map[string]schema.MetaData{"1.0.0.1270": schema.MetaData{
-				Geo: &schema.GeolocationIP{}, ASN: nil}},
+			annotationData: map[string]geo.MetaData{"1.0.0.1270": geo.MetaData{
+				Geo: &geo.GeolocationIP{}, ASN: nil}},
 			timestamp: epoch,
 			res: []*schema.ParisTracerouteHop{&schema.ParisTracerouteHop{Dest_ip: "1.0.0.127",
-				Dest_geolocation: schema.GeolocationIP{}}},
+				Dest_geolocation: geo.GeolocationIP{}}},
 		},
 	}
 	for _, test := range tests {
@@ -260,22 +261,22 @@ func TestCreateRequestDataFromPTHops(t *testing.T) {
 	tests := []struct {
 		hops      []*schema.ParisTracerouteHop
 		timestamp time.Time
-		res       []schema.RequestData
+		res       []geo.RequestData
 	}{
 		{
 			hops:      []*schema.ParisTracerouteHop{},
 			timestamp: epoch,
-			res:       []schema.RequestData{},
+			res:       []geo.RequestData{},
 		},
 		{
 			hops:      []*schema.ParisTracerouteHop{&schema.ParisTracerouteHop{Dest_ip: "1.0.0.127"}},
 			timestamp: epoch,
-			res:       []schema.RequestData{schema.RequestData{"1.0.0.127", 0, epoch}},
+			res:       []geo.RequestData{geo.RequestData{"1.0.0.127", 0, epoch}},
 		},
 		{
 			hops:      []*schema.ParisTracerouteHop{&schema.ParisTracerouteHop{Src_ip: "127.0.0.1"}},
 			timestamp: epoch,
-			res:       []schema.RequestData{schema.RequestData{"127.0.0.1", 0, epoch}},
+			res:       []geo.RequestData{geo.RequestData{"127.0.0.1", 0, epoch}},
 		},
 	}
 	for _, test := range tests {
@@ -305,7 +306,7 @@ func TestAddMetaDataPTHop(t *testing.T) {
 			url:       "/src",
 			res: schema.ParisTracerouteHop{
 				Src_ip:          "127.0.0.1",
-				Src_geolocation: schema.GeolocationIP{Postal_code: "10583"},
+				Src_geolocation: geo.GeolocationIP{Postal_code: "10583"},
 			},
 		},
 		{
@@ -314,7 +315,7 @@ func TestAddMetaDataPTHop(t *testing.T) {
 			url:       "/dest",
 			res: schema.ParisTracerouteHop{
 				Dest_ip:          "127.0.0.1",
-				Dest_geolocation: schema.GeolocationIP{Postal_code: "10583"},
+				Dest_geolocation: geo.GeolocationIP{Postal_code: "10583"},
 			},
 		},
 		{
@@ -323,9 +324,9 @@ func TestAddMetaDataPTHop(t *testing.T) {
 			url:       "/both",
 			res: schema.ParisTracerouteHop{
 				Src_ip:           "127.0.0.1",
-				Src_geolocation:  schema.GeolocationIP{Postal_code: "10583"},
+				Src_geolocation:  geo.GeolocationIP{Postal_code: "10583"},
 				Dest_ip:          "127.0.0.2",
-				Dest_geolocation: schema.GeolocationIP{Postal_code: "10583"},
+				Dest_geolocation: geo.GeolocationIP{Postal_code: "10583"},
 			},
 		},
 	}
@@ -343,24 +344,24 @@ func TestAddMetaDataPTHop(t *testing.T) {
 
 func TestGetAndInsertGeolocationIPStruct(t *testing.T) {
 	tests := []struct {
-		geo       *schema.GeolocationIP
+		geo       *geo.GeolocationIP
 		ip        string
 		timestamp time.Time
 		url       string
-		res       *schema.GeolocationIP
+		res       *geo.GeolocationIP
 	}{
 		{
-			geo:       &schema.GeolocationIP{},
+			geo:       &geo.GeolocationIP{},
 			ip:        "123.123.123.001",
 			timestamp: time.Now(),
 			url:       "portGarbage",
-			res:       &schema.GeolocationIP{},
+			res:       &geo.GeolocationIP{},
 		},
 		{
-			geo: &schema.GeolocationIP{},
+			geo: &geo.GeolocationIP{},
 			ip:  "127.0.0.1",
 			url: "/10583",
-			res: &schema.GeolocationIP{Postal_code: "10583"},
+			res: &geo.GeolocationIP{Postal_code: "10583"},
 		},
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -593,7 +594,7 @@ func TestCopyStructToMap(t *testing.T) {
 func TestGetMetaData(t *testing.T) {
 	tests := []struct {
 		url string
-		res *schema.MetaData
+		res *geo.MetaData
 	}{
 		{
 			url: "portGarbage",
@@ -605,7 +606,7 @@ func TestGetMetaData(t *testing.T) {
 		},
 		{
 			url: "/goodJson",
-			res: &schema.MetaData{},
+			res: &geo.MetaData{},
 		},
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -671,12 +672,12 @@ func TestQueryAnnotationService(t *testing.T) {
 func TestParseJSONMetaDataResponse(t *testing.T) {
 	tests := []struct {
 		testBuffer  []byte
-		resultData  *schema.MetaData
+		resultData  *geo.MetaData
 		resultError error
 	}{
 		{
 			testBuffer:  []byte(`{"Geo":null,"ASN":null}`),
-			resultData:  &schema.MetaData{Geo: nil, ASN: nil},
+			resultData:  &geo.MetaData{Geo: nil, ASN: nil},
 			resultError: nil,
 		},
 		{
@@ -763,7 +764,7 @@ func TestGetAndInsertTwoSidedMetaIntoNDTConnSpec(t *testing.T) {
 func TestGetBatchMetaData(t *testing.T) {
 	tests := []struct {
 		url string
-		res map[string]schema.MetaData
+		res map[string]geo.MetaData
 	}{
 		{
 			url: "portGarbage",
@@ -775,7 +776,7 @@ func TestGetBatchMetaData(t *testing.T) {
 		},
 		{
 			url: "/goodJson",
-			res: map[string]schema.MetaData{"127.0.0.1xyz": {Geo: nil, ASN: nil}},
+			res: map[string]geo.MetaData{"127.0.0.1xyz": {Geo: nil, ASN: nil}},
 		},
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -841,7 +842,7 @@ func TestBatchQueryAnnotationService(t *testing.T) {
 func TestBatchParseJSONMetaDataResponse(t *testing.T) {
 	tests := []struct {
 		testBuffer  []byte
-		resultData  map[string]schema.MetaData
+		resultData  map[string]geo.MetaData
 		resultError error
 	}{
 		{
@@ -849,7 +850,7 @@ func TestBatchParseJSONMetaDataResponse(t *testing.T) {
 			// addresses. The xyz could be a base36
 			// encoded timestamp.
 			testBuffer:  []byte(`{"127.0.0.1xyz": {"Geo":null,"ASN":null}}`),
-			resultData:  map[string]schema.MetaData{"127.0.0.1xyz": {Geo: nil, ASN: nil}},
+			resultData:  map[string]geo.MetaData{"127.0.0.1xyz": {Geo: nil, ASN: nil}},
 			resultError: nil,
 		},
 		{

--- a/parser/metadata_test.go
+++ b/parser/metadata_test.go
@@ -13,7 +13,7 @@ import (
 
 	"cloud.google.com/go/bigquery"
 
-	"github.com/m-lab/etl/geo"
+	"github.com/m-lab/etl/annotation"
 	p "github.com/m-lab/etl/parser"
 	"github.com/m-lab/etl/schema"
 )
@@ -24,27 +24,27 @@ func TestFetchGeoAnnotations(t *testing.T) {
 	tests := []struct {
 		ips       []string
 		timestamp time.Time
-		geoDest   []*geo.GeolocationIP
-		res       []*geo.GeolocationIP
+		geoDest   []*annotation.GeolocationIP
+		res       []*annotation.GeolocationIP
 	}{
 		{
 			ips:       []string{},
 			timestamp: epoch,
-			geoDest:   []*geo.GeolocationIP{},
-			res:       []*geo.GeolocationIP{},
+			geoDest:   []*annotation.GeolocationIP{},
+			res:       []*annotation.GeolocationIP{},
 		},
 		{
 			ips:       []string{"", "127.0.0.1", "2.2.2.2"},
 			timestamp: epoch,
-			geoDest: []*geo.GeolocationIP{
-				&geo.GeolocationIP{},
-				&geo.GeolocationIP{},
-				&geo.GeolocationIP{},
+			geoDest: []*annotation.GeolocationIP{
+				&annotation.GeolocationIP{},
+				&annotation.GeolocationIP{},
+				&annotation.GeolocationIP{},
 			},
-			res: []*geo.GeolocationIP{
-				&geo.GeolocationIP{},
-				&geo.GeolocationIP{Postal_code: "10583"},
-				&geo.GeolocationIP{},
+			res: []*annotation.GeolocationIP{
+				&annotation.GeolocationIP{},
+				&annotation.GeolocationIP{Postal_code: "10583"},
+				&annotation.GeolocationIP{},
 			},
 		},
 	}
@@ -80,7 +80,7 @@ func TestAddMetaDataSSConnSpec(t *testing.T) {
 			url:       "/src",
 			res: schema.Web100ConnectionSpecification{
 				Local_ip:          "127.0.0.1",
-				Local_geolocation: geo.GeolocationIP{Postal_code: "10583"},
+				Local_geolocation: annotation.GeolocationIP{Postal_code: "10583"},
 			},
 		},
 		{
@@ -89,7 +89,7 @@ func TestAddMetaDataSSConnSpec(t *testing.T) {
 			url:       "/dest",
 			res: schema.Web100ConnectionSpecification{
 				Remote_ip:          "127.0.0.1",
-				Remote_geolocation: geo.GeolocationIP{Postal_code: "10583"},
+				Remote_geolocation: annotation.GeolocationIP{Postal_code: "10583"},
 			},
 		},
 		{
@@ -98,9 +98,9 @@ func TestAddMetaDataSSConnSpec(t *testing.T) {
 			url:       "/both",
 			res: schema.Web100ConnectionSpecification{
 				Local_ip:           "127.0.0.1",
-				Local_geolocation:  geo.GeolocationIP{Postal_code: "10583"},
+				Local_geolocation:  annotation.GeolocationIP{Postal_code: "10583"},
 				Remote_ip:          "127.0.0.2",
-				Remote_geolocation: geo.GeolocationIP{Postal_code: "10584"},
+				Remote_geolocation: annotation.GeolocationIP{Postal_code: "10584"},
 			},
 		},
 	}
@@ -136,7 +136,7 @@ func TestAddMetaDataPTConnSpec(t *testing.T) {
 			url:       "/src",
 			res: schema.MLabConnectionSpecification{
 				Server_ip:          "127.0.0.1",
-				Server_geolocation: geo.GeolocationIP{Postal_code: "10583"},
+				Server_geolocation: annotation.GeolocationIP{Postal_code: "10583"},
 			},
 		},
 		{
@@ -145,7 +145,7 @@ func TestAddMetaDataPTConnSpec(t *testing.T) {
 			url:       "/dest",
 			res: schema.MLabConnectionSpecification{
 				Client_ip:          "127.0.0.1",
-				Client_geolocation: geo.GeolocationIP{Postal_code: "10583"},
+				Client_geolocation: annotation.GeolocationIP{Postal_code: "10583"},
 			},
 		},
 		{
@@ -154,9 +154,9 @@ func TestAddMetaDataPTConnSpec(t *testing.T) {
 			url:       "/both",
 			res: schema.MLabConnectionSpecification{
 				Server_ip:          "127.0.0.1",
-				Server_geolocation: geo.GeolocationIP{Postal_code: "10583"},
+				Server_geolocation: annotation.GeolocationIP{Postal_code: "10583"},
 				Client_ip:          "127.0.0.2",
-				Client_geolocation: geo.GeolocationIP{Postal_code: "10584"},
+				Client_geolocation: annotation.GeolocationIP{Postal_code: "10584"},
 			},
 		},
 	}
@@ -192,9 +192,9 @@ func TestAddMetaDataPTHopBatch(t *testing.T) {
 			res: []*schema.ParisTracerouteHop{
 				&schema.ParisTracerouteHop{
 					Src_ip:           "127.0.0.1",
-					Src_geolocation:  geo.GeolocationIP{Area_code: 10583},
+					Src_geolocation:  annotation.GeolocationIP{Area_code: 10583},
 					Dest_ip:          "1.0.0.127",
-					Dest_geolocation: geo.GeolocationIP{Area_code: 10584},
+					Dest_geolocation: annotation.GeolocationIP{Area_code: 10584},
 				},
 			},
 		},
@@ -215,7 +215,7 @@ func TestAddMetaDataPTHopBatch(t *testing.T) {
 func TestAnnotatePTHops(t *testing.T) {
 	tests := []struct {
 		hops           []*schema.ParisTracerouteHop
-		annotationData map[string]geo.MetaData
+		annotationData map[string]annotation.MetaData
 		timestamp      time.Time
 		res            []*schema.ParisTracerouteHop
 	}{
@@ -227,25 +227,25 @@ func TestAnnotatePTHops(t *testing.T) {
 		},
 		{
 			hops:           []*schema.ParisTracerouteHop{nil},
-			annotationData: map[string]geo.MetaData{},
+			annotationData: map[string]annotation.MetaData{},
 			timestamp:      epoch,
 			res:            []*schema.ParisTracerouteHop{nil},
 		},
 		{
 			hops: []*schema.ParisTracerouteHop{&schema.ParisTracerouteHop{Src_ip: "127.0.0.1"}},
-			annotationData: map[string]geo.MetaData{"127.0.0.10": geo.MetaData{
-				Geo: &geo.GeolocationIP{}, ASN: nil}},
+			annotationData: map[string]annotation.MetaData{"127.0.0.10": annotation.MetaData{
+				Geo: &annotation.GeolocationIP{}, ASN: nil}},
 			timestamp: epoch,
 			res: []*schema.ParisTracerouteHop{&schema.ParisTracerouteHop{Src_ip: "127.0.0.1",
-				Src_geolocation: geo.GeolocationIP{}}},
+				Src_geolocation: annotation.GeolocationIP{}}},
 		},
 		{
 			hops: []*schema.ParisTracerouteHop{&schema.ParisTracerouteHop{Dest_ip: "1.0.0.127"}},
-			annotationData: map[string]geo.MetaData{"1.0.0.1270": geo.MetaData{
-				Geo: &geo.GeolocationIP{}, ASN: nil}},
+			annotationData: map[string]annotation.MetaData{"1.0.0.1270": annotation.MetaData{
+				Geo: &annotation.GeolocationIP{}, ASN: nil}},
 			timestamp: epoch,
 			res: []*schema.ParisTracerouteHop{&schema.ParisTracerouteHop{Dest_ip: "1.0.0.127",
-				Dest_geolocation: geo.GeolocationIP{}}},
+				Dest_geolocation: annotation.GeolocationIP{}}},
 		},
 	}
 	for _, test := range tests {
@@ -261,22 +261,22 @@ func TestCreateRequestDataFromPTHops(t *testing.T) {
 	tests := []struct {
 		hops      []*schema.ParisTracerouteHop
 		timestamp time.Time
-		res       []geo.RequestData
+		res       []annotation.RequestData
 	}{
 		{
 			hops:      []*schema.ParisTracerouteHop{},
 			timestamp: epoch,
-			res:       []geo.RequestData{},
+			res:       []annotation.RequestData{},
 		},
 		{
 			hops:      []*schema.ParisTracerouteHop{&schema.ParisTracerouteHop{Dest_ip: "1.0.0.127"}},
 			timestamp: epoch,
-			res:       []geo.RequestData{geo.RequestData{"1.0.0.127", 0, epoch}},
+			res:       []annotation.RequestData{annotation.RequestData{"1.0.0.127", 0, epoch}},
 		},
 		{
 			hops:      []*schema.ParisTracerouteHop{&schema.ParisTracerouteHop{Src_ip: "127.0.0.1"}},
 			timestamp: epoch,
-			res:       []geo.RequestData{geo.RequestData{"127.0.0.1", 0, epoch}},
+			res:       []annotation.RequestData{annotation.RequestData{"127.0.0.1", 0, epoch}},
 		},
 	}
 	for _, test := range tests {
@@ -306,7 +306,7 @@ func TestAddMetaDataPTHop(t *testing.T) {
 			url:       "/src",
 			res: schema.ParisTracerouteHop{
 				Src_ip:          "127.0.0.1",
-				Src_geolocation: geo.GeolocationIP{Postal_code: "10583"},
+				Src_geolocation: annotation.GeolocationIP{Postal_code: "10583"},
 			},
 		},
 		{
@@ -315,7 +315,7 @@ func TestAddMetaDataPTHop(t *testing.T) {
 			url:       "/dest",
 			res: schema.ParisTracerouteHop{
 				Dest_ip:          "127.0.0.1",
-				Dest_geolocation: geo.GeolocationIP{Postal_code: "10583"},
+				Dest_geolocation: annotation.GeolocationIP{Postal_code: "10583"},
 			},
 		},
 		{
@@ -324,9 +324,9 @@ func TestAddMetaDataPTHop(t *testing.T) {
 			url:       "/both",
 			res: schema.ParisTracerouteHop{
 				Src_ip:           "127.0.0.1",
-				Src_geolocation:  geo.GeolocationIP{Postal_code: "10583"},
+				Src_geolocation:  annotation.GeolocationIP{Postal_code: "10583"},
 				Dest_ip:          "127.0.0.2",
-				Dest_geolocation: geo.GeolocationIP{Postal_code: "10583"},
+				Dest_geolocation: annotation.GeolocationIP{Postal_code: "10583"},
 			},
 		},
 	}
@@ -344,24 +344,24 @@ func TestAddMetaDataPTHop(t *testing.T) {
 
 func TestGetAndInsertGeolocationIPStruct(t *testing.T) {
 	tests := []struct {
-		geo       *geo.GeolocationIP
+		geo       *annotation.GeolocationIP
 		ip        string
 		timestamp time.Time
 		url       string
-		res       *geo.GeolocationIP
+		res       *annotation.GeolocationIP
 	}{
 		{
-			geo:       &geo.GeolocationIP{},
+			geo:       &annotation.GeolocationIP{},
 			ip:        "123.123.123.001",
 			timestamp: time.Now(),
 			url:       "portGarbage",
-			res:       &geo.GeolocationIP{},
+			res:       &annotation.GeolocationIP{},
 		},
 		{
-			geo: &geo.GeolocationIP{},
+			geo: &annotation.GeolocationIP{},
 			ip:  "127.0.0.1",
 			url: "/10583",
-			res: &geo.GeolocationIP{Postal_code: "10583"},
+			res: &annotation.GeolocationIP{Postal_code: "10583"},
 		},
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -594,7 +594,7 @@ func TestCopyStructToMap(t *testing.T) {
 func TestGetMetaData(t *testing.T) {
 	tests := []struct {
 		url string
-		res *geo.MetaData
+		res *annotation.MetaData
 	}{
 		{
 			url: "portGarbage",
@@ -606,7 +606,7 @@ func TestGetMetaData(t *testing.T) {
 		},
 		{
 			url: "/goodJson",
-			res: &geo.MetaData{},
+			res: &annotation.MetaData{},
 		},
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -672,12 +672,12 @@ func TestQueryAnnotationService(t *testing.T) {
 func TestParseJSONMetaDataResponse(t *testing.T) {
 	tests := []struct {
 		testBuffer  []byte
-		resultData  *geo.MetaData
+		resultData  *annotation.MetaData
 		resultError error
 	}{
 		{
 			testBuffer:  []byte(`{"Geo":null,"ASN":null}`),
-			resultData:  &geo.MetaData{Geo: nil, ASN: nil},
+			resultData:  &annotation.MetaData{Geo: nil, ASN: nil},
 			resultError: nil,
 		},
 		{
@@ -764,7 +764,7 @@ func TestGetAndInsertTwoSidedMetaIntoNDTConnSpec(t *testing.T) {
 func TestGetBatchMetaData(t *testing.T) {
 	tests := []struct {
 		url string
-		res map[string]geo.MetaData
+		res map[string]annotation.MetaData
 	}{
 		{
 			url: "portGarbage",
@@ -776,7 +776,7 @@ func TestGetBatchMetaData(t *testing.T) {
 		},
 		{
 			url: "/goodJson",
-			res: map[string]geo.MetaData{"127.0.0.1xyz": {Geo: nil, ASN: nil}},
+			res: map[string]annotation.MetaData{"127.0.0.1xyz": {Geo: nil, ASN: nil}},
 		},
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -842,7 +842,7 @@ func TestBatchQueryAnnotationService(t *testing.T) {
 func TestBatchParseJSONMetaDataResponse(t *testing.T) {
 	tests := []struct {
 		testBuffer  []byte
-		resultData  map[string]geo.MetaData
+		resultData  map[string]annotation.MetaData
 		resultError error
 	}{
 		{
@@ -850,7 +850,7 @@ func TestBatchParseJSONMetaDataResponse(t *testing.T) {
 			// addresses. The xyz could be a base36
 			// encoded timestamp.
 			testBuffer:  []byte(`{"127.0.0.1xyz": {"Geo":null,"ASN":null}}`),
-			resultData:  map[string]geo.MetaData{"127.0.0.1xyz": {Geo: nil, ASN: nil}},
+			resultData:  map[string]annotation.MetaData{"127.0.0.1xyz": {Geo: nil, ASN: nil}},
 			resultError: nil,
 		},
 		{

--- a/schema/pt_schema.go
+++ b/schema/pt_schema.go
@@ -1,29 +1,31 @@
 // This files contains schema for Paris TraceRoute tests.
 package schema
 
+import "github.com/m-lab/etl/geo"
+
 // TODO(dev): use mixed case Go variable names throughout
 
 type ParisTracerouteHop struct {
-	Protocol         string        `json:"protocal, string"`
-	Src_ip           string        `json:"src_ip, string"`
-	Src_af           int32         `json:"src_af, int32"`
-	Dest_ip          string        `json:"dest_ip, string"`
-	Dest_af          int32         `json:"dest_af, int32"`
-	Src_hostname     string        `json:"src_hostname, string"`
-	Dest_hostname    string        `json:"dest_hostname, string"`
-	Rtt              []float64     `json:"rtt, []float64"`
-	Src_geolocation  GeolocationIP `json:"src_geolocation"`
-	Dest_geolocation GeolocationIP `json:"dest_geolocation"`
+	Protocol         string            `json:"protocal, string"`
+	Src_ip           string            `json:"src_ip, string"`
+	Src_af           int32             `json:"src_af, int32"`
+	Dest_ip          string            `json:"dest_ip, string"`
+	Dest_af          int32             `json:"dest_af, int32"`
+	Src_hostname     string            `json:"src_hostname, string"`
+	Dest_hostname    string            `json:"dest_hostname, string"`
+	Rtt              []float64         `json:"rtt, []float64"`
+	Src_geolocation  geo.GeolocationIP `json:"src_geolocation"`
+	Dest_geolocation geo.GeolocationIP `json:"dest_geolocation"`
 }
 
 type MLabConnectionSpecification struct {
-	Server_ip          string        `json:"server_ip, string"`
-	Server_af          int32         `json:"server_af, int32"`
-	Client_ip          string        `json:"client_ip, string"`
-	Client_af          int32         `json:"client_af, int32"`
-	Data_direction     int32         `json:"data_direction, int32"`
-	Server_geolocation GeolocationIP `json:"server_geolocation"`
-	Client_geolocation GeolocationIP `json:"client_geolocation"`
+	Server_ip          string            `json:"server_ip, string"`
+	Server_af          int32             `json:"server_af, int32"`
+	Client_ip          string            `json:"client_ip, string"`
+	Client_af          int32             `json:"client_af, int32"`
+	Data_direction     int32             `json:"data_direction, int32"`
+	Server_geolocation geo.GeolocationIP `json:"server_geolocation"`
+	Client_geolocation geo.GeolocationIP `json:"client_geolocation"`
 }
 
 type PT struct {

--- a/schema/pt_schema.go
+++ b/schema/pt_schema.go
@@ -1,31 +1,31 @@
 // This files contains schema for Paris TraceRoute tests.
 package schema
 
-import "github.com/m-lab/etl/geo"
+import "github.com/m-lab/etl/annotation"
 
 // TODO(dev): use mixed case Go variable names throughout
 
 type ParisTracerouteHop struct {
-	Protocol         string            `json:"protocal, string"`
-	Src_ip           string            `json:"src_ip, string"`
-	Src_af           int32             `json:"src_af, int32"`
-	Dest_ip          string            `json:"dest_ip, string"`
-	Dest_af          int32             `json:"dest_af, int32"`
-	Src_hostname     string            `json:"src_hostname, string"`
-	Dest_hostname    string            `json:"dest_hostname, string"`
-	Rtt              []float64         `json:"rtt, []float64"`
-	Src_geolocation  geo.GeolocationIP `json:"src_geolocation"`
-	Dest_geolocation geo.GeolocationIP `json:"dest_geolocation"`
+	Protocol         string                   `json:"protocal, string"`
+	Src_ip           string                   `json:"src_ip, string"`
+	Src_af           int32                    `json:"src_af, int32"`
+	Dest_ip          string                   `json:"dest_ip, string"`
+	Dest_af          int32                    `json:"dest_af, int32"`
+	Src_hostname     string                   `json:"src_hostname, string"`
+	Dest_hostname    string                   `json:"dest_hostname, string"`
+	Rtt              []float64                `json:"rtt, []float64"`
+	Src_geolocation  annotation.GeolocationIP `json:"src_geolocation"`
+	Dest_geolocation annotation.GeolocationIP `json:"dest_geolocation"`
 }
 
 type MLabConnectionSpecification struct {
-	Server_ip          string            `json:"server_ip, string"`
-	Server_af          int32             `json:"server_af, int32"`
-	Client_ip          string            `json:"client_ip, string"`
-	Client_af          int32             `json:"client_af, int32"`
-	Data_direction     int32             `json:"data_direction, int32"`
-	Server_geolocation geo.GeolocationIP `json:"server_geolocation"`
-	Client_geolocation geo.GeolocationIP `json:"client_geolocation"`
+	Server_ip          string                   `json:"server_ip, string"`
+	Server_af          int32                    `json:"server_af, int32"`
+	Client_ip          string                   `json:"client_ip, string"`
+	Client_af          int32                    `json:"client_af, int32"`
+	Data_direction     int32                    `json:"data_direction, int32"`
+	Server_geolocation annotation.GeolocationIP `json:"server_geolocation"`
+	Client_geolocation annotation.GeolocationIP `json:"client_geolocation"`
 }
 
 type PT struct {

--- a/schema/ss_schema.go
+++ b/schema/ss_schema.go
@@ -2,14 +2,16 @@
 // Any changes here should also be made in ss.json
 package schema
 
+import "github.com/m-lab/etl/geo"
+
 type Web100ConnectionSpecification struct {
-	Local_ip           string        `json:"local_ip, string"`
-	Local_af           int64         `json:"local_af, int64"`
-	Local_port         int64         `json:"local_port, int64"`
-	Remote_ip          string        `json:"remote_ip, string"`
-	Remote_port        int64         `json:"remote_port, int64"`
-	Local_geolocation  GeolocationIP `json:"local_geolocation"`
-	Remote_geolocation GeolocationIP `json:"remote_geolocation"`
+	Local_ip           string            `json:"local_ip, string"`
+	Local_af           int64             `json:"local_af, int64"`
+	Local_port         int64             `json:"local_port, int64"`
+	Remote_ip          string            `json:"remote_ip, string"`
+	Remote_port        int64             `json:"remote_port, int64"`
+	Local_geolocation  geo.GeolocationIP `json:"local_geolocation"`
+	Remote_geolocation geo.GeolocationIP `json:"remote_geolocation"`
 }
 
 type Web100Snap struct {

--- a/schema/ss_schema.go
+++ b/schema/ss_schema.go
@@ -2,16 +2,16 @@
 // Any changes here should also be made in ss.json
 package schema
 
-import "github.com/m-lab/etl/geo"
+import "github.com/m-lab/etl/annotation"
 
 type Web100ConnectionSpecification struct {
-	Local_ip           string            `json:"local_ip, string"`
-	Local_af           int64             `json:"local_af, int64"`
-	Local_port         int64             `json:"local_port, int64"`
-	Remote_ip          string            `json:"remote_ip, string"`
-	Remote_port        int64             `json:"remote_port, int64"`
-	Local_geolocation  geo.GeolocationIP `json:"local_geolocation"`
-	Remote_geolocation geo.GeolocationIP `json:"remote_geolocation"`
+	Local_ip           string                   `json:"local_ip, string"`
+	Local_af           int64                    `json:"local_af, int64"`
+	Local_port         int64                    `json:"local_port, int64"`
+	Remote_ip          string                   `json:"remote_ip, string"`
+	Remote_port        int64                    `json:"remote_port, int64"`
+	Local_geolocation  annotation.GeolocationIP `json:"local_geolocation"`
+	Remote_geolocation annotation.GeolocationIP `json:"remote_geolocation"`
 }
 
 type Web100Snap struct {


### PR DESCRIPTION
The geo code is currently spread across the schema and parser directories, and each file mixes content that should be at different dependency levels.  This is currently avoid circular dependencies, but not in a clean way.

So, I am moving the geo specific code into a new package, eliminating the structs from the schema package.

Step 1...
  Moves the "schema" file to annotation/geo_structs.go and renames.
  Fix package prefix for references to structs.
  Add EnableAnnotation flags, which allows us to run this in sandbox but not propagate to prod
  until we are ready.

Step 2...
  Cut and paste geo specific code from parser package into annotator/geo.go and _test files.
  Fix package prefixes.

Step 3...
  Merge the geo_structs.go into geo.go.  (This is combined into a PR that also adds the 1 second timeout client)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/254)
<!-- Reviewable:end -->
