### PR TITLE
Queue tweaks

### DIFF
--- a/appengine/queue.yaml
+++ b/appengine/queue.yaml
@@ -83,7 +83,9 @@ queue:
 #    We actually limit to 40, so we don't overwhelm the number of workers.
 # 2. We have 16 queues, to allow some queues to be empty and still maintain
 #    nearly 100% cpu utilization across 40 instances.
-# 3. Some tasks are pathological, and may never complete.  Since we are
+# 3. Setting max_doublings to 0 means that backoff will increase linearly
+#    by min_backoff_seconds each retry.
+# 4. Some tasks are pathological, and may never complete.  Since we are
 #    draining queues between date submissions, we expect a day's data to
 #    complete within a few hours.  We set an expiration of 12 hours in
 #    case some task consistently fails.
@@ -100,6 +102,7 @@ queue:
     task_age_limit: 12h
     min_backoff_seconds: 30
     max_backoff_seconds: 120
+    # Setting max_doublings to 0 means that backoff will increase by min_backoff_seconds each retry.
     max_doublings: 0
 - name: etl-ndt-batch-1
   target: etl-ndt-batch-parser

--- a/appengine/queue.yaml
+++ b/appengine/queue.yaml
@@ -27,7 +27,7 @@ queue:
 # but we can run about 1200 rows/sec/table without deltas.  This unfortunately
 # means that we should update the number of concurrent requests depending on
 # whether we are doing full deltas.
-# 
+#
 # Without deltas, we are observing about 4 instance-hours / day of data for
 # mid 2017.  This means with 40 instances, we can process about 8 months/day.
 # With deltas, this slows dramatically, to about 10-15 rows/sec/instance,
@@ -37,7 +37,7 @@ queue:
 # per day, which for currentdata rates of 1 million tests per day, is
 # about 30 million rows per day, or about 350 rows/second.
 #
-# When reprocessing data older than 30 days, the pipeline inserts rows 
+# When reprocessing data older than 30 days, the pipeline inserts rows
 # into templated tables, which means there is a separate table per day.
 # So for archive reprocessing more than 30 days in the past, the BQ quota
 # ends up being rows/sec per day/date.
@@ -49,7 +49,7 @@ queue:
 # The new scraper produces about 16K tasks per day, with about 60 row inserts
 # per task.  But older archives are much larger, with perhaps 1000 to 2000 tar
 # files per day, and 600 to 1000 tests per file.
-# 
+#
 # We will limit the rate based on number of concurrent tasks, so we can
 # regulate the throughput independent of the size of the archive files.
 # With deltas, we want 200 rows/second, divided by 1.3 rows/sec per task,
@@ -71,8 +71,8 @@ queue:
 # A corresponding batch reprocessing script will use Gregorian ordinal
 # of the date, mod N, to determine which queue to drop any given date
 # into.  We just choose an appropriate N that gives us the throughput
-# we need.  For now, N=8 gives us a bit of headroom, so this config
-# sets up -0 through -7.
+# we need.  For now, N=16 gives us a bit of headroom, so this config
+# sets up -0 through -15.
 #
 # The current pipeline config has up to 40 instances with 2 cpus and
 # 12 workers each.  This could handle up to 0.9 * 40 * 12 or 432
@@ -82,49 +82,171 @@ queue:
 # SUMMARY:
 # 1. Each queue must limit concurrent requests to about 55 to limit
 #    rate into individual tables to around 200 rows/second (with deltas)
-# 2. We have 8 queues, to allow up to about 1600 rows/second, to
-#    allow 30 days of data to be processed within one day, with
+# 2. We have 16 queues, to allow up to about 1600 rows/second, across both
+#    ndt and sidestream, and allow queue draining before next submission.
+#    This should allow 30 days of data to be processed within one day, with
 #    some headroom for future growth.
+# TODO - misnomer - we are currently using these queues for sidestream as well.
 - name: etl-ndt-batch-0
   target: etl-ndt-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 55
+  max_concurrent_requests: 40
+  retry_parameters:
+    task_age_limit: 8h
+    min_backoff_seconds: 30
+    max_backoff_seconds: 120
+    max_doublings: 0
 - name: etl-ndt-batch-1
   target: etl-ndt-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 55
+  max_concurrent_requests: 40
+  retry_parameters:
+    task_age_limit: 8h
+    min_backoff_seconds: 30
+    max_backoff_seconds: 120
+    max_doublings: 0
 - name: etl-ndt-batch-2
   target: etl-ndt-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 55
+  max_concurrent_requests: 40
+  retry_parameters:
+    task_age_limit: 8h
+    min_backoff_seconds: 30
+    max_backoff_seconds: 120
+    max_doublings: 0
 - name: etl-ndt-batch-3
   target: etl-ndt-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 55
+  max_concurrent_requests: 40
+  retry_parameters:
+    task_age_limit: 8h
+    min_backoff_seconds: 30
+    max_backoff_seconds: 120
+    max_doublings: 0
 - name: etl-ndt-batch-4
   target: etl-ndt-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 55
+  max_concurrent_requests: 40
+  retry_parameters:
+    task_age_limit: 8h
+    min_backoff_seconds: 30
+    max_backoff_seconds: 120
+    max_doublings: 0
 - name: etl-ndt-batch-5
   target: etl-ndt-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 55
+  max_concurrent_requests: 40
+  retry_parameters:
+    task_age_limit: 8h
+    min_backoff_seconds: 30
+    max_backoff_seconds: 120
+    max_doublings: 0
 - name: etl-ndt-batch-6
   target: etl-ndt-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 55
+  max_concurrent_requests: 40
+  retry_parameters:
+    task_age_limit: 8h
+    min_backoff_seconds: 30
+    max_backoff_seconds: 120
+    max_doublings: 0
 - name: etl-ndt-batch-7
   target: etl-ndt-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 55
+  max_concurrent_requests: 40
+  retry_parameters:
+    task_age_limit: 8h
+    min_backoff_seconds: 30
+    max_backoff_seconds: 120
+    max_doublings: 0
+- name: etl-ndt-batch-8
+  target: etl-ndt-batch-parser
+  rate: 5/s
+  bucket_size: 10
+  max_concurrent_requests: 40
+  retry_parameters:
+    task_age_limit: 8h
+    min_backoff_seconds: 30
+    max_backoff_seconds: 120
+    max_doublings: 0
+- name: etl-ndt-batch-9
+  target: etl-ndt-batch-parser
+  rate: 5/s
+  bucket_size: 10
+  max_concurrent_requests: 40
+  retry_parameters:
+    task_age_limit: 8h
+    min_backoff_seconds: 30
+    max_backoff_seconds: 120
+    max_doublings: 0
+- name: etl-ndt-batch-10
+  target: etl-ndt-batch-parser
+  rate: 5/s
+  bucket_size: 10
+  max_concurrent_requests: 40
+  retry_parameters:
+    task_age_limit: 8h
+    min_backoff_seconds: 30
+    max_backoff_seconds: 120
+    max_doublings: 0
+- name: etl-ndt-batch-11
+  target: etl-ndt-batch-parser
+  rate: 5/s
+  bucket_size: 10
+  max_concurrent_requests: 40
+  retry_parameters:
+    task_age_limit: 8h
+    min_backoff_seconds: 30
+    max_backoff_seconds: 120
+    max_doublings: 0
+- name: etl-ndt-batch-12
+  target: etl-ndt-batch-parser
+  rate: 5/s
+  bucket_size: 10
+  max_concurrent_requests: 40
+  retry_parameters:
+    task_age_limit: 8h
+    min_backoff_seconds: 30
+    max_backoff_seconds: 120
+    max_doublings: 0
+- name: etl-ndt-batch-13
+  target: etl-ndt-batch-parser
+  rate: 5/s
+  bucket_size: 10
+  max_concurrent_requests: 40
+  retry_parameters:
+    task_age_limit: 8h
+    min_backoff_seconds: 30
+    max_backoff_seconds: 120
+    max_doublings: 0
+- name: etl-ndt-batch-14
+  target: etl-ndt-batch-parser
+  rate: 5/s
+  bucket_size: 10
+  max_concurrent_requests: 40
+  retry_parameters:
+    task_age_limit: 8h
+    min_backoff_seconds: 30
+    max_backoff_seconds: 120
+    max_doublings: 0
+- name: etl-ndt-batch-15
+  target: etl-ndt-batch-parser
+  rate: 5/s
+  bucket_size: 10
+  max_concurrent_requests: 40
+  retry_parameters:
+    task_age_limit: 8h
+    min_backoff_seconds: 30
+    max_backoff_seconds: 120
+    max_doublings: 0
 
 - name: etl-traceroute-queue
   target: etl-traceroute-parser

--- a/appengine/queue.yaml
+++ b/appengine/queue.yaml
@@ -59,7 +59,7 @@ queue:
 # Without deltas, the throughput is much higher.  We will try with the
 # same number of concurrent tasks, and adjust if needed.
 #
-# To reach the desired 350 rows/second required to process one month's
+# To reach the desired 350 NDT rows/second required to process one month's
 # data each day, we need to process at least 2 days of data in parallel.
 # The quota gaurantee comes from putting any one day's data into a single
 # task queue, and the desired aggregate throughput can be achieved by
@@ -67,33 +67,37 @@ queue:
 # queues.
 #
 # To make things conceptually simple, we will just create queues with
-# suffixes like -0, -1, -2 ...
-# A corresponding batch reprocessing script will use Gregorian ordinal
-# of the date, mod N, to determine which queue to drop any given date
-# into.  We just choose an appropriate N that gives us the throughput
-# we need.  For now, N=16 gives us a bit of headroom, so this config
-# sets up -0 through -15.
+# suffixes like -0, -1, -2 ...  Tasks for each date will be submitted
+# to a single queue, and each queue will be fully drained before
+# submitting a new day's tasks.
+# For now, N=16 gives us a bit of headroom, so this config sets up -0 through -15.
 #
 # The current pipeline config has up to 40 instances with 2 cpus and
-# 12 workers each.  This could handle up to 0.9 * 40 * 12 or 432
+# 15 workers each.  This could handle about 0.9 * 40 * 15 or 560
 # concurrent tasks, which is well in excess of what we currently need.
 # Some adjustments may be needed once this is running regularly.
 #
 # SUMMARY:
 # 1. Each queue must limit concurrent requests to about 55 to limit
-#    rate into individual tables to around 200 rows/second (with deltas)
-# 2. We have 16 queues, to allow up to about 1600 rows/second, across both
-#    ndt and sidestream, and allow queue draining before next submission.
-#    This should allow 30 days of data to be processed within one day, with
-#    some headroom for future growth.
+#    rate into individual tables to around 200 rows/second (with deltas).
+#    We actually limit to 40, so we don't overwhelm the number of workers.
+# 2. We have 16 queues, to allow some queues to be empty and still maintain
+#    nearly 100% cpu utilization across 40 instances.
+# 3. Some tasks are pathological, and may never complete.  Since we are
+#    draining queues between date submissions, we expect a day's data to
+#    complete within a few hours.  We set an expiration of 12 hours in
+#    case some task consistently fails.
+#    TODO - should check into whether limiting retries would be better.
+#
 # TODO - misnomer - we are currently using these queues for sidestream as well.
+#   should rename these to just etl-batch-*
 - name: etl-ndt-batch-0
   target: etl-ndt-batch-parser
   rate: 5/s
   bucket_size: 10
   max_concurrent_requests: 40
   retry_parameters:
-    task_age_limit: 8h
+    task_age_limit: 12h
     min_backoff_seconds: 30
     max_backoff_seconds: 120
     max_doublings: 0
@@ -103,7 +107,7 @@ queue:
   bucket_size: 10
   max_concurrent_requests: 40
   retry_parameters:
-    task_age_limit: 8h
+    task_age_limit: 12h
     min_backoff_seconds: 30
     max_backoff_seconds: 120
     max_doublings: 0
@@ -113,7 +117,7 @@ queue:
   bucket_size: 10
   max_concurrent_requests: 40
   retry_parameters:
-    task_age_limit: 8h
+    task_age_limit: 12h
     min_backoff_seconds: 30
     max_backoff_seconds: 120
     max_doublings: 0
@@ -123,7 +127,7 @@ queue:
   bucket_size: 10
   max_concurrent_requests: 40
   retry_parameters:
-    task_age_limit: 8h
+    task_age_limit: 12h
     min_backoff_seconds: 30
     max_backoff_seconds: 120
     max_doublings: 0
@@ -133,7 +137,7 @@ queue:
   bucket_size: 10
   max_concurrent_requests: 40
   retry_parameters:
-    task_age_limit: 8h
+    task_age_limit: 12h
     min_backoff_seconds: 30
     max_backoff_seconds: 120
     max_doublings: 0
@@ -143,7 +147,7 @@ queue:
   bucket_size: 10
   max_concurrent_requests: 40
   retry_parameters:
-    task_age_limit: 8h
+    task_age_limit: 12h
     min_backoff_seconds: 30
     max_backoff_seconds: 120
     max_doublings: 0
@@ -153,7 +157,7 @@ queue:
   bucket_size: 10
   max_concurrent_requests: 40
   retry_parameters:
-    task_age_limit: 8h
+    task_age_limit: 12h
     min_backoff_seconds: 30
     max_backoff_seconds: 120
     max_doublings: 0
@@ -163,7 +167,7 @@ queue:
   bucket_size: 10
   max_concurrent_requests: 40
   retry_parameters:
-    task_age_limit: 8h
+    task_age_limit: 12h
     min_backoff_seconds: 30
     max_backoff_seconds: 120
     max_doublings: 0
@@ -173,7 +177,7 @@ queue:
   bucket_size: 10
   max_concurrent_requests: 40
   retry_parameters:
-    task_age_limit: 8h
+    task_age_limit: 12h
     min_backoff_seconds: 30
     max_backoff_seconds: 120
     max_doublings: 0
@@ -183,7 +187,7 @@ queue:
   bucket_size: 10
   max_concurrent_requests: 40
   retry_parameters:
-    task_age_limit: 8h
+    task_age_limit: 12h
     min_backoff_seconds: 30
     max_backoff_seconds: 120
     max_doublings: 0
@@ -193,7 +197,7 @@ queue:
   bucket_size: 10
   max_concurrent_requests: 40
   retry_parameters:
-    task_age_limit: 8h
+    task_age_limit: 12h
     min_backoff_seconds: 30
     max_backoff_seconds: 120
     max_doublings: 0
@@ -203,7 +207,7 @@ queue:
   bucket_size: 10
   max_concurrent_requests: 40
   retry_parameters:
-    task_age_limit: 8h
+    task_age_limit: 12h
     min_backoff_seconds: 30
     max_backoff_seconds: 120
     max_doublings: 0
@@ -213,7 +217,7 @@ queue:
   bucket_size: 10
   max_concurrent_requests: 40
   retry_parameters:
-    task_age_limit: 8h
+    task_age_limit: 12h
     min_backoff_seconds: 30
     max_backoff_seconds: 120
     max_doublings: 0
@@ -223,7 +227,7 @@ queue:
   bucket_size: 10
   max_concurrent_requests: 40
   retry_parameters:
-    task_age_limit: 8h
+    task_age_limit: 12h
     min_backoff_seconds: 30
     max_backoff_seconds: 120
     max_doublings: 0
@@ -233,7 +237,7 @@ queue:
   bucket_size: 10
   max_concurrent_requests: 40
   retry_parameters:
-    task_age_limit: 8h
+    task_age_limit: 12h
     min_backoff_seconds: 30
     max_backoff_seconds: 120
     max_doublings: 0
@@ -243,7 +247,7 @@ queue:
   bucket_size: 10
   max_concurrent_requests: 40
   retry_parameters:
-    task_age_limit: 8h
+    task_age_limit: 12h
     min_backoff_seconds: 30
     max_backoff_seconds: 120
     max_doublings: 0

--- a/cmd/etl_worker/app-ndt-batch.yaml
+++ b/cmd/etl_worker/app-ndt-batch.yaml
@@ -49,7 +49,7 @@ env_variables:
   COMMIT_HASH: ${TRAVIS_COMMIT}
 
   NDT_BATCH: 'true'  # Allow instances to discover they are NDT_BATCH instances.
-  MAX_WORKERS: 12
+  MAX_WORKERS: 15  # 12 is good for NDT, but 20 is good for SS.
   BIGQUERY_PROJECT: ${INJECTED_PROJECT}
   BIGQUERY_DATASET: 'batch'
   ANNOTATE_IP: 'true'


### PR DESCRIPTION
Add more batch queues.
Add retry params for batch queues to improve behavior.  Backoff causes sidestream to pulse badly.
Increase workers to 15, which is a good compromise between SS and NDT.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/485)
<!-- Reviewable:end -->
