### PR TITLE
increase ndt queue rate to provide headroom

### DIFF
--- a/appengine/queue.yaml
+++ b/appengine/queue.yaml
@@ -5,8 +5,8 @@ queue:
   target: etl-ndt-parser
   # Average rate at which to release tasks to the service.  Default is 5/sec
   # This is actually the rate at which tokens are added to the bucket.
-  # 1.0 allow processing a day's data (about 11K tasks) in 3 to 4 hours.
-  rate: 1.0/s
+  # 2.0 is adequate to provide about 50% headroom for daily rate.
+  rate: 2.0/s
   # Number of tokens that can accumulate in the bucket.  Default is 5.  This should
   # have very little impact for our environment.
   bucket_size: 10


### PR DESCRIPTION
Looks like our traffic has grown such that the task queue rate no longer has any headroom for NDT pipeline task queue.
Doubling the rate to provide more headroom.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/517)
<!-- Reviewable:end -->
