### PR TITLE
Ndt sandbox fix defer

### DIFF
--- a/annotation/geo.go
+++ b/annotation/geo.go
@@ -218,7 +218,8 @@ func GetBatchGeoData(url string, data []RequestData) map[string]GeoData {
 	// Query the service and grab the response safely
 	annotatorResponse, err := BatchQueryAnnotationService(url, data)
 	if err != nil {
-		log.Println(err)
+		metrics.AnnotationErrorCount.With(prometheus.
+			Labels{"source": err.Error()}).Inc()
 		return nil
 	}
 

--- a/bq/insert.go
+++ b/bq/insert.go
@@ -285,20 +285,21 @@ func (in *BQInserter) Flush() error {
 	//   experience 'Quota error' events.
 
 	var err error
-	retryDelay := in.params.RetryBaseDelay
-	for i := 0; i < 10; i++ {
+	for backoff := in.params.RetryBaseDelay; backoff < time.Minute; backoff *= 2 {
 		// This is heavyweight, and may run forever without a context deadline.
 		ctx, cancel := context.WithTimeout(context.Background(), in.putTimeout)
 		err = in.uploader.Put(ctx, in.rows)
+		cancel()
+
 		if err == nil || !strings.Contains(err.Error(), "Quota exceeded:") {
 			break
 		}
 		metrics.WarningCount.WithLabelValues(in.TableBase(), "", "Quota Exceeded").Inc()
+
 		// Use some randomness to reduce risk of synchronization across tasks.
-		t := retryDelay.Seconds() * (0.5 + rand.Float64()) // between 0.5 and 1.5 * RetryDelay
-		retryDelay = retryDelay + retryDelay
-		time.Sleep(time.Duration(1000000*t) * time.Microsecond)
-		cancel()
+		delayNanos := float32(backoff.Nanoseconds()) * (0.5 + rand.Float32()) // between 0.5 and 1.5 * RetryDelay
+		// Duration is int64 in nanoseconds, so this converts back to a Duration.
+		time.Sleep(time.Duration(delayNanos))
 	}
 
 	// If there is still an error, then handle it.

--- a/bq/insert.go
+++ b/bq/insert.go
@@ -101,10 +101,11 @@ func GetClient(project string) (*bigquery.Client, error) {
 	// when we actually want to access the bigquery backend.
 
 	// Network request
-	// ctx is used only for the request to create the client.  It is not used by
-	// the client.
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+	// It appears that ctx can have a short timeout, BUT we cannot call cancel on it.
+	// If we call defer cancel(), then the client later fails with cancelled context.
+	// So apparently the client holds on to the context, but doesn't care if it
+	// expires.
+	ctx, _ := context.WithTimeout(context.Background(), 3*time.Second)
 	return bigquery.NewClient(ctx, project)
 }
 

--- a/etl/etl.go
+++ b/etl/etl.go
@@ -56,10 +56,10 @@ type InserterParams struct {
 	Dataset string
 	Table   string
 	// Suffix may be an actual _YYYYMMDD or partition $YYYYMMDD
-	Suffix     string        // Table name suffix for templated tables or partitions.
-	PutTimeout time.Duration // max duration of bigquery Put ops.  (for context)
-	BufferSize int           // Number of rows to buffer before writing to backend.
-	RetryDelay time.Duration // Time to sleep between retries on Quota exceeded failures.
+	Suffix         string        // Table name suffix for templated tables or partitions.
+	PutTimeout     time.Duration // max duration of bigquery Put ops.  (for context)
+	BufferSize     int           // Number of rows to buffer before writing to backend.
+	RetryBaseDelay time.Duration // Base of doubling sleep time between retries.
 }
 
 // Parser is the generic interface implemented by each experiment parser.

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -220,7 +220,9 @@ func NewETLSource(client *http.Client, uri string) (*ETLSource, error) {
 	}
 
 	// TODO(prod) Evaluate whether this is long enough.
-	obj, err := getObject(client, bucket, fn, 60*time.Minute)
+	// SS processing sometimes times out with 1 hour.
+	// Is there a limit on http requests from task queue, or into flex instance?
+	obj, err := getObject(client, bucket, fn, 300*time.Minute)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
1. Fix the defered cancel.
2.  Add a missing cancel.
3. Replace annotation error logging with metric.
4. Improve the backoff strategy for failed bq inserts.
5. Increase weird storage timeout to 5 hours.  We are seeing SS timeouts with 1 hour context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/522)
<!-- Reviewable:end -->
