### PR TITLE
Increase timeout to 2 seconds

### DIFF
--- a/annotation/geo.go
+++ b/annotation/geo.go
@@ -237,7 +237,8 @@ func BatchQueryAnnotationService(url string, data []RequestData) ([]byte, error)
 	}
 
 	var netClient = &http.Client{
-		Timeout: time.Second,
+		// Median response time is < 10 msec, but 99th percentile is 0.6 seconds.
+		Timeout: 2 * time.Second,
 	}
 
 	// Make the actual request


### PR DESCRIPTION
The annotator 99th percentile response time is over 0.6 sec.  This results in about 0.05% of annotations failing.  Increasing timeout to 2 seconds should reduce the failures to a very small level.

We need to watch to ensure that this does not reduce cpu utilization too low when the annotator is offline.  I will test on sandbox before merging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/267)
<!-- Reviewable:end -->
