### PR TITLE
Add batch processing service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,11 +112,15 @@ deploy:
     tag: true
     condition: $TRAVIS_TAG == ndt-staging-*
 
-# PROD: Should be used AFTER code review and commit to master branch.  Triggers
-# when *ANY* branch is tagged with ndt-prod-*'
+# PROD: Should be used AFTER code review and commit to master branch.
+# Triggers when *ANY* branch is tagged with ndt-prod-*'
+# Deploys BOTH STREAMING AND BATCH services.
 - provider: script
-  script: $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
+  script:
+  - $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
     /tmp/mlab-oti.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt-prod.yaml
+  - $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
+    /tmp/mlab-oti.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt-batch.yaml
   skip_cleanup: true
   on:
     repo: m-lab/etl

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,7 +109,6 @@ deploy:
   on:
     repo: m-lab/etl
     all_branches: true
-    tag: true
     condition: $TRAVIS_TAG == ndt-staging-*
 
 # PROD: Should be used AFTER code review and commit to master branch.
@@ -117,15 +116,14 @@ deploy:
 # Deploys BOTH STREAMING AND BATCH services.
 - provider: script
   script:
-  - $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
-    /tmp/mlab-oti.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt-prod.yaml
-  - $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
+    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
+    /tmp/mlab-oti.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt-prod.yaml &&
+    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
     /tmp/mlab-oti.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt-batch.yaml
   skip_cleanup: true
   on:
     repo: m-lab/etl
     all_branches: true
-    tag: true
     condition: $TRAVIS_TAG == ndt-prod-*
 
 ######################################################################
@@ -155,9 +153,8 @@ deploy:
   on:
     repo: m-lab/etl
     all_branches: true
-    tag: true
     condition: $TRAVIS_TAG == ss-staging*
-    
+
 # PROD: Should be used AFTER code review and commit to master branch.  Triggers
 # when *ANY* branch is tagged with ss-prod-*'
 - provider: script
@@ -167,7 +164,6 @@ deploy:
   on:
     repo: m-lab/etl
     all_branches: true
-    tag: true
     condition: $TRAVIS_TAG == ss-prod-*
 
 ######################################################################
@@ -187,7 +183,7 @@ deploy:
     # Sandbox branches will be deployed to personalized service names.
     # Integration branch will not use decorated service names.
     condition: $TRAVIS_BRANCH == pt-sandbox-*
-    
+
 # STAGING: Should be used AFTER code review and commit to dev branch.  Triggers
 # when *ANY* branch is tagged with pt-staging-*'
 - provider: script
@@ -197,7 +193,6 @@ deploy:
   on:
     repo: m-lab/etl
     all_branches: true
-    tag: true
     condition: $TRAVIS_TAG == pt-staging-*
 
 # PROD: Should be used AFTER code review and commit to master branch.  Triggers
@@ -209,7 +204,6 @@ deploy:
   on:
     repo: m-lab/etl
     all_branches: true
-    tag: true
     condition: $TRAVIS_TAG == pt-prod*
 
 ######################################################################

--- a/README.md
+++ b/README.md
@@ -6,4 +6,7 @@
 
 MeasurementLab data ingestion pipeline.
 
+To create e.g., NDT table (should rarely be required!!!):
+bq mk --time_partitioning_type=DAY --schema=schema/repeated.json mlab-sandbox:mlab_sandbox.ndt
+
 Also see schema/README.md.

--- a/appengine/queue.yaml
+++ b/appengine/queue.yaml
@@ -13,6 +13,18 @@ queue:
   # Maximum number of concurrent requests.
   max_concurrent_requests: 360
 
+- name: etl-ndt-batch-queue
+  target: etl-ndt-batch-parser
+  # Average rate at which to release tasks to the service.  Default is 5/sec
+  # This is actually the rate at which tokens are added to the bucket.
+  # 1.0 allow processing a day's data (about 11K tasks) in 3 to 4 hours.
+  rate: 5.0/s
+  # Number of tokens that can accumulate in the bucket.  Default is 5.  This should
+  # have very little impact for our environment.
+  bucket_size: 10
+  # Maximum number of concurrent requests. 90% of max_workers * max instances
+  max_concurrent_requests: 900
+
 - name: etl-traceroute-queue
   target: etl-traceroute-parser
   # Average rate at which to release tasks to the service.  Default is 5/sec

--- a/cmd/etl_worker/app-ndt-batch.yaml
+++ b/cmd/etl_worker/app-ndt-batch.yaml
@@ -1,3 +1,6 @@
+# To deploy (from cmd/etl_worker):
+# go build etl_worker.go && gcloud beta app deploy --project=mlab-staging app-ndt-staging.yaml
+
 runtime: custom
 env: flex
 service: etl-ndt-parser
@@ -16,9 +19,12 @@ resources:
   disk_size_gb: 10
 
 automatic_scaling:
-  # We expect fairly steady load, so a modest minimum will rarely cost us anything.
-  min_num_instances: 2
-  max_num_instances: 20
+  # This is intended for batch jobs.  A single instance is required, and we allow
+  # it to scale up to 50 instances to get work done quickly.  However, note that
+  # more than 4 tasks/sec may result in bigquery stream quota problems, so this
+  # may require changes.
+  min_num_instances: 1
+  max_num_instances: 50
   # Very long cool down period, to reduce the likelihood of tasks being truncated.
   cool_down_period_sec: 1800
   # We don't care much about latency, so a high utilization is desireable.
@@ -38,7 +44,7 @@ network:
 
 env_variables:
   MAX_WORKERS: 20
-  BIGQUERY_PROJECT: 'mlab-sandbox'
-  BIGQUERY_DATASET: 'mlab_sandbox'
+  BIGQUERY_PROJECT: 'measurement-lab'
+  BIGQUERY_DATASET: 'batch'
   ANNOTATE_IP: 'true'
   # TODO add custom service-account, instead of using default credentials.

--- a/cmd/etl_worker/app-ndt-batch.yaml
+++ b/cmd/etl_worker/app-ndt-batch.yaml
@@ -1,9 +1,8 @@
-# To deploy (from cmd/etl_worker):
-# go build etl_worker.go && gcloud beta app deploy --project=mlab-staging app-ndt-staging.yaml
+# Use github release to trigger deployment.
 
 runtime: custom
 env: flex
-service: etl-ndt-parser
+service: etl-ndt-batch-parser
 
 # Resource and scaling options. For more background, see:
 #   https://cloud.google.com/appengine/docs/flexible/go/configuring-your-app-with-app-yaml

--- a/cmd/etl_worker/app-ndt-prod.yaml
+++ b/cmd/etl_worker/app-ndt-prod.yaml
@@ -1,3 +1,5 @@
+# Use github release to trigger deployment.
+
 runtime: custom
 env: flex
 service: etl-ndt-parser

--- a/cmd/etl_worker/app-ndt-staging.yaml
+++ b/cmd/etl_worker/app-ndt-staging.yaml
@@ -25,7 +25,8 @@ automatic_scaling:
   # may require changes.
   min_num_instances: 1
   max_num_instances: 50
-  cool_down_period_sec: 300
+  # Very long cool down period, to reduce the likelihood of tasks being truncated.
+  cool_down_period_sec: 1800
   # We don't care much about latency, so a high utilization is desireable.
   cpu_utilization:
     target_utilization: 0.85

--- a/cmd/etl_worker/app-ndt-staging.yaml
+++ b/cmd/etl_worker/app-ndt-staging.yaml
@@ -1,4 +1,6 @@
-# To deploy (from cmd/etl_worker):
+# Use github release to trigger deployment.
+#
+# To deploy from workstation cmd/etl_worker (discouraged!):
 # go build etl_worker.go && gcloud beta app deploy --project=mlab-staging app-ndt-staging.yaml
 
 runtime: custom
@@ -19,12 +21,9 @@ resources:
   disk_size_gb: 10
 
 automatic_scaling:
-  # This is intended for batch jobs.  A single instance is required, and we allow
-  # it to scale up to 50 instances to get work done quickly.  However, note that
-  # more than 1.5 tasks/sec may result in bigquery stream quota problems, so this
-  # may require changes.
-  min_num_instances: 1
-  max_num_instances: 50
+  # We expect fairly steady load, so a modest minimum will rarely cost us anything.
+  min_num_instances: 2
+  max_num_instances: 20
   # Very long cool down period, to reduce the likelihood of tasks being truncated.
   cool_down_period_sec: 1800
   # We don't care much about latency, so a high utilization is desireable.
@@ -43,7 +42,7 @@ network:
     - 9090/tcp
 
 env_variables:
-  MAX_WORKERS: 25
+  MAX_WORKERS: 20
   BIGQUERY_PROJECT: 'mlab-staging'
   BIGQUERY_DATASET: 'staging'
   ANNOTATE_IP: 'true'


### PR DESCRIPTION
This adds another production NDT config, with up to 50 instances, for large batch processing jobs.

NB: the && in the script.  Not sure if this is best way to do this.  Perhaps should have separate scripts, but triggered by the same tag??

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/272)
<!-- Reviewable:end -->
