### PR TITLE
Restore registration of InsertionHistorgram metric

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -49,7 +49,7 @@ func init() {
 	prometheus.MustRegister(BackendFailureCount)
 	prometheus.MustRegister(GCSRetryCount)
 	prometheus.MustRegister(DurationHistogram)
-
+	prometheus.MustRegister(InsertionHistogram)
 }
 
 // TODO


### PR DESCRIPTION
This change restores the registration of the InsertionHistrogram metric that was accidentally removed by https://github.com/m-lab/etl/pull/415

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/434)
<!-- Reviewable:end -->
