### PR TITLE
Fail tasks with high row errors

### DIFF
--- a/bq/insert.go
+++ b/bq/insert.go
@@ -201,8 +201,6 @@ func (in *BQInserter) HandleInsertErrors(err error) error {
 		in.badRows += len(in.rows)
 		err = nil
 	}
-	// Allocate new slice of rows.  Any failed rows are lost.
-	in.rows = make([]interface{}, 0, in.params.BufferSize)
 	return err
 }
 
@@ -220,11 +218,12 @@ func (in *BQInserter) Flush() error {
 	err := in.uploader.Put(ctx, in.rows)
 	if err == nil {
 		in.inserted += len(in.rows)
-		in.rows = make([]interface{}, 0, in.params.BufferSize)
 	} else {
 		// This adjusts the inserted count, failure count, and updates in.rows.
 		err = in.HandleInsertErrors(err)
 	}
+	// Allocate new slice of rows.  Any failed rows are lost.
+	in.rows = make([]interface{}, 0, in.params.BufferSize)
 	return err
 }
 

--- a/etl/etl.go
+++ b/etl/etl.go
@@ -76,6 +76,9 @@ type Parser interface {
 	// including $YYYYMMNN, or _YYYYMMNN
 	FullTableName() string
 
+	// Task level error, based on failed rows, or any other criteria.
+	TaskError() error
+
 	RowStats // Parser must implement RowStats
 }
 

--- a/parser/disco.go
+++ b/parser/disco.go
@@ -52,6 +52,10 @@ func NewDiscoParser(ins etl.Inserter) etl.Parser {
 		RowStats: ins} // Delegate RowStats functions to the Inserter.
 }
 
+func (dp *DiscoParser) TaskError() error {
+	return nil
+}
+
 // Disco data a JSON representation that should be pushed directly into BigQuery.
 // For now, though, we parse into a struct, for compatibility with current inserter
 // backend.

--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -126,6 +126,12 @@ func NewNDTParser(ins etl.Inserter) *NDTParser {
 }
 
 // These functions are also required to complete the etl.Parser interface.
+func (n *NDTParser) TaskError() error {
+	if inserter.Committed() < 10 * inserter.Failed() {
+		return errors.New('Too many insertion failures.')
+	}
+	return nil
+}
 
 func (n *NDTParser) Flush() error {
 	// Process the last group (if it exists) before flushing the inserter.

--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -128,6 +128,8 @@ func NewNDTParser(ins etl.Inserter) *NDTParser {
 // These functions are also required to complete the etl.Parser interface.
 func (n *NDTParser) TaskError() error {
 	if n.inserter.Committed() < 10*n.inserter.Failed() {
+		log.Printf("Warning: high row insert errors: %d / %d\n",
+			n.inserter.Accepted(), n.inserter.Failed())
 		return errors.New("Too many insertion failures.")
 	}
 	return nil

--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -127,8 +127,8 @@ func NewNDTParser(ins etl.Inserter) *NDTParser {
 
 // These functions are also required to complete the etl.Parser interface.
 func (n *NDTParser) TaskError() error {
-	if inserter.Committed() < 10 * inserter.Failed() {
-		return errors.New('Too many insertion failures.')
+	if n.inserter.Committed() < 10*n.inserter.Failed() {
+		return errors.New("Too many insertion failures.")
 	}
 	return nil
 }

--- a/parser/ndt_test.go
+++ b/parser/ndt_test.go
@@ -139,6 +139,25 @@ func TestNDTParser(t *testing.T) {
 	}
 }
 
+func TestNDTTaskError(t *testing.T) {
+	// Load test data.
+	ins := newInMemoryInserter()
+	n := parser.NewNDTParser(ins)
+
+	if n.TaskError() != nil {
+		t.Error(n.TaskError())
+	}
+
+	ins.committed = 10
+	if n.TaskError() != nil {
+		t.Error(n.TaskError())
+	}
+	ins.failed = 2
+	if n.TaskError() == nil {
+		t.Error("Should have non-nil TaskError")
+	}
+}
+
 // compare recursively checks whether actual values equal values in the expected values.
 // The expected values may be a subset of the actual values, but not a superset.
 func compare(t *testing.T, actual schema.Web100ValueMap, expected schema.Web100ValueMap) bool {
@@ -201,11 +220,12 @@ func compare(t *testing.T, actual schema.Web100ValueMap, expected schema.Web100V
 type inMemoryInserter struct {
 	data      []interface{}
 	committed int
+	failed    int
 }
 
 func newInMemoryInserter() *inMemoryInserter {
 	data := make([]interface{}, 0)
-	return &inMemoryInserter{data, 0}
+	return &inMemoryInserter{data, 0, 0}
 }
 
 func (in *inMemoryInserter) InsertRow(data interface{}) error {
@@ -242,5 +262,5 @@ func (in *inMemoryInserter) Committed() int {
 	return in.committed
 }
 func (in *inMemoryInserter) Failed() int {
-	return 0
+	return in.failed
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -54,9 +54,11 @@ func (np *NullParser) ParseAndInsert(meta map[string]bigquery.Value, testName st
 	metrics.TestCount.WithLabelValues("table", "null", "ok").Inc()
 	return nil
 }
-
 func (np *NullParser) TableName() string {
 	return "null-table"
+}
+func (np *NullParser) TaskError() error {
+	return nil
 }
 
 //------------------------------------------------------------------------------------
@@ -94,4 +96,7 @@ func (tp *TestParser) TableName() string {
 }
 func (tp *TestParser) FullTableName() string {
 	return "test-table"
+}
+func (tp *TestParser) TaskError() error {
+	return nil
 }

--- a/parser/pt.go
+++ b/parser/pt.go
@@ -165,6 +165,10 @@ func GetLogtime(filename PTFileName) (time.Time, error) {
 	return t, nil
 }
 
+func (pt *PTParser) TaskError() error {
+	return nil
+}
+
 func (pt *PTParser) TableName() string {
 	return pt.inserter.TableBase()
 }

--- a/parser/ss.go
+++ b/parser/ss.go
@@ -3,7 +3,6 @@ package parser
 
 import (
 	"bytes"
-	"cloud.google.com/go/bigquery"
 	"errors"
 	"fmt"
 	"log"
@@ -12,6 +11,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"cloud.google.com/go/bigquery"
 
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/metrics"
@@ -74,6 +75,10 @@ func ParseKHeader(header string) ([]string, error) {
 		}
 	}
 	return var_names, nil
+}
+
+func (ss *SSParser) TaskError() error {
+	return nil
 }
 
 func (ss *SSParser) TableName() string {

--- a/task/task.go
+++ b/task/task.go
@@ -132,5 +132,10 @@ OUTER:
 	if err != io.EOF {
 		return files, err
 	}
+
+	// Check if the overall task is OK, or should be rejected.
+	if tt.Parser.TaskError() != nil {
+		return files, tt.Parser.TaskError()
+	}
 	return files, nil
 }

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -79,6 +79,9 @@ func (tp *TestParser) FullTableName() string {
 func (tp *TestParser) Flush() error {
 	return nil
 }
+func (tp *TestParser) TaskError() error {
+	return nil
+}
 
 // TODO - pass testName through to BQ inserter?
 func (tp *TestParser) ParseAndInsert(meta map[string]bigquery.Value, testName string, test []byte) error {


### PR DESCRIPTION
Issue #262

There are two cases where we see high row insert errors, but files are not reprocessed.
1.  table is missing and all inserts fail.
2.  insert quota is exceeded, and many inserts fail.

Adds a parser.TaskError check at end of task processing.  
Adds NDT TaskError implementation that fails if more than 10% of row adds failed.

This may result in more dups, if there are spurious errors in excess of 10%, e.g. when there are lots of quota errors.

This enables, but does not address, handling of similar problems in other parsers.  Will add issues to address those.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/274)
<!-- Reviewable:end -->
