### PR TITLE
Add travis env vars to app-engine deployments.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@
 #  * on success, deploy the result when the origin branch matches a supported
 #    deployment target.
 #
+# NOTE: Cloud functions only support primitive IAM roles: Owner, Editor, Viewer.
+# See: https://cloud.google.com/functions/docs/concepts/iam
+# TODO(soltesz): Add deployment automation when fine-grained permissions are
+# possible.
+
 language: go
 
 before_install:
@@ -70,6 +75,55 @@ script:
 # Deploy steps never trigger on a new Pull Request. Deploy steps will trigger
 # after a merge with matching "on:" conditions.
 deploy:
+######################################################################
+## ALL PRODUCTION ETL SERVICES
+######################################################################
+# STAGING: Should be used AFTER code review and commit to master branch.
+# Triggers when *ANY* branch is tagged with staging-*'
+# Deploys ALL SERVICES, NDT, PT, SS, QUEUE_PUSHER, CRON
+# NOTE:
+#  Failure in one of the deployments will terminate the deployment sequence, leaving
+#  the system in a mixed state.  This should be manually addresses ASAP.
+- provider: script
+  script:
+    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
+    /tmp/mlab-staging.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt-staging.yaml &&
+    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
+    /tmp/mlab-staging.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-traceroute-staging.yaml &&
+    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
+    /tmp/mlab-staging.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-sidestream-staging.yaml &&
+    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
+    /tmp/mlab-staging.json $TRAVIS_BUILD_DIR/appengine/queue_pusher
+  skip_cleanup: true
+  on:
+    repo: m-lab/etl
+    all_branches: true
+    condition: $TRAVIS_TAG == staging-*
+
+# PROD: Should be used AFTER code review and commit to master branch.
+# Triggers when *ANY* branch is tagged with prod-*'
+# Deploys ALL SERVICES, NDT, NDT_BATCH, PT, SS, QUEUE_PUSHER, CRON
+# NOTE:
+#  Failure in one of the deployments will terminate the deployment sequence, leaving
+#  the system in a mixed state.  This should be manually addresses ASAP.
+- provider: script
+  script:
+    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
+    /tmp/mlab-oti.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt-prod.yaml &&
+    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
+    /tmp/mlab-oti.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt-batch.yaml &&
+    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
+    /tmp/mlab-oti.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-traceroute-prod.yaml &&
+    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
+    /tmp/mlab-oti.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-sidestream-prod.yaml &&
+    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
+    /tmp/mlab-oti.json $TRAVIS_BUILD_DIR/appengine/queue_pusher
+  skip_cleanup: true
+  on:
+    repo: m-lab/etl
+    all_branches: true
+    condition: $TRAVIS_TAG == prod-*
+
 ######################################################################
 ## Service: etl-disco-parser -- AppEngine Flexible Environment.
 # SANDBOX: before code review for development code in a specific branch.
@@ -260,8 +314,3 @@ deploy:
     all_branches: true
     tag: true
     condition: $TRAVIS_TAG == qp-prod-*
-
-# NOTE: Cloud functions only support primitive IAM roles: Owner, Editor, Viewer.
-# See: https://cloud.google.com/functions/docs/concepts/iam
-# TODO(soltesz): Add deployment automation when fine-grained permissions are
-# possible.

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,9 +78,12 @@ deploy:
 ######################################################################
 ## ALL PRODUCTION ETL SERVICES
 ######################################################################
-# STAGING: Should be used AFTER code review and commit to master branch.
-# Triggers when *ANY* branch is tagged with staging-*'
-# Deploys ALL SERVICES, NDT, PT, SS, QUEUE_PUSHER, CRON
+# STAGING: Automatically deploys all pipeline services on new merge to
+# integration branch.
+# Deploys all staging services: NDT, PT, SS, QUEUE_PUSHER
+# (Currently this does not include NDT_BATCH or CRON, as CRON is in
+# development, and batch is driven by CRON.  Prod include the batch
+# pipeline because we have been using it manually.)
 # NOTE:
 #  Failure in one of the deployments will terminate the deployment sequence, leaving
 #  the system in a mixed state.  This should be manually addresses ASAP.
@@ -97,12 +100,11 @@ deploy:
   skip_cleanup: true
   on:
     repo: m-lab/etl
-    all_branches: true
-    condition: $TRAVIS_TAG == staging-*
+    branch: integration
 
-# PROD: Should be used AFTER code review and commit to master branch.
+# PROD: Should be used AFTER code review, commit to integration, and staging soak.
 # Triggers when *ANY* branch is tagged with prod-*'
-# Deploys ALL SERVICES, NDT, NDT_BATCH, PT, SS, QUEUE_PUSHER, CRON
+# Deploys all production services: NDT, NDT_BATCH, PT, SS, QUEUE_PUSHER
 # NOTE:
 #  Failure in one of the deployments will terminate the deployment sequence, leaving
 #  the system in a mixed state.  This should be manually addresses ASAP.
@@ -171,7 +173,8 @@ deploy:
     branch: integration
 
 # STAGING: Should be used AFTER code review and commit to dev branch.  Triggers
-# when *ANY* branch is tagged with ndt-staging-*'
+# when *ANY* branch is tagged with ndt-staging-*'  This allows pushing individual
+# pipeline components prior to committing to integration branch.
 - provider: script
   script: $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
     /tmp/mlab-staging.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt-staging.yaml


### PR DESCRIPTION
This adds two deployment targets - staging-* and prod-*, which deploy all etl pipelines, instead of individual pipelines.

Leaving the individual targets for now, but probably should remove them later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/380)
<!-- Reviewable:end -->
