### PR TITLE
Adjust insert buffer size for no-deltas

### DIFF
--- a/bq/insert.go
+++ b/bq/insert.go
@@ -47,7 +47,7 @@ func NewInserter(dataset string, dt etl.DataType, partition time.Time) (etl.Inse
 
 	return NewBQInserter(
 		etl.InserterParams{Dataset: dataset, Table: table, Suffix: suffix,
-			Timeout: 15 * time.Minute, BufferSize: etl.DataTypeToBQBufferSize[dt], RetryDelay: 30 * time.Second},
+			Timeout: 15 * time.Minute, BufferSize: dt.BQBufferSize(), RetryDelay: 30 * time.Second},
 		nil)
 }
 

--- a/cmd/etl_worker/app-ndt-batch.yaml
+++ b/cmd/etl_worker/app-ndt-batch.yaml
@@ -42,6 +42,7 @@ network:
     - 9090/tcp
 
 env_variables:
+  NDT_BATCH: 'true'  # Allow instances to discover they are NDT_BATCH instances.
   MAX_WORKERS: 20
   BIGQUERY_PROJECT: 'measurement-lab'
   BIGQUERY_DATASET: 'batch'

--- a/cmd/reproc/reproc_test.go
+++ b/cmd/reproc/reproc_test.go
@@ -25,7 +25,7 @@ func Test_queueFor(t *testing.T) {
 	defer ResetFlags()
 
 	tme, _ := time.Parse("2006/01/02", "2017/09/01")
-	queue := queueFor(tme)
+	queue := queueForDate(tme)
 	if queue != "base-2" {
 		t.Error("bad queue: ", queue)
 	}

--- a/etl/globals.go
+++ b/etl/globals.go
@@ -28,6 +28,8 @@ var (
 	podPattern   = regexp.MustCompile(mlabN_podNN)
 )
 
+
+
 type DataPath struct {
 	// TODO(dev) Delete unused fields.
 	// They are comprehensive now in anticipation of using them to populate
@@ -74,6 +76,17 @@ func (fn *DataPath) GetDataType() DataType {
 //=====================================================================
 
 type DataType string
+
+func (dt DataType) BQBufferSize() int {
+	// Special case for NDT when omitting deltas.
+	if dt == NDT {
+		omitDeltas, _ = strconv.ParseBool(os.Getenv("NDT_OMIT_DELTAS"))
+		if omitDeltas {
+			return 5 * DateTypeToBQBufferSize[dt]
+		}
+	}
+	return 5 * DateTypeToBQBufferSize[dt]
+}
 
 const (
 	NDT     = DataType("ndt")

--- a/etl/globals.go
+++ b/etl/globals.go
@@ -2,7 +2,9 @@ package etl
 
 import (
 	"errors"
+	"os"
 	"regexp"
+	"strconv"
 )
 
 const start = `^gs://(?P<prefix>.*)/(?P<exp>[^/]*)/`
@@ -27,8 +29,6 @@ var (
 	endPattern   = regexp.MustCompile(suffix)
 	podPattern   = regexp.MustCompile(mlabN_podNN)
 )
-
-
 
 type DataPath struct {
 	// TODO(dev) Delete unused fields.
@@ -80,12 +80,12 @@ type DataType string
 func (dt DataType) BQBufferSize() int {
 	// Special case for NDT when omitting deltas.
 	if dt == NDT {
-		omitDeltas, _ = strconv.ParseBool(os.Getenv("NDT_OMIT_DELTAS"))
+		omitDeltas, _ := strconv.ParseBool(os.Getenv("NDT_OMIT_DELTAS"))
 		if omitDeltas {
-			return 5 * DateTypeToBQBufferSize[dt]
+			return 5 * DataTypeToBQBufferSize[dt]
 		}
 	}
-	return 5 * DateTypeToBQBufferSize[dt]
+	return 5 * DataTypeToBQBufferSize[dt]
 }
 
 const (


### PR DESCRIPTION
When NDT_OMIT_DELTAS is set, each row is much smaller, so we can buffer more rows.  This should improve throughput, and likely reduce the number of workers or instances needed.

I'm not entirely happy about having NDT details in globals.go, but it seems much better than having them in insert.go.   If you have a better idea please suggest.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/375)
<!-- Reviewable:end -->

  