### PR TITLE
Revert "Fix: Use explicit key path for ndt-batch"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,8 +131,8 @@ deploy:
     $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
     /tmp/mlab-staging.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt-staging.yaml
     && INJECTED_PROJECT=mlab-staging
-    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
-    /tmp/mlab-staging.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt-batch.yaml
+    $TRAVIS_BUILD_DIR/travis/deploy_app.sh ${INJECTED_PROJECT}
+    /tmp/${INJECTED_PROJECT}.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt-batch.yaml
     && $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
     /tmp/mlab-staging.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-traceroute-staging.yaml
     && $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
@@ -216,8 +216,8 @@ deploy:
     $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-sandbox
     /tmp/mlab-sandbox.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt.yaml
     && INJECTED_PROJECT=mlab-sandbox
-    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-sandbox
-    /tmp/mlab-sandbox.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt-batch.yaml
+    $TRAVIS_BUILD_DIR/travis/deploy_app.sh ${INJECTED_PROJECT}
+    /tmp/${INJECTED_PROJECT}.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt-batch.yaml
   skip_cleanup: true
   on:
     repo: m-lab/etl

--- a/schema/switch_schema.go
+++ b/schema/switch_schema.go
@@ -23,9 +23,3 @@ type SwitchStats struct {
 	Hostname   string   `json:"hostname" bigquery:"hostname"`
 	Experiment string   `json:"experiment" bigquery:"experiment"`
 }
-
-// Size estimates the number of bytes in the SwitchStats object.
-func (s *SwitchStats) Size() int {
-	return (len(s.Meta.FileName) + len(s.Meta.TestName) + 8 +
-		12*len(s.Sample) + len(s.Metric) + len(s.Hostname) + len(s.Experiment))
-}


### PR DESCRIPTION
The fix in https://github.com/m-lab/etl/pull/444 accidentally combined the unreviewed change from https://github.com/m-lab/etl/pull/443.

This change reverts both so that they can be merged independently.



<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/445)
<!-- Reviewable:end -->
 