### PR TITLE
Fix the naming of the destination bucket.

### DIFF
--- a/functions/embargo/transfer.js
+++ b/functions/embargo/transfer.js
@@ -226,7 +226,6 @@ exports.triggerEmbargoHandler = function (project, sourceBucket, filename, callb
  *
  * @param {object} event The Cloud Storage notification event.
  * @param {string} project The cloud project ID
- * @param {string} destBucket The Cloud Storage bucket to move files to.
  * @param {function} done The callback function called when this function completes.
  */
 exports.embargoOnFileNotification = function (event, project, done) {
@@ -237,7 +236,7 @@ exports.embargoOnFileNotification = function (event, project, done) {
             exports.triggerEmbargoHandler(project, file.bucket, file.name, done);
             console.log('Embargo: ', file.bucket, file.name);
         } else {
-            exports.executeWithAuth(exports.makeMoveWithAuth(file, destPublicBucket, done));
+            exports.executeWithAuth(exports.makeMoveWithAuth(file, 'archive-' + project, done));
         }
     } else {
         done(null);


### PR DESCRIPTION
Calculate the destination bucket from the name of the project, rather than referring to a now-deleted local variable, and causing a crash. Deploying to staging in advance of review.

First step in addressing https://github.com/m-lab/scraper/issues/308

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/506)
<!-- Reviewable:end -->
