### PR TITLE
various parameter tweaks

### DIFF
--- a/cmd/etl_worker/app-ndt-batch.yaml
+++ b/cmd/etl_worker/app-ndt-batch.yaml
@@ -24,13 +24,13 @@ automatic_scaling:
   # it to scale up to 40 instances to get work done quickly.  However, note that
   # more than 3 tasks/sec may result in bigquery stream quota problems, so this
   # may require changes.
-  min_num_instances: 1
+  min_num_instances: 10  # Too small a number here, and error rate prevents auto-scaling
   max_num_instances: 40
   # Very long cool down period, to reduce the likelihood of tasks being truncated.
   cool_down_period_sec: 1800
   # We don't care much about latency, so a high utilization is desireable.
   cpu_utilization:
-    target_utilization: 0.85
+    target_utilization: 0.70
 
 # Note: add a public port for GCE auto discovery by prometheus.
 # TODO(dev): are any values redundant or irrelevant?

--- a/etl/globals.go
+++ b/etl/globals.go
@@ -209,7 +209,7 @@ var (
 	dataTypeToBQBufferSize = map[DataType]int{
 		NDT:             10,
 		NDT_OMIT_DELTAS: 50,
-		SS:              100,
+		SS:              500, // Average json size is 2.5K
 		PT:              300,
 		SW:              100,
 		INVALID:         0,

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -220,7 +220,7 @@ func NewETLSource(client *http.Client, uri string) (*ETLSource, error) {
 	}
 
 	// TODO(prod) Evaluate whether this is long enough.
-	obj, err := getObject(client, bucket, fn, 30*time.Minute)
+	obj, err := getObject(client, bucket, fn, 60*time.Minute)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
These are all related to limitations discovered when reprocessing sidestream data.

extend timeout on storage object reads
increase minimum number of batch instances and decrease cpu target
increase buffer size for sidestream

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/478)
<!-- Reviewable:end -->
