### PR TITLE
Register the FileCount metric for counting tar files

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -40,6 +40,7 @@ func init() {
 	prometheus.MustRegister(RowSizeHistogram)
 
 	// Common metrics
+	prometheus.MustRegister(FileCount)
 	prometheus.MustRegister(PanicCount)
 	prometheus.MustRegister(WorkerCount)
 	prometheus.MustRegister(WorkerState)


### PR DESCRIPTION
This change registers the already present `FileCount` metric which counts the number of tar files processed by the ETL parsers.

With this metric it will be possible to compare the output from the etl-embargo to the input of the etl parsers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/510)
<!-- Reviewable:end -->
