### PR TITLE
Add support for ignoring the embargo archive suffix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -149,7 +149,7 @@ deploy:
 ## Service: etl-sidestream-parser -- AppEngine Flexible Environment.
 - provider: script
   script:
-    INJECTED_PROJECT=mab-sandbox
+    INJECTED_PROJECT=mlab-sandbox
     $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-sandbox
     SERVICE_ACCOUNT_mlab_sandbox $TRAVIS_BUILD_DIR/cmd/etl_worker app-sidestream.yaml
   skip_cleanup: true

--- a/etl/globals.go
+++ b/etl/globals.go
@@ -23,7 +23,7 @@ const start = `^gs://(?P<bucket>.*)/(?P<exp>[^/]*)/`
 const datePath = `(?P<datepath>\d{4}/[01]\d/[0123]\d)/`
 const dateTime = `(?P<packeddate>\d{4}[01]\d[0123]\d)T(?P<packedtime>\d{6})Z`
 const mlabN_podNN = `-(?P<host>mlab\d)-(?P<pod>[[:alpha:]]{3}\d[0-9t])-`
-const exp_NNNN = `(?P<experiment>.*)-(?P<filenumber>\d{4})`
+const exp_NNNN = `(?P<experiment>.*)-(?P<filenumber>\d{4})(?P<etag>-e)?`
 const suffix = `(?P<suffix>\.tar|\.tar.gz|\.tgz)$`
 
 // These are here to facilitate use across queue-pusher and parsing components.
@@ -87,7 +87,7 @@ func ValidateTestPath(path string) (*DataPath, error) {
 		Pod:        fields[7],
 		Experiment: fields[8],
 		FileNumber: fields[9],
-		Suffix:     fields[10],
+		Suffix:     fields[11],
 	}
 	return dp, nil
 }

--- a/etl/globals_test.go
+++ b/etl/globals_test.go
@@ -64,6 +64,13 @@ func TestValidateTestPath(t *testing.T) {
 				"m-lab-sandbox", "ndt", "2016/07/14", "20160714", "123456", "mlab1", "lax04", "ndt", "0001", ".tar.gz",
 			},
 		},
+		{
+			name: "success-embargo-tar-gz",
+			path: `gs://embargo-mlab-oti/sidestream/2018/02/27/20180227T000010Z-mlab1-dfw02-sidestream-0000-e.tgz`,
+			want: &etl.DataPath{
+				"embargo-mlab-oti", "sidestream", "2018/02/27", "20180227", "000010", "mlab1", "dfw02", "sidestream", "0000", ".tgz",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This change adds support for parsing embargo archive file names, which add an additional `-e` suffix to files. This change allows us to ad-hoc process embargo'd files such as sidestream for data analysis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/463)
<!-- Reviewable:end -->
