### PR TITLE
Suppress delta generation

### DIFF
--- a/cmd/etl_worker/app-ndt.yaml
+++ b/cmd/etl_worker/app-ndt.yaml
@@ -41,4 +41,5 @@ env_variables:
   BIGQUERY_PROJECT: 'mlab-sandbox'
   BIGQUERY_DATASET: 'mlab_sandbox'
   ANNOTATE_IP: 'true'
+  NDT_OMIT_DELTAS: 'true'
   # TODO add custom service-account, instead of using default credentials.

--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	NDTOmitDeltas = os.GetEnv("NDT_OMIT_DELTAS")
+	NDTOmitDeltas = os.Getenv("NDT_OMIT_DELTAS")
 )
 
 const (

--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,7 +21,8 @@ import (
 )
 
 var (
-	NDTOmitDeltas = os.Getenv("NDT_OMIT_DELTAS")
+	// NDTOmitDeltas flag indicates if deltas should be suppressed.
+	NDTOmitDeltas, _ = strconv.ParseBool(os.Getenv("NDT_OMIT_DELTAS"))
 )
 
 const (
@@ -346,9 +348,9 @@ func (n *NDTParser) processTest(test *fileInfoAndData, testType string) {
 }
 
 func (n *NDTParser) getDeltas(snaplog *web100.SnapLog, testType string) ([]schema.Web100ValueMap, int) {
-	deltas := make([]schema.Web100ValueMap, 1000)
+	deltas := []schema.Web100ValueMap{}
 	deltaFieldCount := 0
-	if true {
+	if NDTOmitDeltas {
 		return deltas, deltaFieldCount
 	}
 	snapshotCount := 0


### PR DESCRIPTION
For near term, we can produce tables without deltas about 5 times faster than with deltas.  We will provide some test tables with deltas, and add deltas back into the main tables in a couple months.

This does some refactoring, and adds an env var check that disables delta generation.  It also sets the env var for sandbox.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/302)
<!-- Reviewable:end -->
