### PR TITLE
Copy metric, hostname, and experiment fields from parsed disco data

### DIFF
--- a/parser/disco.go
+++ b/parser/disco.go
@@ -92,6 +92,11 @@ func (dp *DiscoParser) ParseAndInsert(meta map[string]bigquery.Value, testName s
 		// the extra sample, so we unconditionally ignore it here.
 		stats.Sample = tmp.Sample[:len(tmp.Sample)-1]
 
+		// Copy remaining fields.
+		stats.Metric = tmp.Metric
+		stats.Hostname = tmp.Hostname
+		stats.Experiment = tmp.Experiment
+
 		// Count the number of samples per record.
 		metrics.DeltaNumFieldsHistogram.WithLabelValues(
 			dp.TableName()).Observe(float64(len(stats.Sample)))

--- a/parser/disco_test.go
+++ b/parser/disco_test.go
@@ -86,6 +86,18 @@ func TestJSONParsing(t *testing.T) {
 		t.Error("task_filename incorrect: Expected 'testName', got",
 			uploader.Rows[0].Row["test_id"].(string))
 	}
+	if uploader.Rows[0].Row["metric"].(string) != "switch.multicast.local.rx" {
+		t.Error("task_filename incorrect: Expected 'switch.multicast.local.rx', got",
+			uploader.Rows[0].Row["metric"].(string))
+	}
+	if uploader.Rows[0].Row["hostname"].(string) != "mlab1.sea05.measurement-lab.org" {
+		t.Error("task_filename incorrect: Expected 'mlab1.sea05.measuremet-lab.org', got",
+			uploader.Rows[0].Row["hostname"].(string))
+	}
+	if uploader.Rows[0].Row["experiment"].(string) != "s1.sea05.measurement-lab.org" {
+		t.Error("task_filename incorrect: Expected 's1.sea05.measuremet-lab.org', got",
+			uploader.Rows[0].Row["experiment"].(string))
+	}
 
 	if err != nil {
 		log.Printf("Request: %v\n", uploader.Request)


### PR DESCRIPTION
This change fixes a bug introduced by https://github.com/m-lab/etl/pull/530 whereby the `metric`, `hostname`, and `experiment` fields were not included in the final data.