### PR TITLE
Increment TestCount when InsertRow is successful

### DIFF
--- a/parser/disco.go
+++ b/parser/disco.go
@@ -108,13 +108,13 @@ func (dp *DiscoParser) ParseAndInsert(meta map[string]bigquery.Value, testName s
 			// TODO(dev) Should accumulate errors, instead of aborting?
 			return err
 		}
+		// Count successful inserts.
+		metrics.TestCount.WithLabelValues(dp.TableName(), "disco", "ok").Inc()
 	}
 
 	// Measure the distribution of records per file.
 	metrics.EntryFieldCountHistogram.WithLabelValues(
 		dp.TableName()).Observe(float64(rowCount))
-
-	metrics.TestCount.WithLabelValues(dp.TableName(), "disco", "ok").Inc()
 
 	return nil
 }

--- a/parser/pt.go
+++ b/parser/pt.go
@@ -209,13 +209,12 @@ func (pt *PTParser) InsertOneTest(oneTest cachedPTData) {
 				pt.TableName(), "pt", "insert-err").Inc()
 			insertErr = true
 			log.Printf("insert-err: %v\n", err)
+			// Inc TestCount only once per row.
+			metrics.TestCount.WithLabelValues(pt.TableName(), "pt", "insert-err").Inc()
+		} else {
+			// Inc TestCount on successful row insert.
+			metrics.TestCount.WithLabelValues(pt.TableName(), "pt", "ok").Inc()
 		}
-	}
-	if insertErr {
-		// Inc TestCount only once per test.
-		metrics.TestCount.WithLabelValues(pt.TableName(), "pt", "insert-err").Inc()
-	} else {
-		metrics.TestCount.WithLabelValues(pt.TableName(), "pt", "ok").Inc()
 	}
 }
 

--- a/parser/pt.go
+++ b/parser/pt.go
@@ -193,7 +193,6 @@ func (pt *PTParser) FullTableName() string {
 }
 
 func (pt *PTParser) InsertOneTest(oneTest cachedPTData) {
-	insertErr := false
 	for _, hop := range oneTest.Hops {
 		ptTest := schema.PT{
 			Test_id:              oneTest.TestID,
@@ -207,7 +206,6 @@ func (pt *PTParser) InsertOneTest(oneTest cachedPTData) {
 		if err != nil {
 			metrics.ErrorCount.WithLabelValues(
 				pt.TableName(), "pt", "insert-err").Inc()
-			insertErr = true
 			log.Printf("insert-err: %v\n", err)
 			// Inc TestCount only once per row.
 			metrics.TestCount.WithLabelValues(pt.TableName(), "pt", "insert-err").Inc()


### PR DESCRIPTION
Currently, the Sidestream and NDT parsers increment TestCount on every successful call to `InsertRow`. This change updates the paris-traceroute and disco parsers to do the same. With this change, the DailyParserVolumeTooLow alert will measure volume changes on the number of row inserts consistently across all parsers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/491)
<!-- Reviewable:end -->
