### PR TITLE
Fix: Use explicit key path for ndt-batch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,7 +131,7 @@ deploy:
     $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
     /tmp/mlab-staging.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt-staging.yaml
     && INJECTED_PROJECT=mlab-staging
-    $TRAVIS_BUILD_DIR/travis/deploy_app.sh ${INJECTED_PROJECT}
+    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
     /tmp/mlab-staging.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt-batch.yaml
     && $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
     /tmp/mlab-staging.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-traceroute-staging.yaml
@@ -216,7 +216,7 @@ deploy:
     $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-sandbox
     /tmp/mlab-sandbox.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt.yaml
     && INJECTED_PROJECT=mlab-sandbox
-    $TRAVIS_BUILD_DIR/travis/deploy_app.sh ${INJECTED_PROJECT}
+    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-sandbox
     /tmp/mlab-sandbox.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt-batch.yaml
   skip_cleanup: true
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -132,7 +132,7 @@ deploy:
     /tmp/mlab-staging.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt-staging.yaml
     && INJECTED_PROJECT=mlab-staging
     $TRAVIS_BUILD_DIR/travis/deploy_app.sh ${INJECTED_PROJECT}
-    /tmp/${INJECTED_PROJECT}.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt-batch.yaml
+    /tmp/mlab-staging.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt-batch.yaml
     && $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
     /tmp/mlab-staging.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-traceroute-staging.yaml
     && $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
@@ -217,7 +217,7 @@ deploy:
     /tmp/mlab-sandbox.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt.yaml
     && INJECTED_PROJECT=mlab-sandbox
     $TRAVIS_BUILD_DIR/travis/deploy_app.sh ${INJECTED_PROJECT}
-    /tmp/${INJECTED_PROJECT}.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt-batch.yaml
+    /tmp/mlab-sandbox.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt-batch.yaml
   skip_cleanup: true
   on:
     repo: m-lab/etl

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -371,6 +371,8 @@ var (
 		[]string{"table", "phase", "retries", "status"},
 	)
 
+	// TODO(dev): bytes/row - generalize this metric for any file type.
+	//
 	// RowSizeHistogram provides a histogram of bq row json sizes.  It is intended primarily for
 	// NDT, so the bins are fairly large.  NDT average json is around 200K
 	//
@@ -395,6 +397,8 @@ var (
 		[]string{"table"},
 	)
 
+	// TODO(dev): fields/row - generalize this metric for any file type.
+	//
 	// DeltaNumFieldsHistogram provides a histogram of snapshot delta field counts.  It is intended primarily for
 	// NDT.  Typical is about 13, but max might be up to 120 or so.
 	//
@@ -418,6 +422,8 @@ var (
 		[]string{"table"},
 	)
 
+	// TODO(dev): rows/test - generalize this metric for any file type.
+	//
 	// EntryFieldCountHistogram provides a histogram of (approximate) row field counts.  It is intended primarily for
 	// NDT, so the bins are fairly large.  NDT snapshots typically total about 10k
 	// fields, 99th percentile around 35k fields, and occasionally as many as 50k.
@@ -436,7 +442,10 @@ var (
 		prometheus.HistogramOpts{
 			Name: "etl_entry_field_count",
 			Help: "total snapshot field count distributions.",
-			Buckets: []float64{100, 120, 150, 200, 240, 300, 400, 480, 600, 800,
+			Buckets: []float64{
+				1, 2, 3, 4, 6, 8,
+				10, 12, 15, 20, 24, 30, 40, 48, 60, 80,
+				100, 120, 150, 200, 240, 300, 400, 480, 600, 800,
 				1000, 1200, 1500, 2000, 2400, 3000, 4000, 4800, 6000, 8000,
 				10000, 12000, 15000, 20000, 24000, 30000, 40000, 48000, 60000, 80000,
 				100000, 120000, 150000, 200000, 240000, 300000, 400000, 480000,
@@ -464,7 +473,7 @@ var (
 			Help: "Insertion time distributions.",
 			Buckets: []float64{
 				0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.5, 1.0, 2.0,
-				5.0, 10.0, 20.0, 50.0, 100.0, math.Inf(+1),
+				5.0, 10.0, 20.0, 50.0, 100.0, 200.0, math.Inf(+1),
 			},
 		},
 		// Worker type, e.g. ndt, sidestream, ptr, etc.
@@ -495,16 +504,25 @@ var (
 		},
 		// Worker type, e.g. ndt, sidestream, ptr, etc.
 		// TODO(soltesz): support a status field based on HTTP status.
-		[]string{"worker"},
+		[]string{"worker", "status"},
 	)
 
-	// TODO(dev): generalize this metric for size of any file type.
+	// TODO(dev): bytes/test - generalize this metric for size of any file type.
 	FileSizeHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "etl_web100_snaplog_file_size_bytes",
 			Help: "Size of individual snaplog files.",
 			Buckets: []float64{
 				0,
+				1000,       // 1k
+				5000,       // 5k
+				10000,      // 10k
+				25000,      // 25k
+				50000,      // 50k
+				75000,      // 75k
+				100000,     // 100k
+				200000,     // 200k
+				300000,     // 300k
 				400000,     // 400k
 				500000,     // 500k
 				600000,     // 600k
@@ -541,12 +559,28 @@ var (
 	)
 )
 
+// catchStatus wraps the native http.ResponseWriter and captures any written HTTP
+// status codes.
+type catchStatus struct {
+	http.ResponseWriter
+	status int
+}
+
+// WriteHeader wraps the http.ResponseWriter.WriteHeader method, and preserves the
+// status code.
+func (cw *catchStatus) WriteHeader(code int) {
+	cw.ResponseWriter.WriteHeader(code)
+	cw.status = code
+}
+
 // DurationHandler wraps the call of an inner http.HandlerFunc and records the runtime.
 func DurationHandler(name string, inner http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		t := time.Now()
-		inner.ServeHTTP(w, r)
-		// TODO(soltesz): collect success or failure status.
-		DurationHistogram.WithLabelValues(name).Observe(time.Since(t).Seconds())
+		cw := &catchStatus{w, http.StatusOK} // Default status is OK.
+		inner.ServeHTTP(cw, r)
+		// TODO(soltesz): change 'name' to 'table' label based on request parameter.
+		DurationHistogram.WithLabelValues(name, http.StatusText(cw.status)).Observe(
+			time.Since(t).Seconds())
 	}
 }

--- a/parser/disco.go
+++ b/parser/disco.go
@@ -57,8 +57,14 @@ func (dp *DiscoParser) ParseAndInsert(meta map[string]bigquery.Value, testName s
 		ParseTime: meta["parse_time"].(time.Time).Unix(),
 	}
 
+	// Measure the distribution of disco file sizes. (bytes / file)
+	// TODO: add table label, add extension label.
+	metrics.FileSizeHistogram.WithLabelValues("normal").Observe(float64(len(test)))
+
 	rdr := bytes.NewReader(test)
 	dec := json.NewDecoder(rdr)
+	rowCount := 0
+
 	for dec.More() {
 		var stats schema.SwitchStats
 		stats.Meta = ms
@@ -69,6 +75,16 @@ func (dp *DiscoParser) ParseAndInsert(meta map[string]bigquery.Value, testName s
 			// TODO(dev) Should accumulate errors, instead of aborting?
 			return err
 		}
+		rowCount++
+
+		// Count the number of samples per record.
+		metrics.DeltaNumFieldsHistogram.WithLabelValues(
+			dp.TableName()).Observe(float64(len(stats.Sample)))
+
+		// TODO: measure metrics.RowSizeHistogram every so often with json size.
+		metrics.RowSizeHistogram.WithLabelValues(
+			dp.TableName()).Observe(float64(stats.Size()))
+
 		err = dp.inserter.InsertRow(stats)
 		if err != nil {
 			switch t := err.(type) {
@@ -85,6 +101,11 @@ func (dp *DiscoParser) ParseAndInsert(meta map[string]bigquery.Value, testName s
 			return err
 		}
 	}
+
+	// Measure the distribution of records per file.
+	metrics.EntryFieldCountHistogram.WithLabelValues(
+		dp.TableName()).Observe(float64(rowCount))
+
 	metrics.TestCount.WithLabelValues(dp.TableName(), "disco", "ok").Inc()
 
 	return nil

--- a/schema/switch_schema.go
+++ b/schema/switch_schema.go
@@ -23,3 +23,9 @@ type SwitchStats struct {
 	Hostname   string   `json:"hostname" bigquery:"hostname"`
 	Experiment string   `json:"experiment" bigquery:"experiment"`
 }
+
+// Size estimates the number of bytes in the SwitchStats object.
+func (s *SwitchStats) Size() int {
+	return (len(s.Meta.FileName) + len(s.Meta.TestName) + 8 +
+		12*len(s.Sample) + len(s.Metric) + len(s.Hostname) + len(s.Experiment))
+}


### PR DESCRIPTION
This change uses the explicit key path for ndt-batch. Evidently the previous form resulted in a file name like `/tmp/.json`. 

This kind of bug may be an argument for a stand-along deploy script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/444)
<!-- Reviewable:end -->
