### PR TITLE
Use standard columns for switch schema

### DIFF
--- a/parser/disco.go
+++ b/parser/disco.go
@@ -71,7 +71,7 @@ func (dp *DiscoParser) ParseAndInsert(meta map[string]bigquery.Value, testName s
 		stats := schema.SwitchStats{
 			TaskFilename:  meta["filename"].(string),
 			TestID:        testName,
-			ParseTime:     time.Now().Unix(),
+			ParseTime:     time.Now(),
 			ParserVersion: Version(),
 			// TODO: original archive "log_time" is unknown.
 		}

--- a/parser/disco.go
+++ b/parser/disco.go
@@ -69,9 +69,10 @@ func (dp *DiscoParser) ParseAndInsert(meta map[string]bigquery.Value, testName s
 
 	for dec.More() {
 		stats := schema.SwitchStats{
-			TaskFilename: meta["filename"].(string),
-			TestID:       testName,
-			ParseTime:    meta["parse_time"].(time.Time).Unix(),
+			TaskFilename:  meta["filename"].(string),
+			TestID:        testName,
+			ParseTime:     time.Now().Unix(),
+			ParserVersion: Version(),
 			// TODO: original archive "log_time" is unknown.
 		}
 		tmp := schema.SwitchStats{}

--- a/schema/switch_schema.go
+++ b/schema/switch_schema.go
@@ -8,14 +8,15 @@ type Sample struct {
 
 // SwitchStats represents a row of data taken from the raw DISCO export file.
 type SwitchStats struct {
-	TaskFilename string   `json:"task_filename,string" bigquery:"task_filename"`
-	TestID       string   `json:"test_id,string" bigquery:"test_id"`
-	ParseTime    int64    `json:"parse_time,int64" bigquery:"parse_time"`
-	LogTime      int64    `json:"log_time,int64" bigquery:"log_time"`
-	Sample       []Sample `json:"sample" bigquery:"sample"`
-	Metric       string   `json:"metric" bigquery:"metric"`
-	Hostname     string   `json:"hostname" bigquery:"hostname"`
-	Experiment   string   `json:"experiment" bigquery:"experiment"`
+	TaskFilename  string   `json:"task_filename,string" bigquery:"task_filename"`
+	TestID        string   `json:"test_id,string" bigquery:"test_id"`
+	ParseTime     int64    `json:"parse_time,int64" bigquery:"parse_time"`
+	ParserVersion string   `json:"parser_version,string" bigquery:"parser_version"`
+	LogTime       int64    `json:"log_time,int64" bigquery:"log_time"`
+	Sample        []Sample `json:"sample" bigquery:"sample"`
+	Metric        string   `json:"metric" bigquery:"metric"`
+	Hostname      string   `json:"hostname" bigquery:"hostname"`
+	Experiment    string   `json:"experiment" bigquery:"experiment"`
 }
 
 // Size estimates the number of bytes in the SwitchStats object.

--- a/schema/switch_schema.go
+++ b/schema/switch_schema.go
@@ -1,14 +1,5 @@
 package schema
 
-// TODO: copy disco schema here.
-
-// Meta contains the archive and parse metadata.
-type Meta struct {
-	FileName  string `json:"task_filename,string" bigquery:"task_filename"`
-	TestName  string `json:"test_id,string" bigquery:"test_id"`
-	ParseTime int64  `json:"parse_time,int64" bigquery:"parse_time"`
-}
-
 // Sample is an individual measurement taken by DISCO.
 type Sample struct {
 	Timestamp int64   `json:"timestamp,int64" bigquery:"timestamp"`
@@ -17,15 +8,18 @@ type Sample struct {
 
 // SwitchStats represents a row of data taken from the raw DISCO export file.
 type SwitchStats struct {
-	Meta       Meta     `json:"meta" bigquery:"meta"`
-	Sample     []Sample `json:"sample" bigquery:"sample"`
-	Metric     string   `json:"metric" bigquery:"metric"`
-	Hostname   string   `json:"hostname" bigquery:"hostname"`
-	Experiment string   `json:"experiment" bigquery:"experiment"`
+	TaskFilename string   `json:"task_filename,string" bigquery:"task_filename"`
+	TestID       string   `json:"test_id,string" bigquery:"test_id"`
+	ParseTime    int64    `json:"parse_time,int64" bigquery:"parse_time"`
+	LogTime      int64    `json:"log_time,int64" bigquery:"log_time"`
+	Sample       []Sample `json:"sample" bigquery:"sample"`
+	Metric       string   `json:"metric" bigquery:"metric"`
+	Hostname     string   `json:"hostname" bigquery:"hostname"`
+	Experiment   string   `json:"experiment" bigquery:"experiment"`
 }
 
 // Size estimates the number of bytes in the SwitchStats object.
 func (s *SwitchStats) Size() int {
-	return (len(s.Meta.FileName) + len(s.Meta.TestName) + 8 +
+	return (len(s.TaskFilename) + len(s.TestID) + 8 +
 		12*len(s.Sample) + len(s.Metric) + len(s.Hostname) + len(s.Experiment))
 }

--- a/schema/switch_schema.go
+++ b/schema/switch_schema.go
@@ -1,5 +1,7 @@
 package schema
 
+import "time"
+
 // Sample is an individual measurement taken by DISCO.
 type Sample struct {
 	Timestamp int64   `json:"timestamp,int64" bigquery:"timestamp"`
@@ -8,15 +10,15 @@ type Sample struct {
 
 // SwitchStats represents a row of data taken from the raw DISCO export file.
 type SwitchStats struct {
-	TaskFilename  string   `json:"task_filename,string" bigquery:"task_filename"`
-	TestID        string   `json:"test_id,string" bigquery:"test_id"`
-	ParseTime     int64    `json:"parse_time,int64" bigquery:"parse_time"`
-	ParserVersion string   `json:"parser_version,string" bigquery:"parser_version"`
-	LogTime       int64    `json:"log_time,int64" bigquery:"log_time"`
-	Sample        []Sample `json:"sample" bigquery:"sample"`
-	Metric        string   `json:"metric" bigquery:"metric"`
-	Hostname      string   `json:"hostname" bigquery:"hostname"`
-	Experiment    string   `json:"experiment" bigquery:"experiment"`
+	TaskFilename  string    `json:"task_filename,string" bigquery:"task_filename"`
+	TestID        string    `json:"test_id,string" bigquery:"test_id"`
+	ParseTime     time.Time `json:"parse_time" bigquery:"parse_time"`
+	ParserVersion string    `json:"parser_version,string" bigquery:"parser_version"`
+	LogTime       int64     `json:"log_time,int64" bigquery:"log_time"`
+	Sample        []Sample  `json:"sample" bigquery:"sample"`
+	Metric        string    `json:"metric" bigquery:"metric"`
+	Hostname      string    `json:"hostname" bigquery:"hostname"`
+	Experiment    string    `json:"experiment" bigquery:"experiment"`
 }
 
 // Size estimates the number of bytes in the SwitchStats object.


### PR DESCRIPTION
This change is a companion to https://github.com/m-lab/etl-schema/pull/5

This change updates the disco switch schema to use standard columns for `test_id`, `task_filename` and `parse_time`.

As well, this change should resolve https://github.com/m-lab/etl/issues/462

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/530)
<!-- Reviewable:end -->
