### PR TITLE
Implement Parser interface for test parsers

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -52,6 +52,10 @@ func NewTestParser(ins etl.Inserter) etl.Parser {
 		&parser.FakeRowStats{}} // Use a FakeRowStats to provide the RowStats functions.
 }
 
+func (tp *TestParser) IsParsable(testName string, test []byte) (string, bool) {
+	return "ext", true
+}
+
 func (tp *TestParser) ParseAndInsert(meta map[string]bigquery.Value, testName string, test []byte) error {
 	metrics.TestCount.WithLabelValues("table", "test", "ok").Inc()
 	values := make(map[string]bigquery.Value, len(meta)+1)

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -70,6 +70,10 @@ type TestParser struct {
 	files []string
 }
 
+func (tp *TestParser) IsParsable(testName string, test []byte) (string, bool) {
+	return "ext", true
+}
+
 func (tp *TestParser) TableName() string {
 	return "test-table"
 }


### PR DESCRIPTION
This change completes changes from https://github.com/m-lab/etl/pull/448 to add a new method to the Parser interface.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/453)
<!-- Reviewable:end -->
