### PR TITLE
Batch ann 1

### DIFF
--- a/bq/insert.go
+++ b/bq/insert.go
@@ -153,25 +153,16 @@ type BQInserter struct {
 	// but released by the flusher goroutine.
 	token chan struct{} // Token required for metric updates.
 
+	// TODO: Consider making some of these atomics?
 	pending  int // Number of rows being flushed.
 	inserted int // Number of rows successfully inserted.
 	badRows  int // Number of row failures, including rows in full failures.
 	failures int // Number of complete insert failures.
 }
 
-// AddRow simply inserts a row into the buffer.  Returns error if buffer is full.
-// Not threadsafe.  Should only be called by owning thread.
-func (in *BQInserter) AddRow(data interface{}) error {
-	for len(in.rows) >= in.params.BufferSize-1 {
-		return etl.ErrBufferFull
-	}
-	in.rows = append(in.rows, data)
-	return nil
-}
-
 // Caller should check error, and take appropriate action before calling again.
 // Not threadsafe.  Should only be called by owning thread.
-// Deprecated:  Please use AddRow and FlushAsync instead.
+// Deprecated:  Please use external buffer, Put, and PutAsync instead.
 func (in *BQInserter) InsertRow(data interface{}) error {
 	return in.InsertRows([]interface{}{data})
 }
@@ -204,7 +195,7 @@ func (in *BQInserter) maybeCountRowSize(data []interface{}) {
 
 // Caller should check error, and take appropriate action before calling again.
 // Not threadsafe.  Should only be called by owning thread.
-// Deprecated:  Please use AddRow and FlushAsync instead.
+// Deprecated:  Please use external buffer, Put, and PutAsync instead.
 func (in *BQInserter) InsertRows(data []interface{}) error {
 	metrics.WorkerState.WithLabelValues(in.TableBase(), "insert").Inc()
 	defer metrics.WorkerState.WithLabelValues(in.TableBase(), "insert").Dec()
@@ -292,9 +283,31 @@ func (in *BQInserter) release() {
 	in.token <- struct{}{} // return the token.
 }
 
+// Put sends a slice of rows to BigQuery.
+// It is THREADSAFE.
+// It may block if there is already a Put or Flush in progress.
+func (in *BQInserter) Put(rows []interface{}) error {
+	in.acquire()
+	err := in.flushSlice(rows)
+	in.release()
+	return err
+}
+
+// PutAsync asynchronously sends a slice of rows to BigQuery.
+// It is THREADSAFE.
+// It may block if there is already a Put or Flush in progress.
+func (in *BQInserter) PutAsync(rows []interface{}) {
+	in.acquire()
+	go func() {
+		in.flushSlice(rows)
+		in.release()
+	}()
+}
+
 // Flush synchronously flushes the rows in the row buffer up to BigQuery
 // It is NOT threadsafe, as it touches the row buffer, so should only be called
 // by the owning thread.
+// Deprecated:  Please use external buffer, Put, and PutAsync instead.
 func (in *BQInserter) Flush() error {
 	rows := in.rows
 	// Allocate new slice of rows.  Any failed rows are lost.
@@ -305,23 +318,8 @@ func (in *BQInserter) Flush() error {
 	return err
 }
 
-// FlushAsync asynchronously flushes the rows in the row buffer up to BigQuery.
-// It is NOT threadsafe, as it touches the row buffer, so should only be called
-// by the owning thread.
-// It may block if there is already a flush in progress.
-func (in *BQInserter) FlushAsync() {
-	rows := in.rows
-	// Allocate new slice of rows.  Any failed rows are lost.
-	in.rows = make([]interface{}, 0, in.params.BufferSize)
-	in.acquire()
-	go func() {
-		in.flushSlice(rows)
-		in.release()
-	}()
-}
-
 // flushSlice flushes a slice of rows to BigQuery.
-// It is NOT threadsafe, and should only be called by Flush or FlushAsync.
+// It is NOT threadsafe, and should only be called by Flush.
 func (in *BQInserter) flushSlice(rows []interface{}) error {
 	metrics.WorkerState.WithLabelValues(in.TableBase(), "flush").Inc()
 	defer metrics.WorkerState.WithLabelValues(in.TableBase(), "flush").Dec()

--- a/bq/insert.go
+++ b/bq/insert.go
@@ -283,8 +283,12 @@ func (in *BQInserter) release() {
 	in.token <- struct{}{} // return the token.
 }
 
-// Put sends a slice of rows to BigQuery.
-// It is THREADSAFE.
+// Put sends a slice of rows to BigQuery, processes any
+// errors, and updates row stats. It uses a token to serialize with any previous
+// calls to PutAsync, to ensure that when Put() returns, all flushes
+// have completed and row stats reflect PutAsync requests.  (Of course races
+// may occur if calls are made from multiple goroutines).
+// It is THREAD-SAFE.
 // It may block if there is already a Put or Flush in progress.
 func (in *BQInserter) Put(rows []interface{}) error {
 	in.acquire()
@@ -293,8 +297,12 @@ func (in *BQInserter) Put(rows []interface{}) error {
 	return err
 }
 
-// PutAsync asynchronously sends a slice of rows to BigQuery.
-// It is THREADSAFE.
+// PutAsync asynchronously sends a slice of rows to BigQuery, processes any
+// errors, and updates row stats. It uses a token to serialize with other
+// (likely synchronous) calls, to ensure that when Put() returns, all flushes
+// have completed and row stats reflect PutAsync requests.  (Of course races
+// may occur if these are called from multiple goroutines).
+// It is THREAD-SAFE.
 // It may block if there is already a Put or Flush in progress.
 func (in *BQInserter) PutAsync(rows []interface{}) {
 	in.acquire()

--- a/parser/ndt_test.go
+++ b/parser/ndt_test.go
@@ -236,15 +236,16 @@ func (in *inMemoryInserter) InsertRows(data []interface{}) error {
 	in.data = append(in.data, data...)
 	return nil
 }
-func (in *inMemoryInserter) AddRow(data interface{}) error {
-	in.data = append(in.data, data)
+func (in *inMemoryInserter) Put(data []interface{}) error {
+	in.data = append(in.data, data...)
 	return nil
+}
+func (in *inMemoryInserter) PutAsync(data []interface{}) {
+	in.data = append(in.data, data...)
 }
 func (in *inMemoryInserter) Flush() error {
 	in.committed = len(in.data)
 	return nil
-}
-func (in *inMemoryInserter) FlushAsync() {
 }
 func (in *inMemoryInserter) TableBase() string {
 	return "ndt_test"

--- a/parser/ss.go
+++ b/parser/ss.go
@@ -283,13 +283,7 @@ func (ss *SSParser) ParseAndInsert(meta map[string]bigquery.Value, testName stri
 			log.Printf("cannot pack data into sidestream schema: %v\n", err)
 			continue
 		}
-		// Add row to buffer, possibly flushing buffer if it is full.
-		err = ss.inserter.AddRow(ssTest)
-		if err == etl.ErrBufferFull {
-			// Flush asynchronously, to improve throughput.
-			ss.inserter.FlushAsync()
-			err = ss.inserter.AddRow(ssTest)
-		}
+		err = ss.inserter.InsertRow(ssTest)
 		if err != nil {
 			metrics.ErrorCount.WithLabelValues(
 				ss.TableName(), "ss", "insert-err").Inc()


### PR DESCRIPTION
Add support to BQInserter for external buffering.  (Also removes the row buffer and AddRow and FlushAsync, as those will now be handled outside BQInserter)

This is required to support batch annotation, so that the parser can accumulate rows, then annotate them, then uploader.Put them to bigquery.

This is done on top of vet-ss branch.  Don't review ss.go cleanup of hyphenated var names, as those diffs will disappear when vet-ss is committed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/525)
<!-- Reviewable:end -->
