### PR TITLE
Multiple batch queues

### DIFF
--- a/appengine/queue.yaml
+++ b/appengine/queue.yaml
@@ -46,7 +46,7 @@ queue:
 # of the very large older archives. But by limiting the rate based on
 # number of concurrent tasks, we can regulate the throughput independent
 # of the size of the archive files.  100 rows/second, divided by 1.3 rows/sec
-# per task, results in a target of roughly 60 concurrent tasks per archive date.
+# per task, results in a target of roughly 75 concurrent tasks per archive date.
 #
 # To reach the desired 350 rows/second required to process one month's
 # data each day, we need to process at least 4 days of data in parallel.
@@ -69,7 +69,7 @@ queue:
 # Some adjustments may be needed once this is running regularly.
 #
 # SUMMARY:
-# 1. Each queue must limit concurrent requests to about 60 to limit
+# 1. Each queue must limit concurrent requests to about 75 to limit
 #    rate into individual tables to around 100 rows/second.
 # 2. We have 5 queues, to allow up to about 500 rows/second, to
 #    allow 30 days of data to be processed within one day, with
@@ -78,27 +78,27 @@ queue:
   target: etl-ndt-batch-parser
   rate: 1.0/s
   bucket_size: 10
-  max_concurrent_requests: 60
+  max_concurrent_requests: 75
 - name: etl-ndt-batch_1
   target: etl-ndt-batch-parser
   rate: 1.0/s
   bucket_size: 10
-  max_concurrent_requests: 60
+  max_concurrent_requests: 75
 - name: etl-ndt-batch_2
   target: etl-ndt-batch-parser
   rate: 1.0/s
   bucket_size: 10
-  max_concurrent_requests: 60
+  max_concurrent_requests: 75
 - name: etl-ndt-batch_3
   target: etl-ndt-batch-parser
   rate: 1.0/s
   bucket_size: 10
-  max_concurrent_requests: 60
+  max_concurrent_requests: 75
 - name: etl-ndt-batch_4
   target: etl-ndt-batch-parser
   rate: 1.0/s
   bucket_size: 10
-  max_concurrent_requests: 60
+  max_concurrent_requests: 75
 
 - name: etl-traceroute-queue
   target: etl-traceroute-parser

--- a/appengine/queue.yaml
+++ b/appengine/queue.yaml
@@ -92,12 +92,3 @@ queue:
   # Maximum number of concurrent requests.
   max_concurrent_requests: 180
 
-
-###################################################################################
-- name: etl-pull-queue
-  mode: pull
-  acl:
-  # Provide full access to the taskqueue by the mlab-sandbox default GCE service account.
-  # This should apply to default GCE VMs and AppEngine Flex VMs.
-  - user_email: 581276032543-compute@developer.gserviceaccount.com
-  - writer_email: 581276032543-compute@developer.gserviceaccount.com

--- a/appengine/queue.yaml
+++ b/appengine/queue.yaml
@@ -14,20 +14,31 @@ queue:
   max_concurrent_requests: 360
 
 # BigQuery has a streaming insert quota per table, which we seem to hit
-# at around 3.0 tasks/second.  When reprocessing data older than 30 days,
-# the pipeline inserts rows into templated tables, which means there is
-# a separate table per day.
-# We create multiple queues, with modest rate limits on each queue, and
-# then partition batch jobs across the queues.  Day of the week works
-# nicely, though many other schemes would work just as well.
+# at around 3.0 tasks/second.  For processing archival data, we want to
+# be able to process roughly one month per day.  At 16K tasks per day,
+# this is about 500K tasks per input month, 20K tasks per processing hour,
+# or just under 6 tasks/second.   
+# When reprocessing data older than 30 days, the pipeline inserts rows 
+# into templated tables, which means there is a separate table per day.
+# So, we can exceed the 3 tasks/second rate if we have multiple queues,
+# feed each table from a single queue, and rate limit each queue to
+# less than 3 tasks/second.
+# Below we create 7 queues, one for each day of the week.  This allows
+# us, for example, to process 7 days concurrently, into seven distinct
+# tables.  We can put multiple weeks of data into the queues as well. 
 #
 # This will be used in conjunction with a batch reprocessing script
 # that will spray the requested tasks, by date, across the different
 # queues.
-# Collectively they should be able to fill
-# 50 instances at 12 workers per instance, or 600 altogether.  We
-# allow a total of 560 (80 * 7), which should result in relatively
-# few rejected requests once App Engine fully scales up.
+# Since each queue is rate limited to 1 task/sec, and any given table
+# receives data from a single day, and any given day's data will be
+# directed to a single queue, this will limit the insert rate into 
+# any single table to well below the table quota.
+#
+# The current pipeline config has up to 50 instances with 2 cpus and
+# 12 workers each.  We allow a total of 560 (80 * 7) concurrent tasks,
+# which should result in relatively few rejected requests once App
+# Engine fully scales up.
 # Some adjustments may be needed once this is running regularly.
 - name: etl-ndt-batch-monday
   target: etl-ndt-batch-parser

--- a/appengine/queue.yaml
+++ b/appengine/queue.yaml
@@ -13,51 +13,63 @@ queue:
   # Maximum number of concurrent requests.
   max_concurrent_requests: 360
 
-# We want multiple separate queue, to ensure that batch processing doesn't
-# exceed the per table quota.  Collectively they should be able to fill
-# 50 instances at 12 workers per instance, or about 600 altogether.
+# BigQuery has a streaming insert quota per table, which we seem to hit
+# at around 3.0 tasks/second.  When reprocessing data older than 30 days,
+# the pipeline inserts rows into templated tables, which means there is
+# a separate table per day.
+# We create multiple queues, with modest rate limits on each queue, and
+# then partition batch jobs across the queues.  Day of the week works
+# nicely, though many other schemes would work just as well.
+#
+# This will be used in conjunction with a batch reprocessing script
+# that will spray the requested tasks, by date, across the different
+# queues.
+# Collectively they should be able to fill
+# 50 instances at 12 workers per instance, or 600 altogether.  We
+# allow a total of 560 (80 * 7), which should result in relatively
+# few rejected requests once App Engine fully scales up.
 # Some adjustments may be needed once this is running regularly.
 - name: etl-ndt-batch-monday
   target: etl-ndt-batch-parser
-  rate: 0.8/s
+  rate: 1.0/s
   bucket_size: 10
-  max_concurrent_requests: 100
+  max_concurrent_requests: 80
 
 - name: etl-ndt-batch-tuesday
   target: etl-ndt-batch-parser
-  rate: 0.8/s
+  rate: 1.0/s
   bucket_size: 10
-  max_concurrent_requests: 100
+  max_concurrent_requests: 80
 
 - name: etl-ndt-batch-wednesday
   target: etl-ndt-batch-parser
-  rate: 0.8/s
+  rate: 1.0/s
   bucket_size: 10
-  max_concurrent_requests: 100
+  max_concurrent_requests: 80
 
 - name: etl-ndt-batch-thursday
   target: etl-ndt-batch-parser
-  rate: 0.8/s
+  rate: 1.0/s
   bucket_size: 10
-  max_concurrent_requests: 100
+  max_concurrent_requests: 80
 
 - name: etl-ndt-batch-friday
   target: etl-ndt-batch-parser
-  rate: 0.8/s
+  rate: 1.0/s
   bucket_size: 10
-  max_concurrent_requests: 100
+  max_concurrent_requests: 80
 
 - name: etl-ndt-batch-saturday
   target: etl-ndt-batch-parser
-  rate: 0.8/s
+  rate: 1.0/s
   bucket_size: 10
-  max_concurrent_requests: 100
+  max_concurrent_requests: 80
 
 - name: etl-ndt-batch-sunday
   target: etl-ndt-batch-parser
-  rate: 0.8/s
+  rate: 1.0/s
   bucket_size: 10
-  max_concurrent_requests: 100
+  max_concurrent_requests: 80
 
 - name: etl-traceroute-queue
   target: etl-traceroute-parser

--- a/appengine/queue.yaml
+++ b/appengine/queue.yaml
@@ -13,74 +13,92 @@ queue:
   # Maximum number of concurrent requests.
   max_concurrent_requests: 360
 
-# BigQuery has a streaming insert quota per table, which we seem to hit
-# at around 3.0 tasks/second.  For processing archival data, we want to
-# be able to process roughly one month per day.  At 16K tasks per day,
-# this is about 500K tasks per input month, 20K tasks per processing hour,
-# or just under 6 tasks/second.   
+# For processing archival data, we want to be able to process roughly one month
+# per day, which for current data rates of 1 million tests per day, is
+# about 30 million rows per day, or about 350 rows/second.
+#
+# BigQuery has a streaming insert quota per table.  The published quota is
+# 100MB/sec per table, but we have been hitting the quota at seemingly
+# lower rates - around 200 rows/second for NDT, which is about 20MB/sec of
+# data in the final table.
+# Not clear what is going on - perhaps the quota is on the size of incoming
+# HTTP request data - but we will design to stay well within 200
+# rows/second limit.
+#
 # When reprocessing data older than 30 days, the pipeline inserts rows 
 # into templated tables, which means there is a separate table per day.
-# So, we can exceed the 3 tasks/second rate if we have multiple queues,
-# feed each table from a single queue, and rate limit each queue to
-# less than 3 tasks/second.
-# Below we create 7 queues, one for each day of the week.  This allows
-# us, for example, to process 7 days concurrently, into seven distinct
-# tables.  We can put multiple weeks of data into the queues as well. 
+# So for archive reprocessing more than 30 days in the past, the BQ quota
+# ends up being rows/sec per day/date.
 #
-# This will be used in conjunction with a batch reprocessing script
-# that will spray the requested tasks, by date, across the different
+# Let's choose a conservative BQ rate limit of 100 rows/second, per
+# table, and therefore per archive date.
+#
+# The new scraper produces about 16K tasks per day, with about 60 row inserts
+# per task.  But older archives are much larger, with perhaps 1000 to 2000 tar
+# files per day, and 600 to 1000 tests per file.
+# 
+# The individual tasks in the new pipeline complete in roughly 45 seconds,
+# so the net row insert rate is around 1.3 rows/sec per task, at least
+# when instances are running at modest CPU load of 60% or so.  (The
+# throughput per task drops when CPU utilization exceeds 90% or so).
+#
+# Using task queue rate/sec, we would have to very conservative because
+# of the very large older archives. But by limiting the rate based on
+# number of concurrent tasks, we can regulate the throughput independent
+# of the size of the archive files.  100 rows/second, divided by 1.3 rows/sec
+# per task, results in a target of roughly 60 concurrent tasks per archive date.
+#
+# To reach the desired 350 rows/second required to process one month's
+# data each day, we need to process at least 4 days of data in parallel.
+# The quota gaurantee comes from putting any one day's data into a single
+# task queue, and the desired aggregate throughput can be achieved by
+# having multiple queues, and spraying different days across different
 # queues.
-# Since each queue is rate limited to 1 task/sec, and any given table
-# receives data from a single day, and any given day's data will be
-# directed to a single queue, this will limit the insert rate into 
-# any single table to well below the table quota.
+#
+# To make things conceptually simple, we will just create queues with
+# suffixes like _0, _1, _2 ...
+# A corresponding batch reprocessing script will use Gregorian ordinal
+# of the date, mod N, to determine which queue to drop any given date
+# into.  We just choose an appropriate N that gives us the throughput
+# we need.  For now, N=5 gives us a bit of headroom, so this config
+# sets up _0 through _4.
 #
 # The current pipeline config has up to 50 instances with 2 cpus and
-# 12 workers each.  We allow a total of 560 (80 * 7) concurrent tasks,
-# which should result in relatively few rejected requests once App
-# Engine fully scales up.
+# 12 workers each.  This could handle up to 0.9 * 50 * 12 or 560
+# concurrent tasks, which is well in excess of what we currently need.
 # Some adjustments may be needed once this is running regularly.
-- name: etl-ndt-batch-monday
+#
+# SUMMARY:
+# 1. Each queue must limit concurrent requests to about 60 to limit
+#    rate into individual tables to around 100 rows/second.
+# 2. We have 5 queues, to allow up to about 500 rows/second, to
+#    allow 30 days of data to be processed within one day, with
+#    some headroom for future growth.
+- name: etl-ndt-batch_0
   target: etl-ndt-batch-parser
   rate: 1.0/s
   bucket_size: 10
-  max_concurrent_requests: 80
-
-- name: etl-ndt-batch-tuesday
+  max_concurrent_requests: 60
+- name: etl-ndt-batch_1
   target: etl-ndt-batch-parser
   rate: 1.0/s
   bucket_size: 10
-  max_concurrent_requests: 80
-
-- name: etl-ndt-batch-wednesday
+  max_concurrent_requests: 60
+- name: etl-ndt-batch_2
   target: etl-ndt-batch-parser
   rate: 1.0/s
   bucket_size: 10
-  max_concurrent_requests: 80
-
-- name: etl-ndt-batch-thursday
+  max_concurrent_requests: 60
+- name: etl-ndt-batch_3
   target: etl-ndt-batch-parser
   rate: 1.0/s
   bucket_size: 10
-  max_concurrent_requests: 80
-
-- name: etl-ndt-batch-friday
+  max_concurrent_requests: 60
+- name: etl-ndt-batch_4
   target: etl-ndt-batch-parser
   rate: 1.0/s
   bucket_size: 10
-  max_concurrent_requests: 80
-
-- name: etl-ndt-batch-saturday
-  target: etl-ndt-batch-parser
-  rate: 1.0/s
-  bucket_size: 10
-  max_concurrent_requests: 80
-
-- name: etl-ndt-batch-sunday
-  target: etl-ndt-batch-parser
-  rate: 1.0/s
-  bucket_size: 10
-  max_concurrent_requests: 80
+  max_concurrent_requests: 60
 
 - name: etl-traceroute-queue
   target: etl-traceroute-parser

--- a/appengine/queue.yaml
+++ b/appengine/queue.yaml
@@ -13,45 +13,49 @@ queue:
   # Maximum number of concurrent requests.
   max_concurrent_requests: 360
 
+# We want multiple separate queue, to ensure that batch processing doesn't
+# exceed the per table quota.  Collectively they should be able to fill
+# 50 instances at 12 workers per instance, or about 600 altogether.
+# Some adjustments may be needed once this is running regularly.
 - name: etl-ndt-batch-monday
   target: etl-ndt-batch-parser
-  rate: 0.5/s
+  rate: 0.8/s
   bucket_size: 10
   max_concurrent_requests: 100
 
 - name: etl-ndt-batch-tuesday
   target: etl-ndt-batch-parser
-  rate: 0.5/s
+  rate: 0.8/s
   bucket_size: 10
   max_concurrent_requests: 100
 
 - name: etl-ndt-batch-wednesday
   target: etl-ndt-batch-parser
-  rate: 0.5/s
+  rate: 0.8/s
   bucket_size: 10
   max_concurrent_requests: 100
 
 - name: etl-ndt-batch-thursday
   target: etl-ndt-batch-parser
-  rate: 0.5/s
+  rate: 0.8/s
   bucket_size: 10
   max_concurrent_requests: 100
 
 - name: etl-ndt-batch-friday
   target: etl-ndt-batch-parser
-  rate: 0.5/s
+  rate: 0.8/s
   bucket_size: 10
   max_concurrent_requests: 100
 
 - name: etl-ndt-batch-saturday
   target: etl-ndt-batch-parser
-  rate: 0.5/s
+  rate: 0.8/s
   bucket_size: 10
   max_concurrent_requests: 100
 
 - name: etl-ndt-batch-sunday
   target: etl-ndt-batch-parser
-  rate: 0.5/s
+  rate: 0.8/s
   bucket_size: 10
   max_concurrent_requests: 100
 

--- a/appengine/queue.yaml
+++ b/appengine/queue.yaml
@@ -13,17 +13,47 @@ queue:
   # Maximum number of concurrent requests.
   max_concurrent_requests: 360
 
-- name: etl-ndt-batch-queue
+- name: etl-ndt-batch-monday
   target: etl-ndt-batch-parser
-  # Average rate at which to release tasks to the service.  Default is 5/sec
-  # This is actually the rate at which tokens are added to the bucket.
-  # 1.0 allow processing a day's data (about 11K tasks) in 3 to 4 hours.
-  rate: 5.0/s
-  # Number of tokens that can accumulate in the bucket.  Default is 5.  This should
-  # have very little impact for our environment.
+  rate: 0.5/s
   bucket_size: 10
-  # Maximum number of concurrent requests. 90% of max_workers * max instances
-  max_concurrent_requests: 900
+  max_concurrent_requests: 100
+
+- name: etl-ndt-batch-tuesday
+  target: etl-ndt-batch-parser
+  rate: 0.5/s
+  bucket_size: 10
+  max_concurrent_requests: 100
+
+- name: etl-ndt-batch-wednesday
+  target: etl-ndt-batch-parser
+  rate: 0.5/s
+  bucket_size: 10
+  max_concurrent_requests: 100
+
+- name: etl-ndt-batch-thursday
+  target: etl-ndt-batch-parser
+  rate: 0.5/s
+  bucket_size: 10
+  max_concurrent_requests: 100
+
+- name: etl-ndt-batch-friday
+  target: etl-ndt-batch-parser
+  rate: 0.5/s
+  bucket_size: 10
+  max_concurrent_requests: 100
+
+- name: etl-ndt-batch-saturday
+  target: etl-ndt-batch-parser
+  rate: 0.5/s
+  bucket_size: 10
+  max_concurrent_requests: 100
+
+- name: etl-ndt-batch-sunday
+  target: etl-ndt-batch-parser
+  rate: 0.5/s
+  bucket_size: 10
+  max_concurrent_requests: 100
 
 - name: etl-traceroute-queue
   target: etl-traceroute-parser


### PR DESCRIPTION
This will be used primarily in production, to feed the etl-ndt-batch-parser.  Currently other appengine configs do not configure a batch pipeline.

Also removes the unused pull queue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/292)
<!-- Reviewable:end -->
