### PR TITLE
Add production disco deploy commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -265,9 +265,11 @@ deploy:
     /tmp/mlab-oti.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-traceroute-prod.yaml
     && $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
     /tmp/mlab-oti.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-sidestream-prod.yaml
+    && INJECTED_PROJECT=mlab-oti
+    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
+    /tmp/mlab-oti.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-disco.yaml
     && $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
     /tmp/mlab-oti.json $TRAVIS_BUILD_DIR/appengine/queue_pusher
-    # TODO - add disco here
   skip_cleanup: true
   on:
     repo: m-lab/etl


### PR DESCRIPTION
This change adds the disco parser to the "small-prod" and "prod" deployment groups.

Disco uses the same app-disco.yml for each projects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/446)
<!-- Reviewable:end -->
