### PR TITLE
Verify that Sample length is non-zero

### DIFF
--- a/parser/disco.go
+++ b/parser/disco.go
@@ -90,7 +90,9 @@ func (dp *DiscoParser) ParseAndInsert(meta map[string]bigquery.Value, testName s
 		// this was so the last sample of the current time range would overlap with
 		// the first sample of the next time range. However, this parser does not use
 		// the extra sample, so we unconditionally ignore it here.
-		stats.Sample = tmp.Sample[:len(tmp.Sample)-1]
+		if len(tmp.Sample) > 0 {
+			stats.Sample = tmp.Sample[:len(tmp.Sample)-1]
+		}
 
 		// Copy remaining fields.
 		stats.Metric = tmp.Metric

--- a/parser/disco_test.go
+++ b/parser/disco_test.go
@@ -23,7 +23,7 @@ var test_data []byte = []byte(
 	"metric": "switch.multicast.local.rx",
 	"hostname": "mlab4.sea05.measurement-lab.org",
 	"experiment": "s1.sea05.measurement-lab.org"}
-	{"sample": [{"timestamp": 69870, "value": 0.0}, {"timestamp": 69880, "value": 0.0}],
+	{"sample": [],
 	"metric": "switch.multicast.local.rx",
 	"hostname": "mlab1.sea05.measurement-lab.org",
 	"experiment": "s1.sea05.measurement-lab.org"}`)
@@ -75,7 +75,8 @@ func TestJSONParsing(t *testing.T) {
 	if len(uploader.Rows) != 3 {
 		t.Error("Expected 3, got", len(uploader.Rows))
 	}
-	if len(uploader.Rows[0].Row["sample"].([]bigquery.Value)) != 1 {
+
+	if uploader.Rows[0].Row["sample"] != nil && len(uploader.Rows[0].Row["sample"].([]bigquery.Value)) != 1 {
 		t.Error("Expected 1, got", len(uploader.Rows[0].Row["sample"].([]bigquery.Value)))
 	}
 	if uploader.Rows[0].Row["task_filename"].(string) != "fake-filename.tar" {


### PR DESCRIPTION
This change adds a condition to check whether the `tmp.Sample` contains at least one element.

While `Sample` should normally have a length greater than zero, evidently during the roll out of the pause frame collection there was one export hour that included the "pause" frame metrics but without any samples (b/c they had not been collected yet).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/541)
<!-- Reviewable:end -->
