### PR TITLE
Combine StartTimeStamp with StartTimeUsec as int64 value

### DIFF
--- a/parser/ss.go
+++ b/parser/ss.go
@@ -181,10 +181,6 @@ func PopulateSnap(ss_value map[string]string) (schema.Web100Snap, error) {
 			if err != nil {
 				return *snap, err
 			}
-			if key == "StartTimeStamp" {
-				// Combine the StartTimeStamp and StartTimeUsec values.
-				value = value*1000000 + startTimeUsec
-			}
 			x.SetInt(value)
 		case "string":
 			x.Set(reflect.ValueOf(ss_value[key]))
@@ -198,6 +194,9 @@ func PopulateSnap(ss_value map[string]string) (schema.Web100Snap, error) {
 			}
 		}
 	}
+	// Combine the StartTimeStamp and StartTimeUsec values.
+	snap.StartTimeStamp = snap.StartTimeStamp*1000000 + startTimeUsec
+
 	// TODO: check whether snap has valid LocalAddress, RemAddress. Return error if not.
 	return *snap, nil
 }

--- a/parser/ss_test.go
+++ b/parser/ss_test.go
@@ -21,9 +21,25 @@ func TestPopulateSnap(t *testing.T) {
 	ss_value["CERcvd"] = "22"
 	ss_value["RemAddress"] = "abcd"
 	ss_value["TimeStampRcvd"] = "0"
-	_, err := parser.PopulateSnap(ss_value)
+	ss_value["StartTimeStamp"] = "2222"
+	ss_value["StartTimeUsec"] = "1111"
+	snap, err := parser.PopulateSnap(ss_value)
 	if err != nil {
 		t.Fatalf("Snap fields not populated correctly.")
+	}
+
+	if snap.TimeStampRcvd != false {
+		t.Errorf("TimeStampRcvd; got %t; want false", snap.TimeStampRcvd)
+	}
+	if snap.RemAddress != "abcd" {
+		t.Errorf("RemAddress; got %q; want 'abcd'", snap.RemAddress)
+	}
+	if snap.CERcvd != 22 {
+		t.Errorf("CERcvd; got %d; want 22", snap.CERcvd)
+	}
+	// Verify StartTimeStamp is combined correctly with StartTimeUsec.
+	if snap.StartTimeStamp != 2222001111 {
+		t.Errorf("StartTimeStamp; got %d; want 222001111", snap.StartTimeStamp)
 	}
 }
 


### PR DESCRIPTION
This change adds support to the Sidestream parser for combining the StartTimeStamp and StartTimeUsec web100 values into a single int64 value.

This change reports StartTimeStamp in the same way as it is reported by the NDT parser.

Unfortunately, the sidestream and ndt parsers use incompatible datatypes for holding the web100 values (schema.Web100Snap struct or sidestream, schema.Web100ValueMap for ndt), so there is no shared code between them for handling the conversion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/476)
<!-- Reviewable:end -->
