### PR TITLE
Update the DISCO switch schema

### DIFF
--- a/etl/globals.go
+++ b/etl/globals.go
@@ -175,7 +175,7 @@ const (
 	NDT_OMIT_DELTAS = DataType("ndt_nodelta") // to support larger buffer size.
 	SS              = DataType("sidestream")
 	PT              = DataType("traceroute")
-	SW              = DataType("disco")
+	SW              = DataType("switch")
 	INVALID         = DataType("invalid")
 )
 
@@ -195,7 +195,7 @@ var (
 		NDT:     "ndt",
 		SS:      "sidestream",
 		PT:      "traceroute",
-		SW:      "disco_test",
+		SW:      "switch",
 		INVALID: "invalid",
 	}
 

--- a/parser/disco_test.go
+++ b/parser/disco_test.go
@@ -36,7 +36,7 @@ func TestJSONParsing(t *testing.T) {
 
 	var parser etl.Parser = parser.NewDiscoParser(ins)
 
-	meta := map[string]bigquery.Value{"filename": "filename", "parsetime": time.Now()}
+	meta := map[string]bigquery.Value{"filename": "filename", "parse_time": time.Now()}
 	// Should result in two tests sent to inserter, but no call to uploader.
 	err = parser.ParseAndInsert(meta, "testName", test_data)
 	if ins.Accepted() != 2 {
@@ -77,7 +77,7 @@ func xTestRealBackend(t *testing.T) {
 	ins, err := bq.NewInserter("mlab_sandbox", etl.SW, time.Now())
 	var parser etl.Parser = parser.NewDiscoParser(ins)
 
-	meta := map[string]bigquery.Value{"filename": "filename", "parsetime": time.Now()}
+	meta := map[string]bigquery.Value{"filename": "filename", "parse_time": time.Now()}
 	for i := 0; i < 3; i++ {
 		// Iterations:
 		// Add two rows, no upload.

--- a/schema/README.md
+++ b/schema/README.md
@@ -15,5 +15,8 @@ intended to contain snapshot deltas.  To create a new table:
 pt.json contains the schema for paris traceroute tables.  To create a new table:
     bq mk --time_partitioning_type=DAY --schema schema/pt.json -t mlab_sandbox.pt_test
 
+switch.json contains the schema for DISCO tables. To create a new table:
+    bq mk --time_partitioning_type=DAY --schema schema/switch.json -t mlab_sandbox.switch
+
 As of May 2017, there are (still) differences between the legacy and NDT schema that may
 need to be addressed.

--- a/schema/switch.json
+++ b/schema/switch.json
@@ -1,7 +1,7 @@
 [
     { "name": "meta", "type": "RECORD", "fields": [
-            { "name": "filename", "type": "STRING" },
-            { "name": "testname", "type": "STRING" },
+            { "name": "task_filename", "type": "STRING" },
+            { "name": "test_id", "type": "STRING" },
             { "name": "parse_time", "type": "TIMESTAMP" }
         ]
     },

--- a/schema/switch.json
+++ b/schema/switch.json
@@ -1,0 +1,16 @@
+[
+    { "name": "meta", "type": "RECORD", "fields": [
+            { "name": "filename", "type": "STRING" },
+            { "name": "testname", "type": "STRING" },
+            { "name": "parse_time", "type": "TIMESTAMP" }
+        ]
+    },
+    { "name": "sample", "type": "RECORD", "mode": "REPEATED", "fields": [
+            { "name": "timestamp", "type": "TIMESTAMP" },
+            { "name": "value", "type": "FLOAT" }
+        ]
+    },
+    { "name": "metric", "type": "STRING" },
+    { "name": "hostname", "type": "STRING" },
+    { "name": "experiment", "type": "STRING" }
+]

--- a/schema/switch_schema.go
+++ b/schema/switch_schema.go
@@ -1,0 +1,25 @@
+package schema
+
+// TODO: copy disco schema here.
+
+// Meta contains the archive and parse metadata.
+type Meta struct {
+	FileName  string `json:"filename, string" bigquery:"filename"`
+	TestName  string `json:"testname, string" bigquery:"testname"`
+	ParseTime int64  `json:"parse_time, int64" bigquery:"parse_time"`
+}
+
+// Sample is an individual measurement taken by DISCO.
+type Sample struct {
+	Timestamp int64   `json:"timestamp, int64" bigquery:"timestamp"`
+	Value     float32 `json:"value, float32" bigquery:"value"`
+}
+
+// SwitchStats represents a row of data taken from the raw DISCO export file.
+type SwitchStats struct {
+	Meta       Meta     `json:"meta" bigquery:"meta"`
+	Sample     []Sample `json:"sample" bigquery:"sample"`
+	Metric     string   `json:"metric" bigquery:"metric"`
+	Hostname   string   `json:"hostname" bigquery:"hostname"`
+	Experiment string   `json:"experiment" bigquery:"experiment"`
+}

--- a/schema/switch_schema.go
+++ b/schema/switch_schema.go
@@ -4,8 +4,8 @@ package schema
 
 // Meta contains the archive and parse metadata.
 type Meta struct {
-	FileName  string `json:"filename, string" bigquery:"filename"`
-	TestName  string `json:"testname, string" bigquery:"testname"`
+	FileName  string `json:"task_filename, string" bigquery:"task_filename"`
+	TestName  string `json:"test_id, string" bigquery:"test_id"`
 	ParseTime int64  `json:"parse_time, int64" bigquery:"parse_time"`
 }
 


### PR DESCRIPTION
This change adds disco switch support to the ETL parser.

A new schema definition is included, and the output table renamed to the more recognizable name "switch".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/431)
<!-- Reviewable:end -->
