### PR TITLE
Ndt sandbox async flush cleanup

### DIFF
--- a/bq/bq_test.go
+++ b/bq/bq_test.go
@@ -226,7 +226,7 @@ func TestHandleInsertErrors(t *testing.T) {
 
 	var pme bigquery.PutMultiError
 	pme = append(pme, rie)
-	fakeUploader.SetErr(&rie)
+	fakeUploader.SetErr(&pme)
 	in.AddRow(struct{}{})
 	in.AddRow(struct{}{})
 	in.Flush()

--- a/bq/bq_test.go
+++ b/bq/bq_test.go
@@ -213,7 +213,7 @@ func TestHandleInsertErrors(t *testing.T) {
 
 	var pme bigquery.PutMultiError
 	pme = append(pme, rie)
-	in.(*bq.BQInserter).HandleInsertErrors(pme)
+	in.(*bq.BQInserter).HandleInsertErrors(pme, in.RowsInBuffer())
 
 	// TODO - assert something.
 }

--- a/bq/insert.go
+++ b/bq/insert.go
@@ -17,6 +17,7 @@ package bq
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log"
 	"math/rand"
 	"strings"
@@ -41,6 +42,12 @@ var tableInsertCounts = sync.Map{}
 
 func init() {
 }
+
+// InsertBuffer related constants.
+var (
+	// ErrBufferFull is returned when an InsertBuffer is full.
+	ErrBufferFull = errors.New("insert buffer is full")
+)
 
 // NewInserter creates a new BQInserter with appropriate characteristics.
 func NewInserter(dt etl.DataType, partition time.Time) (etl.Inserter, error) {
@@ -87,8 +94,10 @@ func NewBQInserter(params etl.InserterParams, uploader etl.Uploader) (etl.Insert
 		u.SkipInvalidRows = true
 		uploader = u
 	}
-	in := BQInserter{params: params, uploader: uploader, putTimeout: params.PutTimeout}
-	in.rows = make([]interface{}, 0, in.params.BufferSize)
+	token := make(chan struct{}, 1)
+	token <- struct{}{}
+	rows := make([]interface{}, 0, params.BufferSize)
+	in := BQInserter{params: params, uploader: uploader, putTimeout: params.PutTimeout, rows: rows, token: token}
 	return &in, nil
 }
 
@@ -126,13 +135,33 @@ func (s *MapSaver) Save() (row map[string]bigquery.Value, insertID string, err e
 
 type BQInserter struct {
 	etl.Inserter
+
+	// These are either constant or threadsafe.
 	params     etl.InserterParams
 	uploader   etl.Uploader  // May be a BQ Uploader, or a test Uploader
 	putTimeout time.Duration // Timeout used for BQ put operations.
-	rows       []interface{}
-	inserted   int // Number of rows successfully inserted.
-	badRows    int // Number of row failures, including rows in full failures.
-	failures   int // Number of complete insert failures.
+
+	// Rows must be accessed only by struct owner.
+	rows []interface{}
+
+	// The metrics are accessed by both the struct owner, and the flusher goroutine.
+	// Those accesses are protected by the token.
+	// We use a token instead of a mutex, because it is acquired in FlushAsync,
+	// but released by the flusher goroutine.
+	token chan struct{} // Token required for metric updates.
+
+	inserted int // Number of rows successfully inserted.
+	badRows  int // Number of row failures, including rows in full failures.
+	failures int // Number of complete insert failures.
+}
+
+// AddRow simply inserts a row into the buffer.  Returns error if buffer is full.
+func (in *BQInserter) AddRow(data interface{}) error {
+	for len(in.rows) >= in.params.BufferSize-1 {
+		return ErrBufferFull
+	}
+	in.rows = append(in.rows, data)
+	return nil
 }
 
 // Caller should check error, and take appropriate action before calling again.
@@ -167,9 +196,7 @@ func (in *BQInserter) maybeCountRowSize(data []interface{}) {
 }
 
 // Caller should check error, and take appropriate action before calling again.
-// TODO - should this return a specific error to indicate that a flush is needed
-// instead of flushing internally?  The "handle errors in the middle" would
-// be easier, though other complications would ensue.
+// Deprecated:
 func (in *BQInserter) InsertRows(data []interface{}) error {
 	metrics.WorkerState.WithLabelValues(in.TableBase(), "insert").Inc()
 	defer metrics.WorkerState.WithLabelValues(in.TableBase(), "insert").Dec()
@@ -192,17 +219,17 @@ func (in *BQInserter) InsertRows(data []interface{}) error {
 	return nil
 }
 
-func (in *BQInserter) HandleInsertErrors(err error) error {
+func (in *BQInserter) HandleInsertErrors(err error, numRows int) error {
 	switch typedErr := err.(type) {
 	case bigquery.PutMultiError:
-		if len(typedErr) == len(in.rows) {
+		if len(typedErr) == numRows {
 			log.Printf("%v\n", err)
 			metrics.BackendFailureCount.WithLabelValues(
 				in.TableBase(), "failed insert").Inc()
-			in.failures += 1
+			in.failures++
 		}
 		// If ALL rows failed, and number of rows is large, just report single failure.
-		if len(typedErr) > 10 && len(typedErr) == len(in.rows) {
+		if len(typedErr) > 10 && len(typedErr) == numRows {
 			log.Printf("Insert error: %v\n", err)
 			metrics.ErrorCount.WithLabelValues(
 				in.TableBase(), "unknown", "insert row error").
@@ -221,7 +248,7 @@ func (in *BQInserter) HandleInsertErrors(err error) error {
 				}
 			}
 		}
-		in.inserted += len(in.rows) - len(typedErr)
+		in.inserted += numRows - len(typedErr)
 		in.badRows += len(typedErr)
 		err = nil
 	default:
@@ -232,10 +259,22 @@ func (in *BQInserter) HandleInsertErrors(err error) error {
 			in.TableBase(), "unknown", "UNHANDLED insert error").Inc()
 		// TODO - Conservative, but possibly not correct.
 		// This at least preserves the count invariance.
-		in.badRows += len(in.rows)
+		in.badRows += numRows
 		err = nil
 	}
 	return err
+}
+
+func (in *BQInserter) acquire() {
+	<-in.token
+}
+func (in *BQInserter) release() {
+	in.token <- struct{}{} // return the token.
+}
+
+func (in *BQInserter) Sync() {
+	in.acquire()
+	in.release()
 }
 
 // TODO(dev) Should have a recovery mechanism for failed inserts.
@@ -307,7 +346,7 @@ func (in *BQInserter) Flush() error {
 		in.inserted += len(in.rows)
 	} else {
 		// This adjusts the inserted count, failure count, and updates in.rows.
-		err = in.HandleInsertErrors(err)
+		err = in.HandleInsertErrors(err, len(in.rows))
 	}
 	// Allocate new slice of rows.  Any failed rows are lost.
 	in.rows = make([]interface{}, 0, in.params.BufferSize)
@@ -334,13 +373,25 @@ func (in *BQInserter) Dataset() string {
 func (in *BQInserter) RowsInBuffer() int {
 	return len(in.rows)
 }
+
+// TODO HACK must deal with rows submitted to go flush()
 func (in *BQInserter) Accepted() int {
+	in.acquire()
+	defer in.release()
 	return in.inserted + in.badRows + len(in.rows)
 }
+
+// TODO HACK must deal with rows submitted to go flush()
 func (in *BQInserter) Committed() int {
+	in.acquire()
+	defer in.release()
 	return in.inserted
 }
+
+// TODO HACK must deal with rows submitted to go flush()
 func (in *BQInserter) Failed() int {
+	in.acquire()
+	defer in.release()
 	return in.badRows
 }
 

--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -217,9 +217,6 @@ func subworker(rawFileName string, executionCount, retryCount int) (status int, 
 		// TODO - anything better we could do here?
 	}
 
-	// Wrap inserter to give insertion time metrics.
-	ins = bq.DurationWrapper{ins}
-
 	// Create parser, injecting Inserter
 	p := parser.NewParser(dataType, ins)
 	tsk := task.NewTask(fn, tr, p)

--- a/etl/etl.go
+++ b/etl/etl.go
@@ -29,10 +29,10 @@ type RowStats interface {
 //   After Flush() returns, RowsInBuffer == 0
 type Inserter interface {
 	// InsertRow inserts one row into the insert buffer.
-	// Deprecated:
+	// Deprecated:  Please use AddRow and FlushAsync instead.
 	InsertRow(data interface{}) error
 	// InsertRows inserts multiple rows into the insert buffer.
-	// Deprecated:
+	// Deprecated:  Please use AddRow and FlushAsync instead.
 	InsertRows(data []interface{}) error
 	// Flush flushes any rows in the buffer out to bigquery.
 	// This is synchronous - on return, rows should be committed.

--- a/etl/etl.go
+++ b/etl/etl.go
@@ -28,11 +28,24 @@ type RowStats interface {
 //   After Flush() returns, RowsInBuffer == 0
 type Inserter interface {
 	// InsertRow inserts one row into the insert buffer.
+	// Deprecated:
 	InsertRow(data interface{}) error
 	// InsertRows inserts multiple rows into the insert buffer.
+	// Deprecated:
 	InsertRows(data []interface{}) error
 	// Flush flushes any rows in the buffer out to bigquery.
+	// This is synchronous - on return, rows should be committed.
 	Flush() error
+
+	// AddRow adds a single row to the output buffer.  It
+	// may return ErrBufferFull, but does not trigger flushes.
+	AddRow(data interface{}) error
+	// FlushAsync does an asynchronous buffer flush using
+	// another goroutine.  It may block if another flush is in
+	// progress.
+	FlushAsync()
+	// Sync waits for any pending FlushAsync() to complete.
+	Sync() // Synchronize with the async flusher.
 
 	// Base Table name of the BQ table that the uploader pushes to.
 	TableBase() string

--- a/fake/uploader.go
+++ b/fake/uploader.go
@@ -252,8 +252,8 @@ type FakeUploader struct {
 	CallCount int // Number of times Put is called.
 }
 
-func (up *FakeUploader) SetErr(err error) {
-	up.Err = err
+func (u *FakeUploader) SetErr(err error) {
+	u.Err = err
 }
 
 func NewFakeUploader() *FakeUploader {

--- a/parser/disco_test.go
+++ b/parser/disco_test.go
@@ -17,7 +17,8 @@ func init() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 }
 
-var test_data []byte = []byte(`{
+var test_data []byte = []byte(
+	`{
 	"sample": [{"timestamp": 69850, "value": 0.0}, {"timestamp": 69860, "value": 0.0}],
 	"metric": "switch.multicast.local.rx",
 	"hostname": "mlab4.sea05.measurement-lab.org",
@@ -32,7 +33,7 @@ func TestJSONParsing(t *testing.T) {
 	// This creates a real inserter, with a fake uploader, for local testing.
 	uploader := fake.FakeUploader{}
 	ins, err := bq.NewBQInserter(etl.InserterParams{
-		"mlab-sandbox", "dataset", "disco_test", "", 10 * time.Second, 3, 0 * time.Second}, &uploader)
+		"mlab-sandbox", "dataset", "disco_test", "", 3, 10 * time.Second, time.Second}, &uploader)
 
 	var parser etl.Parser = parser.NewDiscoParser(ins)
 
@@ -47,7 +48,7 @@ func TestJSONParsing(t *testing.T) {
 	// Adds two more rows, triggering an upload of 3 rows.
 	err = parser.ParseAndInsert(meta, "testName", test_data)
 	if len(uploader.Rows) != 3 {
-		t.Error("Uploader Row Count = ", len(uploader.Rows))
+		t.Error("Expected 3, got", len(uploader.Rows))
 	}
 
 	// Adds two more rows, triggering an upload of 3 rows.
@@ -60,7 +61,7 @@ func TestJSONParsing(t *testing.T) {
 		t.Error("RowsInBuffer = ", ins.RowsInBuffer())
 	}
 	if len(uploader.Rows) != 3 {
-		t.Error("Uploader Row Count = ", len(uploader.Rows))
+		t.Error("Expected 3, got", len(uploader.Rows))
 	}
 
 	if err != nil {

--- a/parser/ndt_test.go
+++ b/parser/ndt_test.go
@@ -228,6 +228,9 @@ func newInMemoryInserter() *inMemoryInserter {
 	return &inMemoryInserter{data, 0, 0}
 }
 
+func (in *inMemoryInserter) Sync() {
+}
+
 func (in *inMemoryInserter) InsertRow(data interface{}) error {
 	in.data = append(in.data, data)
 	return nil
@@ -236,9 +239,15 @@ func (in *inMemoryInserter) InsertRows(data []interface{}) error {
 	in.data = append(in.data, data...)
 	return nil
 }
+func (in *inMemoryInserter) AddRow(data interface{}) error {
+	in.data = append(in.data, data)
+	return nil
+}
 func (in *inMemoryInserter) Flush() error {
 	in.committed = len(in.data)
 	return nil
+}
+func (in *inMemoryInserter) FlushAsync() {
 }
 func (in *inMemoryInserter) TableBase() string {
 	return "ndt_test"

--- a/parser/ndt_test.go
+++ b/parser/ndt_test.go
@@ -228,9 +228,6 @@ func newInMemoryInserter() *inMemoryInserter {
 	return &inMemoryInserter{data, 0, 0}
 }
 
-func (in *inMemoryInserter) Sync() {
-}
-
 func (in *inMemoryInserter) InsertRow(data interface{}) error {
 	in.data = append(in.data, data)
 	return nil

--- a/parser/ss.go
+++ b/parser/ss.go
@@ -266,8 +266,10 @@ func (ss *SSParser) ParseAndInsert(meta map[string]bigquery.Value, testName stri
 			log.Printf("cannot pack data into sidestream schema: %v\n", err)
 			continue
 		}
+		// Add row to buffer, possibly flushing buffer if it is full.
 		err = ss.inserter.AddRow(ssTest)
 		if err == etl.ErrBufferFull {
+			// Flush asynchronously, to improve throughput.
 			ss.inserter.FlushAsync()
 			err = ss.inserter.InsertRow(ssTest)
 		}

--- a/parser/ss.go
+++ b/parser/ss.go
@@ -271,7 +271,7 @@ func (ss *SSParser) ParseAndInsert(meta map[string]bigquery.Value, testName stri
 		if err == etl.ErrBufferFull {
 			// Flush asynchronously, to improve throughput.
 			ss.inserter.FlushAsync()
-			err = ss.inserter.InsertRow(ssTest)
+			err = ss.inserter.AddRow(ssTest)
 		}
 		if err != nil {
 			metrics.ErrorCount.WithLabelValues(

--- a/parser/ss.go
+++ b/parser/ss.go
@@ -266,7 +266,11 @@ func (ss *SSParser) ParseAndInsert(meta map[string]bigquery.Value, testName stri
 			log.Printf("cannot pack data into sidestream schema: %v\n", err)
 			continue
 		}
-		err = ss.inserter.InsertRow(ssTest)
+		err = ss.inserter.AddRow(ssTest)
+		if err == etl.ErrBufferFull {
+			ss.inserter.FlushAsync()
+			err = ss.inserter.InsertRow(ssTest)
+		}
 		if err != nil {
 			metrics.ErrorCount.WithLabelValues(
 				ss.TableName(), "ss", "insert-err").Inc()
@@ -276,7 +280,6 @@ func (ss *SSParser) ParseAndInsert(meta map[string]bigquery.Value, testName stri
 			continue
 		}
 		metrics.TestCount.WithLabelValues(ss.TableName(), "ss", "ok").Inc()
-
 	}
 	return nil
 }


### PR DESCRIPTION
This PR:
1. Adapts BQInserter.Flush to FlushSlice, and adds support for asynchronous flushing.
2. Adds FlushAsync() which executes the BQ flush in a goroutine.
3. Add BQInserter.AddRow(), which adds a row without flushing.
4. Updates SS parser to use AddRow(), and FlushAsync()
5. Updates and improves unit tests.
6. Tweaks organization of BQInserter fields.
7. Tweaks parameters in test case BQInserters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/523)
<!-- Reviewable:end -->
