### PR TITLE
Various go vet and go fix fixes

### DIFF
--- a/annotation/geo.go
+++ b/annotation/geo.go
@@ -33,7 +33,7 @@ func getFlagValues() {
 	}
 }
 
-// For testing.
+// EnableAnnotation is used only for testing.  Should be placed in whitebox _test file.
 func EnableAnnotation() {
 	os.Setenv("ANNOTATE_IP", "True")
 	getFlagValues()
@@ -78,14 +78,17 @@ type RequestData struct {
 	Timestamp time.Time // Holds the timestamp from an incoming request
 }
 
+// AnnotatorURL holds the https address of the annotator.
 // TODO(gfr) See if there is a better way of determining
 // where to send the request (there almost certainly is)
 var AnnotatorURL = "https://annotator-dot-" +
 	os.Getenv("GCLOUD_PROJECT") +
 	".appspot.com"
 
+// BaseURL provides the base URL for single annotation requests
 var BaseURL = AnnotatorURL + "/annotate?"
 
+// BatchURL provides the base URL for batch annotation requests
 var BatchURL = AnnotatorURL + "/batch_annotate"
 
 // FetchGeoAnnotations takes a slice of strings
@@ -104,7 +107,7 @@ func FetchGeoAnnotations(ips []string, timestamp time.Time, geoDest []*Geolocati
 				Labels{"source": "Empty IP Address!!!"}).Inc()
 			continue
 		}
-		ip, _ := web100.NormalizeIPv6(ip)
+		ip, _ = web100.NormalizeIPv6(ip)
 		reqData = append(reqData, RequestData{ip, 0, timestamp})
 	}
 	annotationData := GetBatchGeoData(BatchURL, reqData)

--- a/annotation/geo.go
+++ b/annotation/geo.go
@@ -104,7 +104,7 @@ func FetchGeoAnnotations(ips []string, timestamp time.Time, geoDest []*Geolocati
 	for i := range ips {
 		if ips[i] == "" {
 			// TODO(gfr) These should be warning, else we have error > request
-			metrics.AnnotationErrorCount.With(prometheus.
+			metrics.AnnotationWarningCount.With(prometheus.
 				Labels{"source": "Empty IP Address!!!"}).Inc()
 			continue
 		}
@@ -112,6 +112,8 @@ func FetchGeoAnnotations(ips []string, timestamp time.Time, geoDest []*Geolocati
 		normalized[i], err = web100.NormalizeIPv6(ips[i])
 		if err != nil {
 			log.Println(err)
+			metrics.AnnotationWarningCount.With(prometheus.
+				Labels{"source": "NormalizeIPv6 Error"}).Inc()
 		}
 		reqData = append(reqData, RequestData{normalized[i], 0, timestamp})
 	}
@@ -121,7 +123,7 @@ func FetchGeoAnnotations(ips []string, timestamp time.Time, geoDest []*Geolocati
 		data, ok := annotationData[normalized[i]+timeString]
 		if !ok || data.Geo == nil {
 			// TODO(gfr) These should be warning, else we have error > request
-			metrics.AnnotationErrorCount.With(prometheus.
+			metrics.AnnotationWarningCount.With(prometheus.
 				Labels{"source": "Missing or empty data for IP Address!!!"}).Inc()
 			continue
 		}

--- a/annotation/geo.go
+++ b/annotation/geo.go
@@ -229,6 +229,7 @@ func GetBatchGeoData(url string, data []RequestData) map[string]GeoData {
 			Labels{"source": "Failed to parse JSON"}).Inc()
 		log.Println(err)
 		log.Printf("%+v\n", data)
+		log.Printf("%+v\n", string(annotatorResponse))
 		return nil
 	}
 	return geoDataFromResponse

--- a/annotation/geo.go
+++ b/annotation/geo.go
@@ -44,17 +44,17 @@ func EnableAnnotation() {
 // capitalized for exporting, although the originals in the DB schema
 // are not.
 type GeolocationIP struct {
-	Continent_code string  `json:"continent_code, string,omitempty"` // Gives a shorthand for the continent
-	Country_code   string  `json:"country_code, string,omitempty"`   // Gives a shorthand for the country
-	Country_code3  string  `json:"country_code3, string,omitempty"`  // Gives a shorthand for the country
-	Country_name   string  `json:"country_name, string,omitempty"`   // Name of the country
-	Region         string  `json:"region, string,omitempty"`         // Region or State within the country
-	Metro_code     int64   `json:"metro_code, integer,omitempty"`    // Metro code within the country
-	City           string  `json:"city, string,omitempty"`           // City within the region
-	Area_code      int64   `json:"area_code, integer,omitempty"`     // Area code, similar to metro code
-	Postal_code    string  `json:"postal_code, string,omitempty"`    // Postal code, again similar to metro
-	Latitude       float64 `json:"latitude, float"`                  // Latitude
-	Longitude      float64 `json:"longitude, float"`                 // Longitude
+	Continent_code string  `json:"continent_code,string,omitempty"` // Gives a shorthand for the continent
+	Country_code   string  `json:"country_code,string,omitempty"`   // Gives a shorthand for the country
+	Country_code3  string  `json:"country_code3,string,omitempty"`  // Gives a shorthand for the country
+	Country_name   string  `json:"country_name,string,omitempty"`   // Name of the country
+	Region         string  `json:"region,string,omitempty"`         // Region or State within the country
+	Metro_code     int64   `json:"metro_code,integer,omitempty"`    // Metro code within the country
+	City           string  `json:"city,string,omitempty"`           // City within the region
+	Area_code      int64   `json:"area_code,integer,omitempty"`     // Area code, similar to metro code
+	Postal_code    string  `json:"postal_code,string,omitempty"`    // Postal code, again similar to metro
+	Latitude       float64 `json:"latitude,float"`                  // Latitude
+	Longitude      float64 `json:"longitude,float"`                 // Longitude
 
 }
 

--- a/annotation/geo_test.go
+++ b/annotation/geo_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -13,6 +14,11 @@ import (
 
 	"github.com/m-lab/etl/annotation"
 )
+
+func init() {
+	// Always prepend the filename and line number.
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+}
 
 var epoch time.Time = time.Unix(0, 0)
 
@@ -45,7 +51,7 @@ func TestFetchGeoAnnotations(t *testing.T) {
 		},
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, `{"127.0.0.10" : {"Geo":{"postal_code":"10583"},"ASN":{}}`+
+		fmt.Fprint(w, `{"127.0.0.10" : {"Geo":{"postal_code":"\"10583\""},"ASN":{}}`+
 			`,"2.2.2.20" : {"Geo":null,"ASN":null}}`)
 	}))
 	for _, test := range tests {
@@ -80,7 +86,7 @@ func TestGetAndInsertGeolocationIPStruct(t *testing.T) {
 		},
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, `{"Geo":{"postal_code":"10583"},"ASN":{}}`)
+		fmt.Fprint(w, `{"Geo":{"postal_code":"\"10583\""},"ASN":{}}`)
 	}))
 	for _, test := range tests {
 		annotation.BaseURL = ts.URL + test.url

--- a/bq/insert.go
+++ b/bq/insert.go
@@ -15,6 +15,7 @@
 package bq
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"math/rand"
@@ -25,7 +26,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
-	"context"
 
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/metrics"

--- a/bq/insert.go
+++ b/bq/insert.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/metrics"

--- a/cmd/task_client/task_client.go
+++ b/cmd/task_client/task_client.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	"context"
 	"github.com/kr/pretty"
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
 	taskqueue "google.golang.org/api/taskqueue/v1beta2"
 )

--- a/etl/etl.go
+++ b/etl/etl.go
@@ -2,10 +2,10 @@
 package etl
 
 import (
+	"context"
 	"time"
 
 	"cloud.google.com/go/bigquery"
-	"context"
 )
 
 // RowStats interface defines some useful Inserter stats that will also be

--- a/etl/etl.go
+++ b/etl/etl.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // RowStats interface defines some useful Inserter stats that will also be

--- a/fake/uploader.go
+++ b/fake/uploader.go
@@ -6,6 +6,7 @@ package fake
 // are ultimately sent to the service.
 //========================================================================================
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -16,7 +17,6 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/civil"
-	"context"
 	bqv2 "google.golang.org/api/bigquery/v2"
 )
 

--- a/fake/uploader.go
+++ b/fake/uploader.go
@@ -16,7 +16,7 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/civil"
-	"golang.org/x/net/context"
+	"context"
 	bqv2 "google.golang.org/api/bigquery/v2"
 )
 

--- a/go-pre-commit
+++ b/go-pre-commit
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Intended for use with m-lab/git-hooks.
+# Clone or use submodule, and link .git/hooks to git-hooks,
+#  e.g.
+#    mv .git/hooks .git/hooks.orig
+#    ln -s ../../git-hooks .git/hooks
+#
+
+set -x
+set -u
+# travis lint -x # Already done by git-hooks/pre-commit
+
+# TODO There are still a LOT of lint warnings, so skip this for now.
+# golint ./...
+golint ./storage/... ./task/...
+
+# Shadow declarations cause a lot of bugs.  Currently clean.
+go tool vet --shadow .
+
+# These are now clean for vet
+go vet ./annotation/... ./appengine/... ./fake/... ./metrics/... ./schema/... ./task/... ./web100/...
+
+# These are currently partially clean
+go vet -assign -atomic -bool -buildtags -cgocall -copylocks -httpresponse -methods -nilfunc -printf -rangeloops -shift -structtags -tests -unreachable -unsafeptr -unusedresult ./bq/... ./etl/... ./parser/... ./storage/...
+
+# These still have failures in some package
+# go vet -composites -lostcancel ./...
+

--- a/parser/geo_annotation.go
+++ b/parser/geo_annotation.go
@@ -230,14 +230,14 @@ func GetAndInsertTwoSidedGeoIntoNDTConnSpec(spec schema.Web100ValueMap, timestam
 	sip, sok := spec.GetString([]string{"server_ip"})
 	reqData := []annotation.RequestData{}
 	if cok {
-		cip, _ := web100.NormalizeIPv6(cip)
+		cip, _ = web100.NormalizeIPv6(cip)
 		reqData = append(reqData, annotation.RequestData{IP: cip, Timestamp: timestamp})
 	} else {
 		metrics.AnnotationWarningCount.With(prometheus.
 			Labels{"source": "Missing client side IP."}).Inc()
 	}
 	if sok {
-		sip, _ := web100.NormalizeIPv6(sip)
+		sip, _ = web100.NormalizeIPv6(sip)
 		reqData = append(reqData, annotation.RequestData{IP: sip, Timestamp: timestamp})
 	} else {
 		metrics.AnnotationWarningCount.With(prometheus.

--- a/parser/geo_annotation_test.go
+++ b/parser/geo_annotation_test.go
@@ -63,8 +63,8 @@ func TestAddGeoDataSSConnSpec(t *testing.T) {
 		},
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, `{"127.0.0.10" : {"Geo":{"postal_code":"10583"},"ASN":{}}`+
-			`,"127.0.0.20" : {"Geo":{"postal_code":"10584"},"ASN":{}}}`)
+		fmt.Fprint(w, `{"127.0.0.10" : {"Geo":{"postal_code":"\"10583\""},"ASN":{}}`+
+			`,"127.0.0.20" : {"Geo":{"postal_code":"\"10584\""},"ASN":{}}}`)
 	}))
 	for _, test := range tests {
 		annotation.BatchURL = ts.URL + test.url
@@ -119,8 +119,8 @@ func TestAddGeoDataPTConnSpec(t *testing.T) {
 		},
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, `{"127.0.0.10" : {"Geo":{"postal_code":"10583"},"ASN":{}}`+
-			`,"127.0.0.20" : {"Geo":{"postal_code":"10584"},"ASN":{}}}`)
+		fmt.Fprint(w, `{"127.0.0.10" : {"Geo":{"postal_code":"\"10583\""},"ASN":{}}`+
+			`,"127.0.0.20" : {"Geo":{"postal_code":"\"10584\""},"ASN":{}}}`)
 	}))
 	for _, test := range tests {
 		annotation.BatchURL = ts.URL + test.url
@@ -194,16 +194,16 @@ func TestAddGeoDataPTHopBatch(t *testing.T) {
 			res: []*schema.ParisTracerouteHop{
 				&schema.ParisTracerouteHop{
 					Src_ip:           "127.0.0.1",
-					Src_geolocation:  annotation.GeolocationIP{Area_code: 10583},
+					Src_geolocation:  annotation.GeolocationIP{Area_code: 914},
 					Dest_ip:          "1.0.0.127",
-					Dest_geolocation: annotation.GeolocationIP{Area_code: 10584},
+					Dest_geolocation: annotation.GeolocationIP{Area_code: 212},
 				},
 			},
 		},
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, `{"127.0.0.10" : {"Geo":{"area_code":10583},"ASN":{}}`+
-			`,"1.0.0.1270" : {"Geo":{"area_code":10584},"ASN":{}}}`)
+		fmt.Fprint(w, `{"127.0.0.10" : {"Geo":{"area_code":914},"ASN":{}}`+
+			`,"1.0.0.1270" : {"Geo":{"area_code":212},"ASN":{}}}`)
 	}))
 	for _, test := range tests {
 		annotation.BatchURL = ts.URL + test.url
@@ -333,7 +333,7 @@ func TestAddGeoDataPTHop(t *testing.T) {
 		},
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, `{"Geo":{"postal_code":"10583"},"ASN":{}}`)
+		fmt.Fprint(w, `{"Geo":{"postal_code":"\"10583\""},"ASN":{}}`)
 	}))
 	for _, test := range tests {
 		annotation.BaseURL = ts.URL + test.url
@@ -435,8 +435,8 @@ func TestDisabledAnnotation(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callCount += 1
 		// Note: the "h3d0c0" in the IP strings is the appended timestamp.
-		fmt.Fprint(w, `{"127.0.0.1h3d0c0" : {"Geo":{"continent_code":"","country_code":"US","country_code3":"USA","country_name":"United States of America","region":"NY","metro_code":0,"city":"Scarsdale","area_code":10583,"postal_code":"10583","latitude":41.0051,"longitude":73.7846},"ASN":{}}`+
-			`,"1.0.0.127h3d0c0" : {"Geo":{"continent_code":"","country_code":"US","country_code3":"USA","country_name":"United States of America","region":"NY","metro_code":0,"city":"Scarsdale","area_code":10584,"postal_code":"10584","latitude":41.0051,"longitude":73.7846},"ASN":{}}}`)
+		fmt.Fprint(w, `{"127.0.0.1h3d0c0" : {"Geo":{"continent_code":"\"\"","country_code":"\"US\"","country_code3":"USA","country_name":"\"United States of America\"","region":"\"NY\"","metro_code":0,"city":"\"Scarsdale\"","area_code":914,"postal_code":"\"10583\"","latitude":41.0051,"longitude":73.7846},"ASN":{}}`+
+			`,"1.0.0.127h3d0c0" : {"Geo":{"continent_code":"\"\"","country_code":"\"US\"","country_code3":"USA","country_name":"\"United States of America\"","region":"\"NY\"","metro_code":0,"city":"\"Scarsdale\"","area_code":212,"postal_code":"\"10584\"","latitude":41.0051,"longitude":73.7846},"ASN":{}}}`)
 	}))
 	for _, test := range tests {
 		annotation.BatchURL = ts.URL + test.url
@@ -451,8 +451,8 @@ func TestAddGeoDataNDTConnSpec(t *testing.T) {
 	annotation.EnableAnnotation()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Note: the "h3d0c0" in the IP strings is the appended timestamp.
-		fmt.Fprint(w, `{"127.0.0.1h3d0c0" : {"Geo":{"continent_code":"","country_code":"US","country_code3":"USA","country_name":"United States of America","region":"NY","metro_code":0,"city":"Scarsdale","area_code":10583,"postal_code":"10583","latitude":41.0051,"longitude":73.7846},"ASN":{}}`+
-			`,"1.0.0.127h3d0c0" : {"Geo":{"continent_code":"","country_code":"US","country_code3":"USA","country_name":"United States of America","region":"NY","metro_code":0,"city":"Scarsdale","area_code":10584,"postal_code":"10584","latitude":41.0051,"longitude":73.7846},"ASN":{}}}`)
+		fmt.Fprint(w, `{"127.0.0.1h3d0c0" : {"Geo":{"continent_code":"\"\"","country_code":"\"US\"","country_code3":"\"USA\"","country_name":"\"United States of America\"","region":"\"NY\"","metro_code":0,"city":"\"Scarsdale\"","area_code":10583,"postal_code":"\"10583\"","latitude":41.0051,"longitude":73.7846},"ASN":{}}`+
+			`,"1.0.0.127h3d0c0" : {"Geo":{"continent_code":"\"\"","country_code":"\"US\"","country_code3":"\"USA\"","country_name":"\"United States of America\"","region":"\"NY\"","metro_code":0,"city":"\"Scarsdale\"","area_code":10584,"postal_code":"\"10584\"","latitude":41.0051,"longitude":73.7846},"ASN":{}}}`)
 	}))
 	for _, test := range tests {
 		annotation.BatchURL = ts.URL + test.url
@@ -546,8 +546,8 @@ func TestGetAndInsertTwoSidedGeoIntoNDTConnSpec(t *testing.T) {
 		},
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, `{"127.0.0.1h3d0c0" : {"Geo":{"continent_code":"","country_code":"US","country_code3":"USA","country_name":"United States of America","region":"NY","metro_code":0,"city":"Scarsdale","area_code":10583,"postal_code":"10583","latitude":41.0051,"longitude":73.7846},"ASN":{}}`+
-			`,"1.0.0.127h3d0c0" : {"Geo":{"continent_code":"","country_code":"US","country_code3":"USA","country_name":"United States of America","region":"NY","metro_code":0,"city":"Scarsdale","area_code":10584,"postal_code":"10584","latitude":41.0051,"longitude":73.7846},"ASN":{}}}`)
+		fmt.Fprint(w, `{"127.0.0.1h3d0c0" : {"Geo":{"continent_code":"\"\"","country_code":"\"US\"","country_code3":"\"USA\"","country_name":"\"United States of America\"","region":"\"NY\"","metro_code":0,"city":"\"Scarsdale\"","area_code":10583,"postal_code":"\"10583\"","latitude":41.0051,"longitude":73.7846},"ASN":{}}`+
+			`,"1.0.0.127h3d0c0" : {"Geo":{"continent_code":"\"\"","country_code":"\"US\"","country_code3":"\"USA\"","country_name":"\"United States of America\"","region":"\"NY\"","metro_code":0,"city":"\"Scarsdale\"","area_code":10584,"postal_code":"\"10584\"","latitude":41.0051,"longitude":73.7846},"ASN":{}}}`)
 	}))
 	for _, test := range tests {
 		annotation.BatchURL = ts.URL + test.url

--- a/parser/geo_annotation_test.go
+++ b/parser/geo_annotation_test.go
@@ -345,6 +345,7 @@ func TestAddGeoDataPTHop(t *testing.T) {
 }
 
 func testTime() time.Time {
+	// Note: this timestamp corresponds to the "h3d0c0" in the result strings.
 	tst, _ := time.Parse(time.RFC3339, "2002-10-02T15:00:00Z")
 	return tst
 }
@@ -433,7 +434,7 @@ func TestDisabledAnnotation(t *testing.T) {
 	callCount := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callCount += 1
-		// TODO Why do these have "h3d0c0" in the IP strings?
+		// Note: the "h3d0c0" in the IP strings is the appended timestamp.
 		fmt.Fprint(w, `{"127.0.0.1h3d0c0" : {"Geo":{"continent_code":"","country_code":"US","country_code3":"USA","country_name":"United States of America","region":"NY","metro_code":0,"city":"Scarsdale","area_code":10583,"postal_code":"10583","latitude":41.0051,"longitude":73.7846},"ASN":{}}`+
 			`,"1.0.0.127h3d0c0" : {"Geo":{"continent_code":"","country_code":"US","country_code3":"USA","country_name":"United States of America","region":"NY","metro_code":0,"city":"Scarsdale","area_code":10584,"postal_code":"10584","latitude":41.0051,"longitude":73.7846},"ASN":{}}}`)
 	}))
@@ -449,7 +450,7 @@ func TestDisabledAnnotation(t *testing.T) {
 func TestAddGeoDataNDTConnSpec(t *testing.T) {
 	annotation.EnableAnnotation()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// TODO Why do these have "h3d0c0" in the IP strings?
+		// Note: the "h3d0c0" in the IP strings is the appended timestamp.
 		fmt.Fprint(w, `{"127.0.0.1h3d0c0" : {"Geo":{"continent_code":"","country_code":"US","country_code3":"USA","country_name":"United States of America","region":"NY","metro_code":0,"city":"Scarsdale","area_code":10583,"postal_code":"10583","latitude":41.0051,"longitude":73.7846},"ASN":{}}`+
 			`,"1.0.0.127h3d0c0" : {"Geo":{"continent_code":"","country_code":"US","country_code3":"USA","country_name":"United States of America","region":"NY","metro_code":0,"city":"Scarsdale","area_code":10584,"postal_code":"10584","latitude":41.0051,"longitude":73.7846},"ASN":{}}}`)
 	}))

--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -524,9 +524,9 @@ func (n *NDTParser) getAndInsertValues(test *fileInfoAndData, testType string) {
 		// This is not terribly useful as is.  Intended as a place holder for code
 		// we are working on in parallel.
 		congEvents := make(schema.Web100ValueMap, 10)
-		snapNums, err := snaplog.ChangeIndices("SmoothedRTT")
-		if err != nil {
-			log.Println(err)
+		snapNums, snapErr := snaplog.ChangeIndices("SmoothedRTT")
+		if snapErr != nil {
+			log.Println(snapErr)
 		} else {
 			congEvents["indices"] = snapNums
 			congEvents["smoothedRTT"] = snaplog.SliceIntField("SmoothedRTT", snapNums)

--- a/parser/pt.go
+++ b/parser/pt.go
@@ -461,7 +461,7 @@ func Parse(meta map[string]bigquery.Value, testName string, testId string, rawCo
 	lastValidHopLine := ""
 	reachedDest := false
 	for _, oneLine := range strings.Split(string(rawContent[:]), "\n") {
-		oneLine := strings.TrimSuffix(oneLine, "\n")
+		oneLine = strings.TrimSuffix(oneLine, "\n")
 		// Skip empty line or initial lines starting with #.
 		if len(oneLine) == 0 || oneLine[0] == '#' {
 			continue

--- a/parser/ss.go
+++ b/parser/ss.go
@@ -234,7 +234,7 @@ func (ss *SSParser) ParseAndInsert(meta map[string]bigquery.Value, testName stri
 		return err
 	}
 	for _, oneLine := range testContent[1:] {
-		oneLine := strings.TrimSuffix(oneLine, "\n")
+		oneLine = strings.TrimSuffix(oneLine, "\n")
 
 		if len(oneLine) == 0 {
 			continue

--- a/schema/pt_schema.go
+++ b/schema/pt_schema.go
@@ -6,33 +6,33 @@ import "github.com/m-lab/etl/annotation"
 // TODO(dev): use mixed case Go variable names throughout
 
 type ParisTracerouteHop struct {
-	Protocol         string                   `json:"protocal, string"`
-	Src_ip           string                   `json:"src_ip, string"`
-	Src_af           int32                    `json:"src_af, int32"`
-	Dest_ip          string                   `json:"dest_ip, string"`
-	Dest_af          int32                    `json:"dest_af, int32"`
-	Src_hostname     string                   `json:"src_hostname, string"`
-	Dest_hostname    string                   `json:"dest_hostname, string"`
-	Rtt              []float64                `json:"rtt, []float64"`
+	Protocol         string                   `json:"protocal,string"`
+	Src_ip           string                   `json:"src_ip,string"`
+	Src_af           int32                    `json:"src_af,int32"`
+	Dest_ip          string                   `json:"dest_ip,string"`
+	Dest_af          int32                    `json:"dest_af,int32"`
+	Src_hostname     string                   `json:"src_hostname,string"`
+	Dest_hostname    string                   `json:"dest_hostname,string"`
+	Rtt              []float64                `json:"rtt,[]float64"`
 	Src_geolocation  annotation.GeolocationIP `json:"src_geolocation"`
 	Dest_geolocation annotation.GeolocationIP `json:"dest_geolocation"`
 }
 
 type MLabConnectionSpecification struct {
-	Server_ip          string                   `json:"server_ip, string"`
-	Server_af          int32                    `json:"server_af, int32"`
-	Client_ip          string                   `json:"client_ip, string"`
-	Client_af          int32                    `json:"client_af, int32"`
-	Data_direction     int32                    `json:"data_direction, int32"`
+	Server_ip          string                   `json:"server_ip,string"`
+	Server_af          int32                    `json:"server_af,int32"`
+	Client_ip          string                   `json:"client_ip,string"`
+	Client_af          int32                    `json:"client_af,int32"`
+	Data_direction     int32                    `json:"data_direction,int32"`
 	Server_geolocation annotation.GeolocationIP `json:"server_geolocation"`
 	Client_geolocation annotation.GeolocationIP `json:"client_geolocation"`
 }
 
 type PT struct {
-	Test_id              string                      `json:"test_id, string"`
-	Project              int32                       `json:"project, int32"`
-	Log_time             int64                       `json:"log_time, int64"`
+	Test_id              string                      `json:"test_id,string"`
+	Project              int32                       `json:"project,int32"`
+	Log_time             int64                       `json:"log_time,int64"`
 	Connection_spec      MLabConnectionSpecification `json:"connection_spec"`
 	Paris_traceroute_hop ParisTracerouteHop          `json:"paris_traceroute_hop"`
-	Type                 int32                       `json:"type, int32"`
+	Type                 int32                       `json:"type,int32"`
 }

--- a/schema/ss_schema.go
+++ b/schema/ss_schema.go
@@ -5,180 +5,180 @@ package schema
 import "github.com/m-lab/etl/annotation"
 
 type Web100ConnectionSpecification struct {
-	Local_ip           string                   `json:"local_ip, string"`
-	Local_af           int64                    `json:"local_af, int64"`
-	Local_port         int64                    `json:"local_port, int64"`
-	Remote_ip          string                   `json:"remote_ip, string"`
-	Remote_port        int64                    `json:"remote_port, int64"`
+	Local_ip           string                   `json:"local_ip,string"`
+	Local_af           int64                    `json:"local_af,int64"`
+	Local_port         int64                    `json:"local_port,int64"`
+	Remote_ip          string                   `json:"remote_ip,string"`
+	Remote_port        int64                    `json:"remote_port,int64"`
 	Local_geolocation  annotation.GeolocationIP `json:"local_geolocation"`
 	Remote_geolocation annotation.GeolocationIP `json:"remote_geolocation"`
 }
 
 type Web100Snap struct {
-	AbruptTimeouts       int64  `json:"AbruptTimeouts, int64"`
-	ActiveOpen           int64  `json:"ActiveOpen, int64"`
-	CERcvd               int64  `json:"CERcvd, int64"`
-	CongAvoid            int64  `json:"CongAvoid, int64"`
-	CongOverCount        int64  `json:"CongOverCount, int64"`
-	CongSignals          int64  `json:"CongSignals, int64"`
-	CountRTT             int64  `json:"CountRTT, int64"`
-	CurAppRQueue         int64  `json:"CurAppRQueue, int64"`
-	CurAppWQueue         int64  `json:"CurAppWQueue, int64"`
-	CurCwnd              int64  `json:"CurCwnd, int64"`
-	CurMSS               int64  `json:"CurMSS, int64"`
-	CurRTO               int64  `json:"CurRTO, int64"`
-	CurReasmQueue        int64  `json:"CurReasmQueue, int64"`
-	CurRetxQueue         int64  `json:"CurRetxQueue, int64"`
-	CurRwinRcvd          int64  `json:"CurRwinRcvd, int64"`
-	CurRwinSent          int64  `json:"CurRwinSent, int64"`
-	CurSsthresh          int64  `json:"CurSsthresh, int64"`
-	CurTimeoutCount      int64  `json:"CurTimeoutCount, int64"`
-	DSACKDups            int64  `json:"DSACKDups, int64"`
-	DataOctetsIn         int64  `json:"DataOctetsIn, int64"`
-	DataOctetsOut        int64  `json:"DataOctetsOut, int64"`
-	DataSegsIn           int64  `json:"DataSegsIn, int64"`
-	DataSegsOut          int64  `json:"DataSegsOut, int64"`
-	DupAckEpisodes       int64  `json:"DupAckEpisodes, int64"`
-	DupAcksIn            int64  `json:"DupAcksIn, int64"`
-	DupAcksOut           int64  `json:"DupAcksOut, int64"`
-	Duration             int64  `json:"Duration, int64"`
-	ECESent              int64  `json:"ECESent, int64"`
-	ECN                  int64  `json:"ECN, int64"`
-	ECNNonceRcvd         int64  `json:"ECNNonceRcvd, int64"`
-	ECNsignals           int64  `json:"ECNsignals, int64"`
-	ElapsedMicroSecs     int64  `json:"ElapsedMicroSecs, int64"`
-	ElapsedSecs          int64  `json:"ElapsedSecs, int64"`
-	FastRetran           int64  `json:"FastRetran, int64"`
-	HCDataOctetsIn       int64  `json:"HCDataOctetsIn, int64"`
-	HCDataOctetsOut      int64  `json:"HCDataOctetsOut, int64"`
-	HCSumRTT             int64  `json:"HCSumRTT, int64"`
-	HCThruOctetsAcked    int64  `json:"HCThruOctetsAcked, int64"`
-	HCThruOctetsReceived int64  `json:"HCThruOctetsReceived, int64"`
-	InRecovery           int64  `json:"InRecovery, int64"`
-	IpTosIn              int64  `json:"IpTosIn, int64"`
-	IpTosOut             int64  `json:"IpTosOut, int64"`
-	IpTtl                int64  `json:"IpTtl, int64"`
-	LimCwnd              int64  `json:"LimCwnd, int64"`
-	LimMSS               int64  `json:"LimMSS, int64"`
-	LimRwin              int64  `json:"LimRwin, int64"`
-	LimSsthresh          int64  `json:"LimSsthresh, int64"`
-	LocalAddress         string `json:"LocalAddress, string"`
-	LocalAddressType     int64  `json:"LocalAddressType, int64"`
-	LocalPort            int64  `json:"LocalPort, int64"`
-	MSSRcvd              int64  `json:"MSSRcvd, int64"`
-	MSSSent              int64  `json:"MSSSent, int64"`
-	MaxAppRQueue         int64  `json:"MaxAppRQueue, int64"`
-	MaxAppWQueue         int64  `json:"MaxAppWQueue, int64"`
-	MaxCaCwnd            int64  `json:"MaxCaCwnd, int64"`
-	MaxMSS               int64  `json:"MaxMSS, int64"`
-	MaxPipeSize          int64  `json:"MaxPipeSize, int64"`
-	MaxRTO               int64  `json:"MaxRTO, int64"`
-	MaxRTT               int64  `json:"MaxRTT, int64"`
-	MaxReasmQueue        int64  `json:"MaxReasmQueue, int64"`
-	MaxRetxQueue         int64  `json:"MaxRetxQueue, int64"`
-	MaxRwinRcvd          int64  `json:"MaxRwinRcvd, int64"`
-	MaxRwinSent          int64  `json:"MaxRwinSent, int64"`
-	MaxSsCwnd            int64  `json:"MaxSsCwnd, int64"`
-	MaxSsthresh          int64  `json:"MaxSsthresh, int64"`
-	MinMSS               int64  `json:"MinMSS, int64"`
-	MinRTO               int64  `json:"MinRTO, int64"`
-	MinRTT               int64  `json:"MinRTT, int64"`
-	MinRwinRcvd          int64  `json:"MinRwinRcvd, int64"`
-	MinRwinSent          int64  `json:"MinRwinSent, int64"`
-	MinSsthresh          int64  `json:"MinSsthresh, int64"`
-	Nagle                int64  `json:"Nagle, int64"`
-	NonRecovDA           int64  `json:"NonRecovDA, int64"`
-	NonRecovDAEpisodes   int64  `json:"NonRecovDAEpisodes, int64"`
-	OctetsRetrans        int64  `json:"OctetsRetrans, int64"`
-	OtherReductions      int64  `json:"OtherReductions, int64"`
-	PipeSize             int64  `json:"PipeSize, int64"`
-	PostCongCountRTT     int64  `json:"PostCongCountRTT, int64"`
-	PostCongSumRTT       int64  `json:"PostCongSumRTT, int64"`
-	PreCongSumCwnd       int64  `json:"PreCongSumCwnd, int64"`
-	PreCongSumRTT        int64  `json:"PreCongSumRTT, int64"`
-	QuenchRcvd           int64  `json:"QuenchRcvd, int64"`
-	RTTVar               int64  `json:"RTTVar, int64"`
-	RcvNxt               int64  `json:"RcvNxt, int64"`
-	RcvRTT               int64  `json:"RcvRTT, int64"`
-	RcvWindScale         int64  `json:"RcvWindScale, int64"`
-	RecInitial           int64  `json:"RecInitial, int64"`
-	RemAddress           string `json:"RemAddress, string"`
-	RemPort              int64  `json:"RemPort, int64"`
-	RetranThresh         int64  `json:"RetranThresh, int64"`
-	SACK                 int64  `json:"SACK, int64"`
-	SACKBlocksRcvd       int64  `json:"SACKBlocksRcvd, int64"`
-	SACKsRcvd            int64  `json:"SACKsRcvd, int64"`
-	SampleRTT            int64  `json:"SampleRTT, int64"`
-	SegsIn               int64  `json:"SegsIn, int64"`
-	SegsOut              int64  `json:"SegsOut, int64"`
-	SegsRetrans          int64  `json:"SegsRetrans, int64"`
-	SendStall            int64  `json:"SendStall, int64"`
-	SlowStart            int64  `json:"SlowStart, int64"`
-	SmoothedRTT          int64  `json:"SmoothedRTT, int64"`
-	SndInitial           int64  `json:"SndInitial, int64"`
-	SndLimBytesCwnd      int64  `json:"SndLimBytesCwnd, int64"`
-	SndLimBytesRwin      int64  `json:"SndLimBytesRwin, int64"`
-	SndLimBytesSender    int64  `json:"SndLimBytesSender, int64"`
-	SndLimTimeCwnd       int64  `json:"SndLimTimeCwnd, int64"`
-	SndLimTimeRwin       int64  `json:"SndLimTimeRwin, int64"`
-	SndLimTimeSnd        int64  `json:"SndLimTimeSnd, int64"`
-	SndLimTransCwnd      int64  `json:"SndLimTransCwnd, int64"`
-	SndLimTransRwin      int64  `json:"SndLimTransRwin, int64"`
-	SndLimTransSnd       int64  `json:"SndLimTransSnd, int64"`
-	SndMax               int64  `json:"SndMax, int64"`
-	SndNxt               int64  `json:"SndNxt, int64"`
-	SndUna               int64  `json:"SndUna, int64"`
-	SndWindScale         int64  `json:"SndWindScale, int64"`
-	SoftErrorReason      int64  `json:"SoftErrorReason, int64"`
-	SoftErrors           int64  `json:"SoftErrors, int64"`
-	SpuriousFrDetected   int64  `json:"SpuriousFrDetected, int64"`
-	SpuriousRtoDetected  int64  `json:"SpuriousRtoDetected, int64"`
-	StartTimeStamp       int64  `json:"StartTimeStamp, int64"`
-	State                int64  `json:"State, int64"`
-	SubsequentTimeouts   int64  `json:"SubsequentTimeouts, int64"`
-	SumOctetsReordered   int64  `json:"SumOctetsReordered, int64"`
-	SumRTT               int64  `json:"SumRTT, int64"`
-	ThruOctetsAcked      int64  `json:"ThruOctetsAcked, int64"`
-	ThruOctetsReceived   int64  `json:"ThruOctetsReceived, int64"`
-	TimeStamps           int64  `json:"TimeStamps, int64"`
-	TimeStampRcvd        bool   `json:"TimeStampRcvd, bool"`
-	TimeStampSent        bool   `json:"TimeStampSent, bool"`
-	Timeouts             int64  `json:"Timeouts, int64"`
-	WAD_CwndAdjust       int64  `json:"WAD_CwndAdjust, int64"`
-	WAD_IFQ              int64  `json:"WAD_IFQ, int64"`
-	WAD_MaxBurst         int64  `json:"WAD_MaxBurst, int64"`
-	WAD_MaxSsthresh      int64  `json:"WAD_MaxSsthresh, int64"`
-	WAD_NoAI             int64  `json:"WAD_NoAI, int64"`
-	WillSendSACK         int64  `json:"WillSendSACK, int64"`
-	WillUseSACK          int64  `json:"WillUseSACK, int64"`
-	WinScaleRcvd         int64  `json:"WinScaleRcvd, int64"`
-	WinScaleSent         int64  `json:"WinScaleSent, int64"`
-	X_OtherReductionsCM  int64  `json:"X_OtherReductionsCM, int64"`
-	X_OtherReductionsCV  int64  `json:"X_OtherReductionsCV, int64"`
-	X_Rcvbuf             int64  `json:"X_Rcvbuf, int64"`
-	X_Sndbuf             int64  `json:"X_Sndbuf, int64"`
-	X_dbg1               int64  `json:"X_dbg1, int64"`
-	X_dbg2               int64  `json:"X_dbg2, int64"`
-	X_dbg3               int64  `json:"X_dbg3, int64"`
-	X_dbg4               int64  `json:"X_dbg4, int64"`
-	X_rcv_ssthresh       int64  `json:"X_rcv_ssthresh, int64"`
-	X_wnd_clamp          int64  `json:"X_wnd_clamp, int64"`
-	ZeroRwinRcvd         int64  `json:"ZeroRwinRcvd, int64"`
-	ZeroRwinSent         int64  `json:"ZeroRwinSent, int64"`
+	AbruptTimeouts       int64  `json:"AbruptTimeouts,int64"`
+	ActiveOpen           int64  `json:"ActiveOpen,int64"`
+	CERcvd               int64  `json:"CERcvd,int64"`
+	CongAvoid            int64  `json:"CongAvoid,int64"`
+	CongOverCount        int64  `json:"CongOverCount,int64"`
+	CongSignals          int64  `json:"CongSignals,int64"`
+	CountRTT             int64  `json:"CountRTT,int64"`
+	CurAppRQueue         int64  `json:"CurAppRQueue,int64"`
+	CurAppWQueue         int64  `json:"CurAppWQueue,int64"`
+	CurCwnd              int64  `json:"CurCwnd,int64"`
+	CurMSS               int64  `json:"CurMSS,int64"`
+	CurRTO               int64  `json:"CurRTO,int64"`
+	CurReasmQueue        int64  `json:"CurReasmQueue,int64"`
+	CurRetxQueue         int64  `json:"CurRetxQueue,int64"`
+	CurRwinRcvd          int64  `json:"CurRwinRcvd,int64"`
+	CurRwinSent          int64  `json:"CurRwinSent,int64"`
+	CurSsthresh          int64  `json:"CurSsthresh,int64"`
+	CurTimeoutCount      int64  `json:"CurTimeoutCount,int64"`
+	DSACKDups            int64  `json:"DSACKDups,int64"`
+	DataOctetsIn         int64  `json:"DataOctetsIn,int64"`
+	DataOctetsOut        int64  `json:"DataOctetsOut,int64"`
+	DataSegsIn           int64  `json:"DataSegsIn,int64"`
+	DataSegsOut          int64  `json:"DataSegsOut,int64"`
+	DupAckEpisodes       int64  `json:"DupAckEpisodes,int64"`
+	DupAcksIn            int64  `json:"DupAcksIn,int64"`
+	DupAcksOut           int64  `json:"DupAcksOut,int64"`
+	Duration             int64  `json:"Duration,int64"`
+	ECESent              int64  `json:"ECESent,int64"`
+	ECN                  int64  `json:"ECN,int64"`
+	ECNNonceRcvd         int64  `json:"ECNNonceRcvd,int64"`
+	ECNsignals           int64  `json:"ECNsignals,int64"`
+	ElapsedMicroSecs     int64  `json:"ElapsedMicroSecs,int64"`
+	ElapsedSecs          int64  `json:"ElapsedSecs,int64"`
+	FastRetran           int64  `json:"FastRetran,int64"`
+	HCDataOctetsIn       int64  `json:"HCDataOctetsIn,int64"`
+	HCDataOctetsOut      int64  `json:"HCDataOctetsOut,int64"`
+	HCSumRTT             int64  `json:"HCSumRTT,int64"`
+	HCThruOctetsAcked    int64  `json:"HCThruOctetsAcked,int64"`
+	HCThruOctetsReceived int64  `json:"HCThruOctetsReceived,int64"`
+	InRecovery           int64  `json:"InRecovery,int64"`
+	IpTosIn              int64  `json:"IpTosIn,int64"`
+	IpTosOut             int64  `json:"IpTosOut,int64"`
+	IpTtl                int64  `json:"IpTtl,int64"`
+	LimCwnd              int64  `json:"LimCwnd,int64"`
+	LimMSS               int64  `json:"LimMSS,int64"`
+	LimRwin              int64  `json:"LimRwin,int64"`
+	LimSsthresh          int64  `json:"LimSsthresh,int64"`
+	LocalAddress         string `json:"LocalAddress,string"`
+	LocalAddressType     int64  `json:"LocalAddressType,int64"`
+	LocalPort            int64  `json:"LocalPort,int64"`
+	MSSRcvd              int64  `json:"MSSRcvd,int64"`
+	MSSSent              int64  `json:"MSSSent,int64"`
+	MaxAppRQueue         int64  `json:"MaxAppRQueue,int64"`
+	MaxAppWQueue         int64  `json:"MaxAppWQueue,int64"`
+	MaxCaCwnd            int64  `json:"MaxCaCwnd,int64"`
+	MaxMSS               int64  `json:"MaxMSS,int64"`
+	MaxPipeSize          int64  `json:"MaxPipeSize,int64"`
+	MaxRTO               int64  `json:"MaxRTO,int64"`
+	MaxRTT               int64  `json:"MaxRTT,int64"`
+	MaxReasmQueue        int64  `json:"MaxReasmQueue,int64"`
+	MaxRetxQueue         int64  `json:"MaxRetxQueue,int64"`
+	MaxRwinRcvd          int64  `json:"MaxRwinRcvd,int64"`
+	MaxRwinSent          int64  `json:"MaxRwinSent,int64"`
+	MaxSsCwnd            int64  `json:"MaxSsCwnd,int64"`
+	MaxSsthresh          int64  `json:"MaxSsthresh,int64"`
+	MinMSS               int64  `json:"MinMSS,int64"`
+	MinRTO               int64  `json:"MinRTO,int64"`
+	MinRTT               int64  `json:"MinRTT,int64"`
+	MinRwinRcvd          int64  `json:"MinRwinRcvd,int64"`
+	MinRwinSent          int64  `json:"MinRwinSent,int64"`
+	MinSsthresh          int64  `json:"MinSsthresh,int64"`
+	Nagle                int64  `json:"Nagle,int64"`
+	NonRecovDA           int64  `json:"NonRecovDA,int64"`
+	NonRecovDAEpisodes   int64  `json:"NonRecovDAEpisodes,int64"`
+	OctetsRetrans        int64  `json:"OctetsRetrans,int64"`
+	OtherReductions      int64  `json:"OtherReductions,int64"`
+	PipeSize             int64  `json:"PipeSize,int64"`
+	PostCongCountRTT     int64  `json:"PostCongCountRTT,int64"`
+	PostCongSumRTT       int64  `json:"PostCongSumRTT,int64"`
+	PreCongSumCwnd       int64  `json:"PreCongSumCwnd,int64"`
+	PreCongSumRTT        int64  `json:"PreCongSumRTT,int64"`
+	QuenchRcvd           int64  `json:"QuenchRcvd,int64"`
+	RTTVar               int64  `json:"RTTVar,int64"`
+	RcvNxt               int64  `json:"RcvNxt,int64"`
+	RcvRTT               int64  `json:"RcvRTT,int64"`
+	RcvWindScale         int64  `json:"RcvWindScale,int64"`
+	RecInitial           int64  `json:"RecInitial,int64"`
+	RemAddress           string `json:"RemAddress,string"`
+	RemPort              int64  `json:"RemPort,int64"`
+	RetranThresh         int64  `json:"RetranThresh,int64"`
+	SACK                 int64  `json:"SACK,int64"`
+	SACKBlocksRcvd       int64  `json:"SACKBlocksRcvd,int64"`
+	SACKsRcvd            int64  `json:"SACKsRcvd,int64"`
+	SampleRTT            int64  `json:"SampleRTT,int64"`
+	SegsIn               int64  `json:"SegsIn,int64"`
+	SegsOut              int64  `json:"SegsOut,int64"`
+	SegsRetrans          int64  `json:"SegsRetrans,int64"`
+	SendStall            int64  `json:"SendStall,int64"`
+	SlowStart            int64  `json:"SlowStart,int64"`
+	SmoothedRTT          int64  `json:"SmoothedRTT,int64"`
+	SndInitial           int64  `json:"SndInitial,int64"`
+	SndLimBytesCwnd      int64  `json:"SndLimBytesCwnd,int64"`
+	SndLimBytesRwin      int64  `json:"SndLimBytesRwin,int64"`
+	SndLimBytesSender    int64  `json:"SndLimBytesSender,int64"`
+	SndLimTimeCwnd       int64  `json:"SndLimTimeCwnd,int64"`
+	SndLimTimeRwin       int64  `json:"SndLimTimeRwin,int64"`
+	SndLimTimeSnd        int64  `json:"SndLimTimeSnd,int64"`
+	SndLimTransCwnd      int64  `json:"SndLimTransCwnd,int64"`
+	SndLimTransRwin      int64  `json:"SndLimTransRwin,int64"`
+	SndLimTransSnd       int64  `json:"SndLimTransSnd,int64"`
+	SndMax               int64  `json:"SndMax,int64"`
+	SndNxt               int64  `json:"SndNxt,int64"`
+	SndUna               int64  `json:"SndUna,int64"`
+	SndWindScale         int64  `json:"SndWindScale,int64"`
+	SoftErrorReason      int64  `json:"SoftErrorReason,int64"`
+	SoftErrors           int64  `json:"SoftErrors,int64"`
+	SpuriousFrDetected   int64  `json:"SpuriousFrDetected,int64"`
+	SpuriousRtoDetected  int64  `json:"SpuriousRtoDetected,int64"`
+	StartTimeStamp       int64  `json:"StartTimeStamp,int64"`
+	State                int64  `json:"State,int64"`
+	SubsequentTimeouts   int64  `json:"SubsequentTimeouts,int64"`
+	SumOctetsReordered   int64  `json:"SumOctetsReordered,int64"`
+	SumRTT               int64  `json:"SumRTT,int64"`
+	ThruOctetsAcked      int64  `json:"ThruOctetsAcked,int64"`
+	ThruOctetsReceived   int64  `json:"ThruOctetsReceived,int64"`
+	TimeStamps           int64  `json:"TimeStamps,int64"`
+	TimeStampRcvd        bool   `json:"TimeStampRcvd,bool"`
+	TimeStampSent        bool   `json:"TimeStampSent,bool"`
+	Timeouts             int64  `json:"Timeouts,int64"`
+	WAD_CwndAdjust       int64  `json:"WAD_CwndAdjust,int64"`
+	WAD_IFQ              int64  `json:"WAD_IFQ,int64"`
+	WAD_MaxBurst         int64  `json:"WAD_MaxBurst,int64"`
+	WAD_MaxSsthresh      int64  `json:"WAD_MaxSsthresh,int64"`
+	WAD_NoAI             int64  `json:"WAD_NoAI,int64"`
+	WillSendSACK         int64  `json:"WillSendSACK,int64"`
+	WillUseSACK          int64  `json:"WillUseSACK,int64"`
+	WinScaleRcvd         int64  `json:"WinScaleRcvd,int64"`
+	WinScaleSent         int64  `json:"WinScaleSent,int64"`
+	X_OtherReductionsCM  int64  `json:"X_OtherReductionsCM,int64"`
+	X_OtherReductionsCV  int64  `json:"X_OtherReductionsCV,int64"`
+	X_Rcvbuf             int64  `json:"X_Rcvbuf,int64"`
+	X_Sndbuf             int64  `json:"X_Sndbuf,int64"`
+	X_dbg1               int64  `json:"X_dbg1,int64"`
+	X_dbg2               int64  `json:"X_dbg2,int64"`
+	X_dbg3               int64  `json:"X_dbg3,int64"`
+	X_dbg4               int64  `json:"X_dbg4,int64"`
+	X_rcv_ssthresh       int64  `json:"X_rcv_ssthresh,int64"`
+	X_wnd_clamp          int64  `json:"X_wnd_clamp,int64"`
+	ZeroRwinRcvd         int64  `json:"ZeroRwinRcvd,int64"`
+	ZeroRwinSent         int64  `json:"ZeroRwinSent,int64"`
 }
 
 type Web100LogEntry struct {
-	Log_time        int64                         `json:"log_time, int64"`
-	Version         string                        `json:"version, string"`
-	Group_name      string                        `json:"group_name, string"`
+	Log_time        int64                         `json:"log_time,int64"`
+	Version         string                        `json:"version,string"`
+	Group_name      string                        `json:"group_name,string"`
 	Connection_spec Web100ConnectionSpecification `json:"connection_spec"`
 	Snap            Web100Snap                    `json:"snap"`
 }
 
 type SS struct {
-	Test_id          string         `json:"test_id, string"`
-	Project          int64          `json:"project, int64"`
-	Log_time         int64          `json:"log_time, int64"`
-	Type             int64          `json:"type, int64"`
+	Test_id          string         `json:"test_id,string"`
+	Project          int64          `json:"project,int64"`
+	Log_time         int64          `json:"log_time,int64"`
+	Type             int64          `json:"type,int64"`
 	Web100_log_entry Web100LogEntry `json:"web100_log_entry"`
 }

--- a/schema/switch_schema.go
+++ b/schema/switch_schema.go
@@ -4,15 +4,15 @@ package schema
 
 // Meta contains the archive and parse metadata.
 type Meta struct {
-	FileName  string `json:"task_filename, string" bigquery:"task_filename"`
-	TestName  string `json:"test_id, string" bigquery:"test_id"`
-	ParseTime int64  `json:"parse_time, int64" bigquery:"parse_time"`
+	FileName  string `json:"task_filename,string" bigquery:"task_filename"`
+	TestName  string `json:"test_id,string" bigquery:"test_id"`
+	ParseTime int64  `json:"parse_time,int64" bigquery:"parse_time"`
 }
 
 // Sample is an individual measurement taken by DISCO.
 type Sample struct {
-	Timestamp int64   `json:"timestamp, int64" bigquery:"timestamp"`
-	Value     float32 `json:"value, float32" bigquery:"value"`
+	Timestamp int64   `json:"timestamp,int64" bigquery:"timestamp"`
+	Value     float32 `json:"value,float32" bigquery:"value"`
 }
 
 // SwitchStats represents a row of data taken from the raw DISCO export file.

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -9,6 +9,7 @@ package storage
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"encoding/base64"
 	"errors"
 	"io"
@@ -21,7 +22,6 @@ import (
 
 	"github.com/m-lab/etl/metrics"
 
-	"context"
 	"golang.org/x/oauth2/google"
 	storage "google.golang.org/api/storage/v1"
 )

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/m-lab/etl/metrics"
 
-	"golang.org/x/net/context"
+	"context"
 	"golang.org/x/oauth2/google"
 	storage "google.golang.org/api/storage/v1"
 )

--- a/task/task.go
+++ b/task/task.go
@@ -117,7 +117,7 @@ OUTER:
 			metrics.FileSizeHistogram.WithLabelValues(
 				tt.Parser.TableName(), kind, "parsed").Observe(float64(len(data)))
 		}
-		err := tt.Parser.ParseAndInsert(tt.meta, testname, data)
+		err = tt.Parser.ParseAndInsert(tt.meta, testname, data)
 		// Shouldn't have any of these, as they should be handled in ParseAndInsert.
 		if err != nil {
 			metrics.TaskCount.WithLabelValues(


### PR DESCRIPTION
This PR cleans up a number of go vet warnings.  It also fixes all the "context" imports that used an obsolete version of context.

I suspected a possible ipv6 triple colon bug in the geo_annotation.go code related to cip and sip (client and server ip addresses).  Added a unit test to try to expose it, but it seems that it is WAI.  Left the test there anyway.

After these changes, etl passes the following vet checks.
go tool vet --shadow .
go vet ./annotation/... ./appengine/... ./fake/... ./metrics/... ./schema/... ./task/... ./web100/...
go vet -assign -atomic -bool -buildtags -cgocall -copylocks -httpresponse -methods -nilfunc -printf -rangeloops -shift -structtags -tests -unreachable -unsafeptr -unusedresult ./bq/... ./etl/... ./parser/... ./storage/...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/497)
<!-- Reviewable:end -->
