### PR TITLE
Add cloud function trigger to embargo buckets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -157,7 +157,7 @@ deploy:
     repo: m-lab/etl
     all_branches: true
     condition: $TRAVIS_BRANCH == cf-sandbox-* || $TRAVIS_BRANCH == sandbox-*
-    
+
 ## Service: etl-ndt-parser -- AppEngine Flexible Environment.
 - provider: script
   script:
@@ -282,7 +282,7 @@ deploy:
   on:
     repo: m-lab/etl
     all_branches: true
-    condition: $TRAVIS_BRANCH == cf-prod-* || $TRAVIS_BRANCH == prod-*
+    condition: $TRAVIS_BRANCH == cf-prod-* || $TRAVIS_BRANCH == ndt-prod-* || $TRAVIS_BRANCH == prod-*
 
 
 ###################### SMALLER ETL SERVICES ###############################

--- a/.travis.yml
+++ b/.travis.yml
@@ -152,6 +152,7 @@ deploy:
     $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_sandbox
     && cd $TRAVIS_BUILD_DIR/functions
     && gcloud beta functions deploy createSandboxTaskOnFileNotification --stage-bucket=functions-mlab-sandbox --trigger-resource=archive-mlab-sandbox --project=mlab-sandbox
+    && gcloud beta functions deploy createSandboxTaskOnFileNotification --stage-bucket=functions-mlab-sandbox --trigger-resource=embargo-mlab-sandbox --project=mlab-sandbox
   skip_cleanup: true
   on:
     repo: m-lab/etl
@@ -256,6 +257,7 @@ deploy:
     SERVICE_ACCOUNT_mlab_staging $TRAVIS_BUILD_DIR/appengine/queue_pusher
     && cd $TRAVIS_BUILD_DIR/functions
     && gcloud beta functions deploy createStagingTaskOnFileNotification --stage-bucket=functions-mlab-staging --trigger-resource=archive-mlab-staging --project=mlab-staging
+    && gcloud beta functions deploy createStagingTaskOnFileNotification --stage-bucket=functions-mlab-staging --trigger-resource=embargo-mlab-staging --project=mlab-staging
     && cd $TRAVIS_BUILD_DIR/functions/embargo
     && gcloud beta functions deploy embargoOnFileNotificationStaging --stage-bucket=functions-mlab-staging --trigger-resource=scraper-mlab-staging --project=mlab-staging
   skip_cleanup: true
@@ -276,6 +278,7 @@ deploy:
     $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_oti
     && cd $TRAVIS_BUILD_DIR/functions
     && gcloud beta functions deploy createProdTaskOnFileNotification --stage-bucket=functions-mlab-oti --trigger-resource=archive-mlab-oti --project=mlab-oti
+    && gcloud beta functions deploy createProdTaskOnFileNotification --stage-bucket=functions-mlab-oti --trigger-resource=embargo-mlab-oti --project=mlab-oti
     && cd $TRAVIS_BUILD_DIR/functions/embargo
     && gcloud beta functions deploy embargoOnFileNotificationOti --stage-bucket=functions-mlab-oti --trigger-resource=scraper-mlab-oti --project=mlab-oti
   skip_cleanup: true


### PR DESCRIPTION
We want to process ALL sidestream data as it comes in.  This PR adds cloud functions on the embargo bucket, so that both the archive bucket and the embargo bucket notifications trigger the pipeline.

Used **gsutil notification list gs://embargo-mlab-oti** to ensure that there was not already a notification registered.

This method also allows us to monitor whether all data is being handled properly by the embargo process, and to distinguish easily in BQ whether rows should be visible to the public.

Note: This also adds the ndt-prod deployment trigger to the production cloud function deployment section, so that cloud functions will be deployed any time NDT is deployed.  They are NOT auto-deployed with the small-prod trigger.  This is intentional, so that we don't accidentally impact NDT operation when we only intend to update small-prod targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/538)
<!-- Reviewable:end -->
