### PR TITLE
Allow leading ./ in filenames

### DIFF
--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -39,7 +39,7 @@ const (
 //=========================================================================
 
 // TODO - should this be optional?
-const dateDir = `^(?P<dir>\d{4}/\d{2}/\d{2}/)?`
+const dateDir = `^(./)?(?P<dir>\d{4}/\d{2}/\d{2}/)?`
 
 // TODO - use time.Parse to parse this part of the filename.
 const dateField = `(?P<date>\d{8})`

--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -39,7 +39,7 @@ const (
 //=========================================================================
 
 // TODO - should this be optional?
-const dateDir = `^(./)?(?P<dir>\d{4}/\d{2}/\d{2}/)?`
+const dateDir = `(?:\./)?(?P<dir>\d{4}/\d{2}/\d{2}/)?`
 
 // TODO - use time.Parse to parse this part of the filename.
 const dateField = `(?P<date>\d{8})`

--- a/parser/ndt_test.go
+++ b/parser/ndt_test.go
@@ -17,6 +17,7 @@ import (
 // A handful of file names from a single ndt tar file.
 var testFileNames []string = []string{
 	`20170509T00:05:13.863119000Z_45.56.98.222.c2s_ndttrace`,
+	`20170509T00:05:13.863119000Z_45.56.98.222.c2s_ndttrace`,
 	`20170509T00:05:13.863119000Z_45.56.98.222.s2c_ndttrace`,
 	`20170509T00:05:13.863119000Z_eb.measurementlab.net:40074.s2c_snaplog`,
 	`20170509T00:05:13.863119000Z_eb.measurementlab.net:43628.c2s_snaplog`,
@@ -53,6 +54,10 @@ var testFileNames []string = []string{
 func TestValidation(t *testing.T) {
 	for _, test := range testFileNames {
 		_, err := parser.ParseNDTFileName("2017/05/09/" + test)
+		if err != nil {
+			t.Error(err)
+		}
+		_, err = parser.ParseNDTFileName("./2017/05/09/" + test)
 		if err != nil {
 			t.Error(err)
 		}


### PR DESCRIPTION
Continuous scraper now has leading ./ in filenames.  We will want to fix this,  but allowing it now for testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/290)
<!-- Reviewable:end -->
