### PR TITLE
Parse to base_tables instead of public

### DIFF
--- a/cmd/etl_worker/app-ndt-prod.yaml
+++ b/cmd/etl_worker/app-ndt-prod.yaml
@@ -20,7 +20,7 @@ resources:
 automatic_scaling:
   # We expect fairly steady load, so a modest minimum will rarely cost us anything.
   min_num_instances: 2
-  max_num_instances: 20
+  max_num_instances: 10
   # Very long cool down period, to reduce the likelihood of tasks being truncated.
   cool_down_period_sec: 1800
   # We don't care much about latency, so a high utilization is desireable.
@@ -43,8 +43,9 @@ env_variables:
   RELEASE_TAG: ${TRAVIS_TAG}
   COMMIT_HASH: ${TRAVIS_COMMIT}
 
-  MAX_WORKERS: 20
+  MAX_WORKERS: 12
   BIGQUERY_PROJECT: 'measurement-lab'
-  BIGQUERY_DATASET: 'public'
+  BIGQUERY_DATASET: 'base_tables'
   ANNOTATE_IP: 'true'
+  NDT_OMIT_DELTAS: 'true'
   # TODO add custom service-account, instead of using default credentials.


### PR DESCRIPTION
We have agreed to use dataset base_tables instead of public for the continuous pipeline output.
This also disables snapshot deltas, and adjusts worker and instance limits.

Before pushing to prod, need to suspend the task queue to avoid having to merge old and new table.

critzo - this is just an FYI - won't wait for your review, but feel free to comment.

Issue #403

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/404)
<!-- Reviewable:end -->
