### PR TITLE
use batch annotation for ss.go

### DIFF
--- a/parser/disco_test.go
+++ b/parser/disco_test.go
@@ -34,12 +34,18 @@ func TestJSONParsing(t *testing.T) {
 	uploader := fake.FakeUploader{}
 	ins, err := bq.NewBQInserter(etl.InserterParams{
 		"mlab-sandbox", "dataset", "disco_test", "", 3, 10 * time.Second, time.Second}, &uploader)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	var parser etl.Parser = parser.NewDiscoParser(ins)
 
 	meta := map[string]bigquery.Value{"filename": "filename", "parse_time": time.Now()}
 	// Should result in two tests sent to inserter, but no call to uploader.
 	err = parser.ParseAndInsert(meta, "testName", test_data)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if ins.Accepted() != 2 {
 		t.Error("Accepted = ", ins.Accepted())
 		t.Fail()
@@ -47,6 +53,9 @@ func TestJSONParsing(t *testing.T) {
 
 	// Adds two more rows, triggering an upload of 3 rows.
 	err = parser.ParseAndInsert(meta, "testName", test_data)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(uploader.Rows) != 3 {
 		t.Error("Expected 3, got", len(uploader.Rows))
 	}

--- a/parser/ss.go
+++ b/parser/ss.go
@@ -22,7 +22,6 @@ import (
 
 // Parser for parsing sidestream tests.
 
-// SSParser provides a parser implementation for SideStream data.
 // RowBuffer for SS.
 type RowBuffer struct {
 	bufferSize int
@@ -74,7 +73,7 @@ func (buf *RowBuffer) Annotate(tableBase string) {
 	metrics.AnnotationTimeSummary.With(prometheus.Labels{"test_type": "SS"}).Observe(float64(time.Since(start).Nanoseconds()))
 }
 
-// SSParser contains the elements of a sidestream parser.
+// SSParser provides a parser implementation for SideStream data.
 type SSParser struct {
 	inserter etl.Inserter
 	etl.RowStats

--- a/parser/ss.go
+++ b/parser/ss.go
@@ -30,7 +30,7 @@ type RowBuffer struct {
 }
 
 // AddRow simply inserts a row into the buffer.  Returns error if buffer is full.
-// Not threadsafe.  Should only be called by owning thread.
+// Not thread-safe.  Should only be called by owning thread.
 func (buf *RowBuffer) AddRow(row schema.SS) error {
 	for len(buf.rows) >= buf.bufferSize-1 {
 		return etl.ErrBufferFull
@@ -39,12 +39,16 @@ func (buf *RowBuffer) AddRow(row schema.SS) error {
 	return nil
 }
 
+// TakeRows returns all rows in the buffer, and clears the buffer.
+// Not thread-safe.  Should only be called by owning thread.
 func (buf *RowBuffer) TakeRows() []interface{} {
 	res := buf.rows
 	buf.rows = make([]interface{}, 0, buf.bufferSize)
 	return res
 }
 
+// Annotate fetches annotations for all rows in the buffer.
+// Not thread-safe.  Should only be called by owning thread.
 func (buf *RowBuffer) Annotate(tableBase string) {
 	metrics.WorkerState.WithLabelValues(tableBase, "annotate").Inc()
 	defer metrics.WorkerState.WithLabelValues(tableBase, "annotate").Dec()

--- a/parser/ss_test.go
+++ b/parser/ss_test.go
@@ -28,7 +28,7 @@ func TestPopulateSnap(t *testing.T) {
 		t.Fatalf("Snap fields not populated correctly.")
 	}
 
-	if snap.TimeStampRcvd != false {
+	if snap.TimeStampRcvd {
 		t.Errorf("TimeStampRcvd; got %t; want false", snap.TimeStampRcvd)
 	}
 	if snap.RemAddress != "abcd" {
@@ -70,7 +70,9 @@ func TestSSInserter(t *testing.T) {
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	if ins.RowsInBuffer() != 6 {
-		t.Fatalf("Number of rows in PT table is wrong.")
+	n.Flush()
+	if ins.Committed() != 6 {
+		t.Fatalf("Expected %d, Got %d.", 6, ins.Committed())
 	}
 }
+


### PR DESCRIPTION
Switch sidestream over to use local row buffer, and annotate all rows in a batch annotation call, prior to sending to inserter.

Also adds some missing error checking.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/527)
<!-- Reviewable:end -->
