### PR TITLE
Compute project and dataset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -247,14 +247,14 @@ deploy:
 
 ######################################################################
 #  Prod deployments
-#  Deployed on manual tagging with prod-*, or (group)-prod-*
+#  Deployed on manual tagging with prod-*, ndt-prod-*, or small-prod-*
 #  Should be used AFTER code review, commit to integration, and staging soak.
-#  Triggers when *ANY* branch is tagged with prod-*'
+#  Triggers when *ANY* branch is tagged with one of these tags'
 ######################################################################
 
 ###################### SMALLER ETL SERVICES ###############################
 # Deploys smaller production services: PT, SS, DISCO
-# Triggers when *ANY* branch is tagged with qp-prod-* OR prod-*
+# Triggers when *ANY* branch is tagged with small-prod-* OR prod-*
 # NOTE: See later target for ndt-prod-*, which also triggers on prod-*, and
 #       deploys the NDT daily and batch pipelines.
 # NOTE: Failure in one of the deployments will terminate the deployment sequence,
@@ -280,7 +280,7 @@ deploy:
 
 ###################### NDT SERVICES ###############################
 # Deploys BOTH STREAMING AND BATCH services, along with queue config.
-# Triggers when *ANY* branch is tagged with qp-prod-* OR prod-*
+# Triggers when *ANY* branch is tagged with ndt-prod-* OR prod-*
 - provider: script
   script:
     $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_oti

--- a/bq/bq_test.go
+++ b/bq/bq_test.go
@@ -3,6 +3,7 @@ package bq_test
 import (
 	"errors"
 	"log"
+	"os"
 	"testing"
 	"time"
 
@@ -90,6 +91,31 @@ func TestBasicInsert(t *testing.T) {
 		t.Error("Should have accepted three rows")
 	}
 	in.Flush()
+}
+
+func TestInsertConfig(t *testing.T) {
+	os.Setenv("GCLOUD_PROJECT", "mlab-oti")
+	in, err := bq.NewInserter(etl.SS, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if in.Dataset() != "private" {
+		t.Errorf("Want private, got %s", in.Dataset())
+	}
+	if in.Project() != "mlab-oti" {
+		t.Errorf("Want private, got %s", in.Project())
+	}
+
+	in, err = bq.NewInserter(etl.NDT, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if in.Dataset() != "base_tables" {
+		t.Errorf("Want private, got %s", in.Dataset())
+	}
+	if in.Project() != "measurement-lab" {
+		t.Errorf("Want measurement-lab, got %s", in.Project())
+	}
 }
 
 func TestBufferingAndFlushing(t *testing.T) {

--- a/bq/bq_test.go
+++ b/bq/bq_test.go
@@ -93,7 +93,13 @@ func TestBasicInsert(t *testing.T) {
 	in.Flush()
 }
 
+// This does not currently work with mlab-testing credentials, and we
+// probably don't want it to.  So disabling it in travis.
 func TestInsertConfig(t *testing.T) {
+	_, isTravis := os.LookupEnv("TRAVIS")
+	if isTravis {
+		return
+	}
 	os.Setenv("GCLOUD_PROJECT", "mlab-oti")
 	in, err := bq.NewInserter(etl.SS, time.Now())
 	if err != nil {
@@ -103,7 +109,7 @@ func TestInsertConfig(t *testing.T) {
 		t.Errorf("Want private, got %s", in.Dataset())
 	}
 	if in.Project() != "mlab-oti" {
-		t.Errorf("Want private, got %s", in.Project())
+		t.Errorf("Want mlab-oti, got %s", in.Project())
 	}
 
 	in, err = bq.NewInserter(etl.NDT, time.Now())

--- a/bq/bq_test.go
+++ b/bq/bq_test.go
@@ -46,7 +46,7 @@ func xTestRealPartitionInsert(t *testing.T) {
 		Item{Name: tag + "_x1", Count: 12, Foobar: 44}}
 
 	in, err := bq.NewBQInserter(
-		etl.InserterParams{"mlab_sandbox", "test2", "_20160201", 10 * time.Second, 1, 0 * time.Second}, nil)
+		etl.InserterParams{"mlab-testing", "dataset", "test2", "_20160201", 10 * time.Second, 1, 0 * time.Second}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func TestBasicInsert(t *testing.T) {
 		Item{Name: tag + "_x1", Count: 12, Foobar: 44}}
 
 	in, err := bq.NewBQInserter(
-		etl.InserterParams{"mlab_sandbox", "test2", "", 10 * time.Second, 1, 0 * time.Second},
+		etl.InserterParams{"mlab-testing", "dataset", "test2", "", 10 * time.Second, 1, 0 * time.Second},
 		fake.NewFakeUploader())
 	if err != nil {
 		t.Fatal(err)
@@ -100,7 +100,7 @@ func TestBufferingAndFlushing(t *testing.T) {
 	// Set up an Inserter with a fake Uploader backend for testing.
 	// Buffer 3 rows, so that we can test the buffering.
 	in, err := bq.NewBQInserter(
-		etl.InserterParams{"mlab_sandbox", "test2", "", 10 * time.Second, 3, 0 * time.Second},
+		etl.InserterParams{"mlab-testing", "dataset", "test2", "", 10 * time.Second, 3, 0 * time.Second},
 		fake.NewFakeUploader())
 	if err != nil {
 		log.Printf("%v\n", err)
@@ -163,7 +163,7 @@ func TestBufferingAndFlushing(t *testing.T) {
 // Just manual testing for now - need to assert something useful.
 func TestHandleInsertErrors(t *testing.T) {
 	in, e := bq.NewBQInserter(
-		etl.InserterParams{"dataset", "table", "", time.Minute, 5, 0 * time.Second},
+		etl.InserterParams{"mlab-testing", "dataset", "table", "", time.Minute, 5, 0 * time.Second},
 		fake.NewFakeUploader())
 	if e != nil {
 		log.Printf("%v\n", e)
@@ -192,7 +192,7 @@ func TestQuotaError(t *testing.T) {
 	// Set up an Inserter with a fake Uploader backend for testing.
 	// Buffer 3 rows, so that we can test the buffering.
 	in, e := bq.NewBQInserter(
-		etl.InserterParams{"dataset", "table", "", time.Minute, 5, 1 * time.Millisecond},
+		etl.InserterParams{"mlab-testing", "dataset", "table", "", time.Minute, 5, 1 * time.Millisecond},
 		fakeUploader)
 	if e != nil {
 		log.Printf("%v\n", e)

--- a/bq/insert.go
+++ b/bq/insert.go
@@ -103,7 +103,7 @@ func GetClient(project string) (*bigquery.Client, error) {
 	// Network request
 	// ctx is used only for the request to create the client.  It is not used by
 	// the client.
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	return bigquery.NewClient(ctx, project)
 }

--- a/bq/insert.go
+++ b/bq/insert.go
@@ -318,6 +318,9 @@ func (in *BQInserter) TableBase() string {
 func (in *BQInserter) TableSuffix() string {
 	return in.params.Suffix
 }
+func (in *BQInserter) Project() string {
+	return in.params.Project
+}
 func (in *BQInserter) Dataset() string {
 	return in.params.Dataset
 }

--- a/cmd/etl_worker/app-disco.yaml
+++ b/cmd/etl_worker/app-disco.yaml
@@ -37,6 +37,6 @@ env_variables:
   COMMIT_HASH: ${TRAVIS_COMMIT}
 
   MAX_WORKERS: 30
-  BIGQUERY_PROJECT: ${INJECTED_PROJECT}
-  BIGQUERY_DATASET: 'base_tables'
+  # BIGQUERY_PROJECT: ''  # Overrides computed project name based on GCLOUD_PROJECT
+  # BIGQUERY_DATASET: 'base_tables' # Overrided computed dataset.
   ANNOTATE_IP: 'false'

--- a/cmd/etl_worker/app-ndt-batch.yaml
+++ b/cmd/etl_worker/app-ndt-batch.yaml
@@ -50,8 +50,8 @@ env_variables:
 
   NDT_BATCH: 'true'  # Allow instances to discover they are NDT_BATCH instances.
   MAX_WORKERS: 15  # 12 is good for NDT, but 20 is good for SS.
-  BIGQUERY_PROJECT: ${INJECTED_PROJECT}
-  BIGQUERY_DATASET: 'batch'
+  # BIGQUERY_PROJECT: ''  # Overrides computed project name based on GCLOUD_PROJECT
+  # BIGQUERY_DATASET: 'base_tables' # Overrided computed dataset.
   ANNOTATE_IP: 'true'
   NDT_OMIT_DELTAS: 'true'
   # TODO add custom service-account, instead of using default credentials.

--- a/cmd/etl_worker/app-ndt-prod.yaml
+++ b/cmd/etl_worker/app-ndt-prod.yaml
@@ -44,8 +44,8 @@ env_variables:
   COMMIT_HASH: ${TRAVIS_COMMIT}
 
   MAX_WORKERS: 12
-  BIGQUERY_PROJECT: 'measurement-lab'
-  BIGQUERY_DATASET: 'base_tables'
+  # BIGQUERY_PROJECT: ''  # Overrides computed project name based on GCLOUD_PROJECT
+  # BIGQUERY_DATASET: 'base_tables' # Overrided computed dataset.
   ANNOTATE_IP: 'true'
   NDT_OMIT_DELTAS: 'true'
   # TODO add custom service-account, instead of using default credentials.

--- a/cmd/etl_worker/app-ndt-staging.yaml
+++ b/cmd/etl_worker/app-ndt-staging.yaml
@@ -47,7 +47,7 @@ env_variables:
   COMMIT_HASH: ${TRAVIS_COMMIT}
 
   MAX_WORKERS: 20
-  BIGQUERY_PROJECT: 'mlab-staging'
-  BIGQUERY_DATASET: 'staging'
+  # BIGQUERY_PROJECT: ''  # Overrides computed project name based on GCLOUD_PROJECT
+  # BIGQUERY_DATASET: 'base_tables' # Overrided computed dataset.
   ANNOTATE_IP: 'true'
   # TODO add custom service-account, instead of using default credentials.

--- a/cmd/etl_worker/app-ndt.yaml
+++ b/cmd/etl_worker/app-ndt.yaml
@@ -42,8 +42,8 @@ env_variables:
   COMMIT_HASH: ${TRAVIS_COMMIT}
 
   MAX_WORKERS: 12
-  BIGQUERY_PROJECT: 'mlab-sandbox'
-  BIGQUERY_DATASET: 'mlab_sandbox'
+  # BIGQUERY_PROJECT: ''  # Overrides computed project name based on GCLOUD_PROJECT
+  # BIGQUERY_DATASET: 'base_tables' # Overrided computed dataset.
   ANNOTATE_IP: 'true'
   NDT_OMIT_DELTAS: 'true'
   # TODO add custom service-account, instead of using default credentials.

--- a/cmd/etl_worker/app-sidestream.yaml
+++ b/cmd/etl_worker/app-sidestream.yaml
@@ -41,6 +41,6 @@ env_variables:
   COMMIT_HASH: ${TRAVIS_COMMIT}
 
   MAX_WORKERS: 50
-  BIGQUERY_PROJECT: ${INJECTED_PROJECT}
-  BIGQUERY_DATASET: 'base_tables'
+  # BIGQUERY_PROJECT: ''  # Overrides computed project name based on GCLOUD_PROJECT
+  # BIGQUERY_DATASET: 'base_tables' # Overrided computed dataset.
   ANNOTATE_IP: 'true'

--- a/cmd/etl_worker/app-traceroute.yaml
+++ b/cmd/etl_worker/app-traceroute.yaml
@@ -10,7 +10,7 @@ resources:
   cpu: 2
   # Instances support between [(cpu * 0.9) - 0.4, (cpu * 6.5) - 0.4]
   # Actual memory available is exposed via GAE_MEMORY_MB environment variable.
-  # even though the parser has extremely limited RAM requirements, the 
+  # even though the parser has extremely limited RAM requirements, the
   # minimum RAM assignable to 2 CPUs is around 1.5GB
   memory_gb: 1.5
 
@@ -40,6 +40,6 @@ env_variables:
   COMMIT_HASH: ${TRAVIS_COMMIT}
 
   MAX_WORKERS: 5
-  BIGQUERY_PROJECT: ${INJECTED_PROJECT}
-  BIGQUERY_DATASET: 'base_tables'
+  # BIGQUERY_PROJECT: ''  # Overrides computed project name based on GCLOUD_PROJECT
+  # BIGQUERY_DATASET: 'base_tables' # Overrided computed dataset.
   ANNOTATE_IP: 'true'

--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -209,8 +209,7 @@ func subworker(rawFileName string, executionCount, retryCount int) (status int, 
 	dateFormat := "20060102"
 	date, err := time.Parse(dateFormat, data.PackedDate)
 
-	dataset := etl.DataTypeToDataset(dataType)
-	ins, err := bq.NewInserter(dataset, dataType, date)
+	ins, err := bq.NewInserter(dataType, date)
 	if err != nil {
 		metrics.TaskCount.WithLabelValues(data.TableBase(), string(dataType), "NewInserterError").Inc()
 		log.Printf("Error creating BQ Inserter:  %v", err)

--- a/etl/etl.go
+++ b/etl/etl.go
@@ -43,6 +43,8 @@ type Inserter interface {
 	FullTableName() string
 	// Dataset name of the BQ dataset containing the table.
 	Dataset() string
+	// Project name
+	Project() string
 
 	RowStats // Inserter must implement RowStats
 }

--- a/etl/etl.go
+++ b/etl/etl.go
@@ -49,8 +49,8 @@ type Inserter interface {
 
 // InserterParams for NewInserter
 type InserterParams struct {
-	// The project comes from os.GetEnv("GCLOUD_PROJECT")
-	// These specify the google cloud dataset/table to write to.
+	// These specify the google cloud project:dataset.table to write to.
+	Project string
 	Dataset string
 	Table   string
 	// Suffix may be an actual _YYYYMMDD or partition $YYYYMMDD

--- a/etl/etl.go
+++ b/etl/etl.go
@@ -57,7 +57,7 @@ type InserterParams struct {
 	Table   string
 	// Suffix may be an actual _YYYYMMDD or partition $YYYYMMDD
 	Suffix     string        // Table name suffix for templated tables or partitions.
-	Timeout    time.Duration // max duration of backend calls.  (for context)
+	PutTimeout time.Duration // max duration of bigquery Put ops.  (for context)
 	BufferSize int           // Number of rows to buffer before writing to backend.
 	RetryDelay time.Duration // Time to sleep between retries on Quota exceeded failures.
 }

--- a/etl/globals.go
+++ b/etl/globals.go
@@ -105,7 +105,7 @@ func ValidateTestPath(path string) (*DataPath, error) {
 
 // GetDataType finds the type of data stored in a file from its complete filename
 func (fn *DataPath) GetDataType() DataType {
-	dt, ok := DirToDataType[fn.Exp1]
+	dt, ok := dirToDataType[fn.Exp1]
 	if !ok {
 		return INVALID
 	}
@@ -114,7 +114,7 @@ func (fn *DataPath) GetDataType() DataType {
 
 // TableBase returns the base bigquery table name associated with the DataPath data type.
 func (fn *DataPath) TableBase() string {
-	return DataTypeToTable[fn.GetDataType()]
+	return fn.GetDataType().Table()
 }
 
 // IsBatchService return true if this is a NDT batch service.
@@ -196,7 +196,7 @@ const (
 var (
 	// DirToDataType maps from gs:// subdirectory to data type.
 	// TODO - this should be loaded from a config.
-	DirToDataType = map[string]DataType{
+	dirToDataType = map[string]DataType{
 		"ndt":              NDT,
 		"sidestream":       SS,
 		"paris-traceroute": PT,
@@ -205,7 +205,7 @@ var (
 
 	// DataTypeToTable maps from data type to BigQuery table name.
 	// TODO - this should be loaded from a config.
-	DataTypeToTable = map[DataType]string{
+	dataTypeToTable = map[DataType]string{
 		NDT:     "ndt",
 		SS:      "sidestream",
 		PT:      "traceroute",
@@ -227,9 +227,9 @@ var (
 	// queue_pusher.go
 )
 
-// DataTypeToDataset returns the appropriate dataset to use.
+// Dataset returns the appropriate dataset to use.
 // This is a bit of a hack, but works for our current needs.
-func DataTypeToDataset(dt DataType) string {
+func (dt DataType) Dataset() string {
 	if dt == SS {
 		return "private"
 	}
@@ -239,6 +239,21 @@ func DataTypeToDataset(dt DataType) string {
 	}
 
 	return "base_tables"
+}
+
+// Table returns the appropriate table to use.
+func (dt DataType) Table() string {
+	return dataTypeToTable[dt]
+}
+
+// BigqueryProject returns the appropriate project.
+func (dt DataType) BigqueryProject() string {
+	project := os.Getenv("GCLOUD_PROJECT")
+	// For production, all datatypes except SS write to tables in measurement-lab.
+	if project == "mlab-oti" && dt != SS {
+		return "measurement-lab"
+	}
+	return project
 }
 
 // CountPanics updates the PanicCount metric, then repanics.

--- a/etl/globals.go
+++ b/etl/globals.go
@@ -230,6 +230,10 @@ var (
 // Dataset returns the appropriate dataset to use.
 // This is a bit of a hack, but works for our current needs.
 func (dt DataType) Dataset() string {
+	dataset, override := os.LookupEnv("BIGQUERY_DATASET")
+	if override {
+		return dataset
+	}
 	if dt == SS {
 		return "private"
 	}
@@ -248,7 +252,11 @@ func (dt DataType) Table() string {
 
 // BigqueryProject returns the appropriate project.
 func (dt DataType) BigqueryProject() string {
-	project := os.Getenv("GCLOUD_PROJECT")
+	project, override := os.LookupEnv("BIGQUERY_PROJECT")
+	if override {
+		return project
+	}
+	project = os.Getenv("GCLOUD_PROJECT")
 	// For production, all datatypes except SS write to tables in measurement-lab.
 	if project == "mlab-oti" && dt != SS {
 		return "measurement-lab"

--- a/etl/globals.go
+++ b/etl/globals.go
@@ -227,6 +227,26 @@ var (
 	// queue_pusher.go
 )
 
+/*******************************************************************************
+*  TODO: These methods to compute the appropriate project and dataset are ugly.
+*  In not to distant future we need a better solution.
+*  See https://github.com/m-lab/etl/issues/519
+********************************************************************************/
+
+// BigqueryProject returns the appropriate project.
+func (dt DataType) BigqueryProject() string {
+	project, override := os.LookupEnv("BIGQUERY_PROJECT")
+	if override {
+		return project
+	}
+	project = os.Getenv("GCLOUD_PROJECT")
+	// For production, all datatypes except SS write to tables in measurement-lab.
+	if project == "mlab-oti" && dt != SS {
+		return "measurement-lab"
+	}
+	return project
+}
+
 // Dataset returns the appropriate dataset to use.
 // This is a bit of a hack, but works for our current needs.
 func (dt DataType) Dataset() string {
@@ -248,20 +268,6 @@ func (dt DataType) Dataset() string {
 // Table returns the appropriate table to use.
 func (dt DataType) Table() string {
 	return dataTypeToTable[dt]
-}
-
-// BigqueryProject returns the appropriate project.
-func (dt DataType) BigqueryProject() string {
-	project, override := os.LookupEnv("BIGQUERY_PROJECT")
-	if override {
-		return project
-	}
-	project = os.Getenv("GCLOUD_PROJECT")
-	// For production, all datatypes except SS write to tables in measurement-lab.
-	if project == "mlab-oti" && dt != SS {
-		return "measurement-lab"
-	}
-	return project
 }
 
 // CountPanics updates the PanicCount metric, then repanics.

--- a/etl/globals_test.go
+++ b/etl/globals_test.go
@@ -200,15 +200,15 @@ func TestCountPanics(t *testing.T) {
 }
 
 func TestSidestreamDataset(t *testing.T) {
-	if etl.DataTypeToDataset(etl.SS) != "private" {
-		t.Error("For SS, should be private:", etl.DataTypeToDataset(etl.SS))
+	if etl.SS.Dataset() != "private" {
+		t.Error("For SS, should be private:", etl.SS.Dataset())
 	}
 	etl.IsBatch = true
-	if etl.DataTypeToDataset(etl.NDT) != "batch" {
-		t.Error("For IsBatchService, should be batch:", etl.DataTypeToDataset(etl.NDT))
+	if etl.NDT.Dataset() != "batch" {
+		t.Error("For IsBatchService, should be batch:", etl.NDT.Dataset())
 	}
 	etl.IsBatch = false
-	if etl.DataTypeToDataset(etl.NDT) != "base_tables" {
-		t.Error("For IsBatchService, should be batch:", etl.DataTypeToDataset(etl.NDT))
+	if etl.NDT.Dataset() != "base_tables" {
+		t.Error("For IsBatchService, should be batch:", etl.NDT.Dataset())
 	}
 }

--- a/etl/globals_test.go
+++ b/etl/globals_test.go
@@ -202,49 +202,112 @@ func TestCountPanics(t *testing.T) {
 
 func TestDataset(t *testing.T) {
 	tests := []struct {
-		dt       etl.DataType
-		isBatch  bool
-		gproject string // Shouldn't matter
-		want     string
+		dt      etl.DataType
+		isBatch bool
+		want    string
 	}{
-		{etl.NDT, true, "mlab-oti", "batch"},
-		{etl.NDT, false, "mlab-oti", "base_tables"},
-		{etl.PT, true, "mlab-oti", "batch"},
-		{etl.PT, false, "mlab-oti", "base_tables"},
-		{etl.SS, true, "mlab-oti", "private"},
-		{etl.SS, false, "mlab-oti", "private"},
+		{etl.NDT, true, "batch"},
+		{etl.NDT, false, "base_tables"},
+		{etl.PT, true, "batch"},
+		{etl.PT, false, "base_tables"},
+		{etl.SS, true, "private"},
+		{etl.SS, false, "private"},
 	}
 
+	// Project shouldn't matter, so test different values to confirm.
+	os.Setenv("GCLOUD_PROJECT", "mlab-sandbox")
 	for _, test := range tests {
 		etl.IsBatch = test.isBatch
-		os.Setenv("GCLOUD_PROJECT", test.gproject)
 		got := test.dt.Dataset()
 		if got != test.want {
-			t.Errorf("for %s,%s, want: %s, got: %s.", test.dt, test.gproject, test.want, got)
+			t.Errorf("for %s want: %s, got: %s.", test.dt, test.want, got)
 		}
 	}
+	os.Setenv("GCLOUD_PROJECT", "mlab-oti")
+	for _, test := range tests {
+		etl.IsBatch = test.isBatch
+		got := test.dt.Dataset()
+		if got != test.want {
+			t.Errorf("for %s want: %s, got: %s.", test.dt, test.want, got)
+		}
+	}
+
+	override_tests := []struct {
+		dt      etl.DataType
+		isBatch bool
+		want    string
+	}{
+		{etl.NDT, true, "override"},
+		{etl.NDT, false, "override"},
+		{etl.PT, true, "override"},
+		{etl.PT, false, "override"},
+		{etl.SS, true, "override"},
+		{etl.SS, false, "override"},
+	}
+
+	// Test override
+	os.Setenv("BIGQUERY_DATASET", "override")
+	for _, test := range override_tests {
+		etl.IsBatch = test.isBatch
+		got := test.dt.Dataset()
+		if got != test.want {
+			t.Errorf("for %s want: %s, got: %s.", test.dt, test.want, got)
+		}
+	}
+
 }
 
 func TestBQProject(t *testing.T) {
 	tests := []struct {
 		dt       etl.DataType
-		isBatch  bool // Shouldn't matter
 		gproject string
 		want     string
 	}{
-		{etl.NDT, true, "mlab-oti", "measurement-lab"},
-		{etl.NDT, true, "staging", "staging"},
-		{etl.PT, false, "mlab-oti", "measurement-lab"},
-		{etl.SS, true, "mlab-oti", "mlab-oti"},
-		{etl.SS, false, "mlab-oti", "mlab-oti"},
+		{etl.NDT, "mlab-oti", "measurement-lab"},
+		{etl.NDT, "staging", "staging"},
+		{etl.PT, "mlab-oti", "measurement-lab"},
+		{etl.SS, "mlab-oti", "mlab-oti"},
+		{etl.SS, "mlab-oti", "mlab-oti"},
 	}
 
+	// isBatch  state shouldn't matter, so test with both values
+	etl.IsBatch = true
 	for _, test := range tests {
-		etl.IsBatch = test.isBatch
 		os.Setenv("GCLOUD_PROJECT", test.gproject)
 		got := test.dt.BigqueryProject()
 		if got != test.want {
 			t.Errorf("for %s,%s, want: %s, got: %s.", test.dt, test.gproject, test.want, got)
 		}
 	}
+	etl.IsBatch = false
+	for _, test := range tests {
+		os.Setenv("GCLOUD_PROJECT", test.gproject)
+		got := test.dt.BigqueryProject()
+		if got != test.want {
+			t.Errorf("for %s,%s, want: %s, got: %s.", test.dt, test.gproject, test.want, got)
+		}
+	}
+
+	// Test override
+	os.Setenv("BIGQUERY_PROJECT", "override_project")
+	override_tests := []struct {
+		dt       etl.DataType
+		gproject string
+		want     string
+	}{
+		{etl.NDT, "mlab-oti", "override_project"},
+		{etl.NDT, "staging", "override_project"},
+		{etl.PT, "mlab-oti", "override_project"},
+		{etl.SS, "mlab-oti", "override_project"},
+		{etl.SS, "mlab-oti", "override_project"},
+	}
+	etl.IsBatch = false
+	for _, test := range override_tests {
+		os.Setenv("GCLOUD_PROJECT", test.gproject)
+		got := test.dt.BigqueryProject()
+		if got != test.want {
+			t.Errorf("for %s,%s, want: %s, got: %s.", test.dt, test.gproject, test.want, got)
+		}
+	}
+
 }

--- a/etl/globals_test.go
+++ b/etl/globals_test.go
@@ -233,10 +233,10 @@ func TestBQProject(t *testing.T) {
 		want     string
 	}{
 		{etl.NDT, true, "mlab-oti", "measurement-lab"},
+		{etl.NDT, true, "staging", "staging"},
 		{etl.PT, false, "mlab-oti", "measurement-lab"},
 		{etl.SS, true, "mlab-oti", "mlab-oti"},
-		{etl.SS, false, "foobar", "foobar"},
-		{etl.NDT, true, "foobar", "foobar"},
+		{etl.SS, false, "mlab-oti", "mlab-oti"},
 	}
 
 	for _, test := range tests {

--- a/parser/disco_test.go
+++ b/parser/disco_test.go
@@ -32,7 +32,7 @@ func TestJSONParsing(t *testing.T) {
 	// This creates a real inserter, with a fake uploader, for local testing.
 	uploader := fake.FakeUploader{}
 	ins, err := bq.NewBQInserter(etl.InserterParams{
-		"mlab_sandbox", "disco_test", "", 10 * time.Second, 3, 0 * time.Second}, &uploader)
+		"mlab-sandbox", "dataset", "disco_test", "", 10 * time.Second, 3, 0 * time.Second}, &uploader)
 
 	var parser etl.Parser = parser.NewDiscoParser(ins)
 
@@ -74,7 +74,7 @@ func TestJSONParsing(t *testing.T) {
 // DISABLED
 // This tests insertion into a test table in the cloud.  Should not normally be executed.
 func xTestRealBackend(t *testing.T) {
-	ins, err := bq.NewInserter("mlab_sandbox", etl.SW, time.Now())
+	ins, err := bq.NewInserter(etl.SW, time.Now())
 	var parser etl.Parser = parser.NewDiscoParser(ins)
 
 	meta := map[string]bigquery.Value{"filename": "filename", "parse_time": time.Now()}

--- a/parser/ndt_test.go
+++ b/parser/ndt_test.go
@@ -252,6 +252,9 @@ func (in *inMemoryInserter) FullTableName() string {
 func (in *inMemoryInserter) Dataset() string {
 	return ""
 }
+func (in *inMemoryInserter) Project() string {
+	return ""
+}
 func (in *inMemoryInserter) RowsInBuffer() int {
 	return len(in.data) - in.committed
 }


### PR DESCRIPTION
This PR:
 1. adds a Project parameter to InserterParams,
 2. regularizes selection of project, dataset, and table in etl/globals.go.
 3. eliminates export of previously exported maps in globals.go, (replacing with methods)
 4. switches from singleton BQ client to client per task, to allow sidestream tasks to use a different client associated with possibly different project.

Also implements TODO to cleanup obsolete dataset parameter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/518)
<!-- Reviewable:end -->
