### PR TITLE
Add IsParsable to Parser interface & generalize FileSizeHistogram

### DIFF
--- a/etl/etl.go
+++ b/etl/etl.go
@@ -47,7 +47,7 @@ type Inserter interface {
 	RowStats // Inserter must implement RowStats
 }
 
-// Params for NewInserter
+// InserterParams for NewInserter
 type InserterParams struct {
 	// The project comes from os.GetEnv("GCLOUD_PROJECT")
 	// These specify the google cloud dataset/table to write to.
@@ -60,7 +60,14 @@ type InserterParams struct {
 	RetryDelay time.Duration // Time to sleep between retries on Quota exceeded failures.
 }
 
+// Parser is the generic interface implemented by each experiment parser.
 type Parser interface {
+	// IsParsable reports a canonical file "kind" and whether the file appears to
+	// be parsable based on the name and content size. A true result does not
+	// guarantee that ParseAndInsert will succeed, but a false result means that
+	// ParseAndInsert can be skipped.
+	IsParsable(testName string, test []byte) (string, bool)
+
 	// meta - metadata, e.g. from the original tar file name.
 	// testName - Name of test file (typically extracted from a tar file)
 	// test - binary test data

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -507,11 +507,16 @@ var (
 		[]string{"worker", "status"},
 	)
 
-	// TODO(dev): bytes/test - generalize this metric for size of any file type.
+	// FileSizeHistogram provides a histogram of source file sizes. The bucket
+	// sizes should cover a wide range of input file sizes.
+	//
+	// Example usage:
+	//   metrics.FileSizeHistogram.WithLabelValues(
+	//       "ndt", "c2s_snaplog", "parsed").Observe(size)
 	FileSizeHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name: "etl_web100_snaplog_file_size_bytes",
-			Help: "Size of individual snaplog files.",
+			Name: "etl_test_file_size_bytes",
+			Help: "Size of individual archive files.",
 			Buckets: []float64{
 				0,
 				1000,       // 1k
@@ -555,7 +560,7 @@ var (
 				math.Inf(+1),
 			},
 		},
-		[]string{"range"},
+		[]string{"table", "kind", "group"},
 	)
 )
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -516,7 +516,7 @@ var (
 	FileSizeHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "etl_test_file_size_bytes",
-			Help: "Size of individual archive files.",
+			Help: "Size of individual test files.",
 			Buckets: []float64{
 				0,
 				1000,       // 1k

--- a/parser/disco.go
+++ b/parser/disco.go
@@ -40,6 +40,8 @@ func (dp *DiscoParser) TaskError() error {
 
 // IsParsable returns the canonical test type and whether to parse data.
 func (dp *DiscoParser) IsParsable(testName string, data []byte) (string, bool) {
+	// Files look like: "<date>-to-<date>-switch.json.gz"
+	// Notice the "-" before switch.
 	if strings.HasSuffix(testName, "switch.json") ||
 		strings.HasSuffix(testName, "switch.json.gz") {
 		return "switch", true

--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -351,6 +351,7 @@ func (n *NDTParser) processGroup() {
 // However, we often get s2c and c2s without corresponding meta files.  When this happens,
 // we proceed with an empty metaFile.
 func (n *NDTParser) processTest(test *fileInfoAndData, testType string) {
+	// TODO: handle this logic earlier in ParseAndInsert or in IsParsable.
 	if len(test.data) > 10*1024*1024 {
 		metrics.ErrorCount.WithLabelValues(
 			n.TableName(), testType, ">10MB").Inc()

--- a/parser/pt.go
+++ b/parser/pt.go
@@ -252,7 +252,7 @@ func (pt *PTParser) NumBufferedTests() int {
 
 // IsParsable returns the canonical test type and whether to parse data.
 func (pt *PTParser) IsParsable(testName string, data []byte) (string, bool) {
-	if strings.HasSuffix(testName, "paris") {
+	if strings.HasSuffix(testName, ".paris") {
 		return "paris", true
 	}
 	return "unknown", false

--- a/parser/pt.go
+++ b/parser/pt.go
@@ -250,6 +250,15 @@ func (pt *PTParser) NumBufferedTests() int {
 	return len(pt.previousTests)
 }
 
+// IsParsable returns the canonical test type and whether to parse data.
+func (pt *PTParser) IsParsable(testName string, data []byte) (string, bool) {
+	if strings.HasSuffix(testName, "paris") {
+		return "paris", true
+	}
+	return "unknown", false
+}
+
+// ParseAndInsert parses a paris-traceroute log file and inserts results into a single row.
 func (pt *PTParser) ParseAndInsert(meta map[string]bigquery.Value, testName string, rawContent []byte) error {
 	metrics.WorkerState.WithLabelValues(pt.TableName(), "pt").Inc()
 	defer metrics.WorkerState.WithLabelValues(pt.TableName(), "pt").Dec()

--- a/parser/ss.go
+++ b/parser/ss.go
@@ -190,7 +190,7 @@ func PopulateSnap(ss_value map[string]string) (schema.Web100Snap, error) {
 
 // IsParsable returns the canonical test type and whether to parse data.
 func (ss *SSParser) IsParsable(testName string, data []byte) (string, bool) {
-	if strings.HasSuffix(testName, "web100") {
+	if strings.HasSuffix(testName, ".web100") {
 		return "web100", true
 	}
 	if strings.HasSuffix(testName, ".tra") {

--- a/parser/ss.go
+++ b/parser/ss.go
@@ -188,14 +188,24 @@ func PopulateSnap(ss_value map[string]string) (schema.Web100Snap, error) {
 	return *snap, nil
 }
 
+// IsParsable returns the canonical test type and whether to parse data.
+func (ss *SSParser) IsParsable(testName string, data []byte) (string, bool) {
+	if strings.HasSuffix(testName, "web100") {
+		return "web100", true
+	}
+	if strings.HasSuffix(testName, ".tra") {
+		// Ignore the trace file for sidestream test.
+		return "trace", false
+	}
+	return "unknown", false
+}
+
+// ParseAndInsert extracts each sidestream record from the rawContent and inserts each into a separate row.
 func (ss *SSParser) ParseAndInsert(meta map[string]bigquery.Value, testName string, rawContent []byte) error {
 	// TODO: for common metric states with constant labels, define global constants.
 	metrics.WorkerState.WithLabelValues(ss.TableName(), "ss").Inc()
 	defer metrics.WorkerState.WithLabelValues(ss.TableName(), "ss").Dec()
-	if strings.Contains(testName, ".tra") {
-		// Ignore the trace file for sidestream test.
-		return nil
-	}
+
 	log_time, err := ExtractLogtimeFromFilename(testName)
 	if err != nil {
 		return err

--- a/task/task.go
+++ b/task/task.go
@@ -107,6 +107,16 @@ OUTER:
 			// If verbose, log the filename that is skipped.
 			continue
 		}
+		kind, parsable := tt.Parser.IsParsable(testname, data)
+		if !parsable {
+			metrics.FileSizeHistogram.WithLabelValues(
+				tt.Parser.TableName(), kind, "ignored").Observe(float64(len(data)))
+			// Don't bother calling ParseAndInsert since this is unparsable.
+			continue
+		} else {
+			metrics.FileSizeHistogram.WithLabelValues(
+				tt.Parser.TableName(), kind, "parsed").Observe(float64(len(data)))
+		}
 		err := tt.Parser.ParseAndInsert(tt.meta, testname, data)
 		// Shouldn't have any of these, as they should be handled in ParseAndInsert.
 		if err != nil {


### PR DESCRIPTION
This change adds a new method to the Parser interface that reports whether a file is parsable, along with the canonical name for the "kind" of file. With this information, the task can decide at run time whether each file IsParsable and whether to call ParseAndInsert.

As well, this change uses FileSizeHistogram for all parsers, and distinguishes them using the parser destination table name, file "kind" and whether the files are parsed or ignored.

Previously, FileSizeHistogram was only used by the NDT parser. This change provides similar information for all parsers.

For NDT there is slightly less information, because the "normal" and "huge" categories are merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/448)
<!-- Reviewable:end -->
