### PR TITLE
Views sandbox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -210,7 +210,6 @@ deploy:
   script:
     # Update these version numbers when making changes to the views.
     # TODO - add feature to allow making aliases from existing intermediate.
-    # gcloud auth activate-service-account --key-file=/tmp/mlab-sandbox.json
     $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_sandbox
     && cd $TRAVIS_BUILD_DIR/schema/views_legacysql
     && ./make_views.sh mlab-sandbox intermediate_v3_1_1 rc_v3_1 "rc release"

--- a/.travis.yml
+++ b/.travis.yml
@@ -211,7 +211,7 @@ deploy:
     # Update these version numbers when making changes to the views.
     # TODO - add feature to allow making aliases from existing intermediate.
     # gcloud auth activate-service-account --key-file=/tmp/mlab-sandbox.json
-    $TRAVIS_BUILD_DIR/travis/activate-service-account.sh -SERVICE_ACCOUNT_mlab_sandbox
+    $TRAVIS_BUILD_DIR/travis/activate_service_account.sh -SERVICE_ACCOUNT_mlab_sandbox
     && cd $TRAVIS_BUILD_DIR/schema/views_legacysql
     && ./make_views.sh mlab-sandbox intermediate_v3_1_1 rc_v3_1 "rc release"
     && cd $TRAVIS_BUILD_DIR/schema/views_standardsql

--- a/.travis.yml
+++ b/.travis.yml
@@ -211,7 +211,7 @@ deploy:
     # Update these version numbers when making changes to the views.
     # TODO - add feature to allow making aliases from existing intermediate.
     # gcloud auth activate-service-account --key-file=/tmp/mlab-sandbox.json
-    $TRAVIS_BUILD_DIR/travis/activate_service_account.sh -SERVICE_ACCOUNT_mlab_sandbox
+    $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_sandbox
     && cd $TRAVIS_BUILD_DIR/schema/views_legacysql
     && ./make_views.sh mlab-sandbox intermediate_v3_1_1 rc_v3_1 "rc release"
     && cd $TRAVIS_BUILD_DIR/schema/views_standardsql

--- a/.travis.yml
+++ b/.travis.yml
@@ -210,7 +210,8 @@ deploy:
   script:
     # Update these version numbers when making changes to the views.
     # TODO - add feature to allow making aliases from existing intermediate.
-    $TRAVIS_BUILD_DIR/travis/activate-service-account.sh -SERVICE_ACCOUNT_mlab_sandbox
+    # $TRAVIS_BUILD_DIR/travis/activate-service-account.sh -SERVICE_ACCOUNT_mlab_sandbox
+    gcloud auth activate-service-account --key-file=/tmp/mlab-sandbox.json
     && cd $TRAVIS_BUILD_DIR/schema/views_legacysql
     && ./make_views.sh mlab-sandbox intermediate_v3_1_1 rc_v3_1 "rc release"
     && cd $TRAVIS_BUILD_DIR/schema/views_standardsql

--- a/.travis.yml
+++ b/.travis.yml
@@ -133,7 +133,7 @@ deploy:
 ## Service: queue-pusher -- AppEngine Standard Environment.
 - provider: script
   script:
-    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-sandbox
+    $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-sandbox
     /tmp/mlab-sandbox.json $TRAVIS_BUILD_DIR/appengine/queue_pusher
   skip_cleanup: true
   on:
@@ -144,10 +144,10 @@ deploy:
 ## Service: etl-ndt-parser -- AppEngine Flexible Environment.
 - provider: script
   script:
-    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-sandbox
+    $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-sandbox
     /tmp/mlab-sandbox.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt.yaml
     && INJECTED_PROJECT=mlab-sandbox
-    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-sandbox
+    $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-sandbox
     /tmp/mlab-sandbox.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt-batch.yaml
   skip_cleanup: true
   on:
@@ -159,7 +159,7 @@ deploy:
 - provider: script
   script:
     INJECTED_PROJECT=mab-sandbox
-    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-sandbox
+    $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-sandbox
     /tmp/mlab-sandbox.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-sidestream.yaml
   skip_cleanup: true
   on:
@@ -171,7 +171,7 @@ deploy:
 - provider: script
   script:
     INJECTED_PROJECT=mlab-sandbox
-    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-sandbox
+    $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-sandbox
     /tmp/mlab-sandbox.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-traceroute.yaml
   skip_cleanup: true
   on:
@@ -183,7 +183,7 @@ deploy:
 - provider: script
   script:
     INJECTED_PROJECT=mlab-sandbox
-    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-sandbox
+    $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-sandbox
     /tmp/mlab-sandbox.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-disco.yaml
   skip_cleanup: true
   on:
@@ -197,7 +197,7 @@ deploy:
   script:
     # These injected params specify the project and bucket used by the service.
     INJECTED_PROJECT=mlab-sandbox INJECTED_BUCKET=archive-mlab-sandbox
-    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-sandbox
+    $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-sandbox
     /tmp/mlab-sandbox.json $TRAVIS_BUILD_DIR/cmd/gardener app.yaml
   skip_cleanup: true
   on:
@@ -210,8 +210,8 @@ deploy:
   script:
     # Update these version numbers when making changes to the views.
     # TODO - add feature to allow making aliases from existing intermediate.
-    # $TRAVIS_BUILD_DIR/travis/activate-service-account.sh -SERVICE_ACCOUNT_mlab_sandbox
-    gcloud auth activate-service-account --key-file=/tmp/mlab-sandbox.json
+    # gcloud auth activate-service-account --key-file=/tmp/mlab-sandbox.json
+    $TRAVIS_BUILD_DIR/travis/activate-service-account.sh -SERVICE_ACCOUNT_mlab_sandbox
     && cd $TRAVIS_BUILD_DIR/schema/views_legacysql
     && ./make_views.sh mlab-sandbox intermediate_v3_1_1 rc_v3_1 "rc release"
     && cd $TRAVIS_BUILD_DIR/schema/views_standardsql
@@ -246,24 +246,24 @@ deploy:
 # and better error handling.
 - provider: script
   script:
-    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
+    $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-staging
     /tmp/mlab-staging.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt-staging.yaml
     && INJECTED_PROJECT=mlab-staging
-    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
+    $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-staging
     /tmp/mlab-staging.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt-batch.yaml
     && INJECTED_PROJECT=mlab-staging
-    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
+    $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-staging
     /tmp/mlab-staging.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-traceroute.yaml
     && INJECTED_PROJECT=mlab-staging
-    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
+    $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-staging
     /tmp/mlab-staging.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-sidestream.yaml
     && INJECTED_PROJECT=mlab-staging
-    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
+    $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-staging
     /tmp/mlab-staging.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-disco.yaml
     && INJECTED_PROJECT=mlab-staging INJECTED_BUCKET=archive-mlab-staging
-    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
+    $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-staging
     /tmp/mlab-staging.json $TRAVIS_BUILD_DIR/cmd/gardener app.yaml
-    && $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
+    && $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-staging
     /tmp/mlab-staging.json $TRAVIS_BUILD_DIR/appengine/queue_pusher
     && cd $TRAVIS_BUILD_DIR/schema/views_legacysql
     && ./make_views.sh mlab-staging intermediate_v3_1_1 rc_v3_1 "rc release"
@@ -291,15 +291,15 @@ deploy:
 - provider: script
   script:
     INJECTED_PROJECT=measurement-lab
-    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
+    $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-oti
     /tmp/mlab-oti.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-traceroute.yaml
     && INJECTED_BUCKET=measurement-lab
-    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
+    $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-oti
     /tmp/mlab-oti.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-sidestream.yaml
     && INJECTED_PROJECT=measurement-lab
-    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
+    $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-oti
     /tmp/mlab-oti.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-disco.yaml
-    && $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
+    && $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-oti
     /tmp/mlab-oti.json $TRAVIS_BUILD_DIR/appengine/queue_pusher
   skip_cleanup: true
   on:
@@ -312,10 +312,10 @@ deploy:
 # Triggers when *ANY* branch is tagged with qp-prod-* OR prod-*
 - provider: script
   script:
-    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
+    $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-oti
     /tmp/mlab-oti.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt-prod.yaml
     && INJECTED_PROJECT=measurement-lab
-    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
+    $TRAVIS_BUILD_DIR/travis/deploy_app_legacy_keyfile.sh mlab-oti
     /tmp/mlab-oti.json $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt-batch.yaml
   skip_cleanup: true
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -205,6 +205,21 @@ deploy:
     all_branches: true
     condition: $TRAVIS_BRANCH == gardener-sandbox-* || $TRAVIS_BRANCH == sandbox-*
 
+## Bigquery Views
+- provider: script
+  script:
+    # Update these version numbers when making changes to the views.
+    # TODO - add feature to allow making aliases from existing intermediate.
+    cd $TRAVIS_BUILD_DIR/schema/views_legacysql
+    && ./make_views.sh mlab-sandbox intermediate_v3_1_1 rc_v3_1 "rc release"
+    && cd $TRAVIS_BUILD_DIR/schema/views_standardsql
+    && ./make_views.sh mlab-sandbox intermediate_v3_1_1 rc_v3_1 "rc release"
+  skip_cleanup: true
+  on:
+    repo: m-lab/etl
+    all_branches: true
+    condition: $TRAVIS_BRANCH == views-sandbox-* || $TRAVIS_BRANCH == sandbox-*
+
 ######################################################################
 #  Staging deployments
 #  Auto deployed on merge with integration branch

--- a/.travis.yml
+++ b/.travis.yml
@@ -210,7 +210,8 @@ deploy:
   script:
     # Update these version numbers when making changes to the views.
     # TODO - add feature to allow making aliases from existing intermediate.
-    cd $TRAVIS_BUILD_DIR/schema/views_legacysql
+    $TRAVIS_BUILD_DIR/travis/activate-service-account.sh -SERVICE_ACCOUNT_mlab_sandbox
+    && cd $TRAVIS_BUILD_DIR/schema/views_legacysql
     && ./make_views.sh mlab-sandbox intermediate_v3_1_1 rc_v3_1 "rc release"
     && cd $TRAVIS_BUILD_DIR/schema/views_standardsql
     && ./make_views.sh mlab-sandbox intermediate_v3_1_1 rc_v3_1 "rc release"

--- a/schema/views_legacysql/common_etl.sql
+++ b/schema/views_legacysql/common_etl.sql
@@ -70,5 +70,5 @@ SELECT
   web100_log_entry.snap.X_Rcvbuf, web100_log_entry.snap.X_Sndbuf, web100_log_entry.snap.X_dbg1,
   web100_log_entry.snap.X_dbg2, web100_log_entry.snap.X_dbg3, web100_log_entry.snap.X_dbg4,
   web100_log_entry.snap.X_rcv_ssthresh, web100_log_entry.snap.X_wnd_clamp
-FROM [measurement-lab:base_tables.ndt]
+FROM [${PROJECT}:base_tables.ndt]
 WHERE _PARTITIONTIME >= TIMESTAMP("2017-05-11 00:00:00")

--- a/schema/views_legacysql/make_views.sh
+++ b/schema/views_legacysql/make_views.sh
@@ -20,6 +20,10 @@
 # This means that each view must be created before being used in other
 # view definitions.
 
+# Service Accounts
+# View targets require bigquery-table-deployer
+# Appengine targets require ...
+
 set -u
 ###########################################################################
 #                            Bash Parameters                              #
@@ -56,7 +60,7 @@ create_view() {
 
   # Some FROM targets must link to specified dataset.
   # Substitute dataset name for STANDARD_SUB sql vars.
-  sql=`echo "$sql" | DATASET=${dataset/:/.} envsubst '$DATASET $PROJECT'`
+  sql=`echo "$sql" | DATASET=${dataset/:/.} PROJECT=${PROJECT} envsubst '$DATASET $PROJECT'`
 
   echo $dataset.$view
   bq rm --force $dataset.$view

--- a/schema/views_legacysql/make_views.sh
+++ b/schema/views_legacysql/make_views.sh
@@ -56,7 +56,7 @@ create_view() {
 
   # Some FROM targets must link to specified dataset.
   # Substitute dataset name for STANDARD_SUB sql vars.
-  sql=`echo "$sql" | DATASET=${dataset/:/.} envsubst '$DATASET'`
+  sql=`echo "$sql" | DATASET=${dataset/:/.} envsubst '$DATASET $PROJECT'`
 
   echo $dataset.$view
   bq rm --force $dataset.$view

--- a/schema/views_legacysql/make_views.sh
+++ b/schema/views_legacysql/make_views.sh
@@ -4,7 +4,7 @@
 # This should generally be run from a travis deployment, and the
 # arguments should be derived from the deployment tag.
 # The following legacySQL views are created in the rc/release datasets:
-#      ndt_all​ - all (lightly filtered) tests, excluding EB,
+#    ndt_all​ - all (lightly filtered) tests, excluding EB,
 #              blacklisted, short and very long tests.
 #    Separate views for download and upload NDT tests:
 # ​​​     ndt_downloads
@@ -21,8 +21,8 @@
 # view definitions.
 
 # Service Accounts
-# View targets require bigquery-table-deployer
-# Appengine targets require ...
+#   This script creates datasets and views, which require several bigquery permissions.
+#   The appropriate permissions are provided by the bigquery-table-deployer role.
 
 set -u
 ###########################################################################

--- a/schema/views_legacysql/ndt_exhaustive.sql
+++ b/schema/views_legacysql/ndt_exhaustive.sql
@@ -6,4 +6,4 @@
 SELECT *
 FROM
  [${DATASET}.common_etl_legacysql],
- [measurement-lab:legacy.ndt_plx_legacysql]
+ [${PROJECT}:legacy.ndt_plx_legacysql]

--- a/schema/views_standardsql/common_etl.sql
+++ b/schema/views_standardsql/common_etl.sql
@@ -75,5 +75,5 @@ SELECT
       web100_log_entry.snap.X_rcv_ssthresh, web100_log_entry.snap.X_wnd_clamp)
     AS snap)
   AS web100_log_entry
-FROM `measurement-lab.base_tables.ndt`
+FROM `${PROJECT}.base_tables.ndt`
 WHERE _PARTITIONTIME >= TIMESTAMP("2017-05-11 00:00:00")

--- a/schema/views_standardsql/make_views.sh
+++ b/schema/views_standardsql/make_views.sh
@@ -56,7 +56,7 @@ create_view() {
 
   # Some FROM targets must link to specified dataset.
   # Substitute dataset name for STANDARD_SUB sql vars.
-  sql=`echo "$sql" | DATASET=${dataset/:/.} envsubst '$PROJECT $DATASET'`
+  sql=`echo "$sql" | DATASET=${dataset/:/.} PROJECT=${PROJECT} envsubst '$PROJECT $DATASET'`
 
   echo $dataset.$view
   bq rm --force $dataset.$view

--- a/schema/views_standardsql/make_views.sh
+++ b/schema/views_standardsql/make_views.sh
@@ -56,7 +56,7 @@ create_view() {
 
   # Some FROM targets must link to specified dataset.
   # Substitute dataset name for STANDARD_SUB sql vars.
-  sql=`echo "$sql" | DATASET=${dataset/:/.} envsubst '$DATASET'`
+  sql=`echo "$sql" | DATASET=${dataset/:/.} envsubst '$PROJECT $DATASET'`
 
   echo $dataset.$view
   bq rm --force $dataset.$view

--- a/schema/views_standardsql/make_views.sh
+++ b/schema/views_standardsql/make_views.sh
@@ -20,6 +20,10 @@
 # This means that each view must be created before being used in other
 # view definitions.
 
+# Service Accounts
+#   This script creates datasets and views, which require several bigquery permissions.
+#   The appropriate permissions are provided by the bigquery-table-deployer role.
+
 set -u
 ###########################################################################
 #                            Bash Parameters                              #

--- a/schema/views_standardsql/ndt_exhaustive.sql
+++ b/schema/views_standardsql/ndt_exhaustive.sql
@@ -8,4 +8,4 @@ FROM `${DATASET}.common_etl`
 WHERE partition_date > DATE("2017-05-10")
 UNION ALL
 SELECT *
-FROM `measurement-lab.legacy.ndt_plx`
+FROM `${PROJECT}.legacy.ndt_plx`


### PR DESCRIPTION
This PR generalizes the sql and make_views.sh files to support creation of views in any project.  It also adds an individual views-sandbox target to allow pre-merge testing.

In parallel, I have added an appropriate ROLE in mlab-sandbox to support the view deployment.  This should also be added in staging and prod.  Prod currently has some other permission mechanism set up.

Still TODO:
  1.  The views in the legacy dataset are not yet automated.  I've added an issue #457 to track this.
  2.  We may want to have separate service accounts for this, rather than broadening the set of roles allowed to the standard deployment SA.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/458)
<!-- Reviewable:end -->
