### PR TITLE
Update ETL parsers with standard columns

### DIFF
--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -552,6 +552,8 @@ func (n *NDTParser) getAndInsertValues(test *fileInfoAndData, testType string) {
 	} else {
 		results["parse_time"] = string(now)
 	}
+	// Record the parser version used to calculate this row.
+	results["parser_version"] = Version()
 
 	connSpec := schema.EmptyConnectionSpec()
 	if n.metaFile != nil {

--- a/parser/pt.go
+++ b/parser/pt.go
@@ -195,8 +195,11 @@ func (pt *PTParser) FullTableName() string {
 func (pt *PTParser) InsertOneTest(oneTest cachedPTData) {
 	for _, hop := range oneTest.Hops {
 		ptTest := schema.PT{
-			Test_id:              oneTest.TestID,
-			Log_time:             oneTest.LogTime.Unix(),
+			TestID:        oneTest.TestID,
+			LogTime:       oneTest.LogTime.Unix(),
+			ParseTime:     time.Now(),
+			ParserVersion: Version(),
+			// TODO: add TaskFilename
 			Connection_spec:      *(oneTest.ConnSpec),
 			Paris_traceroute_hop: *hop,
 			Type:                 int32(2),

--- a/parser/pt_test.go
+++ b/parser/pt_test.go
@@ -154,9 +154,10 @@ func TestPTInserter(t *testing.T) {
 	}
 
 	expectedValues := &schema.PT{
-		Test_id:  "20170320T23:53:10Z-172.17.94.34-33456-74.125.224.100-33457.paris",
-		Project:  3,
-		Log_time: 1490053990,
+		TestID:        "20170320T23:53:10Z-172.17.94.34-33456-74.125.224.100-33457.paris",
+		Project:       3,
+		LogTime:       1490053990,
+		ParserVersion: parser.Version(),
 		Connection_spec: schema.MLabConnectionSpecification{
 			Server_ip:      "172.17.94.34",
 			Server_af:      2,
@@ -176,6 +177,8 @@ func TestPTInserter(t *testing.T) {
 		},
 		Type: 2,
 	}
+	// Copy ParseTime from actual output before using DeepEqual.
+	expectedValues.ParseTime = (ins.data[0].(schema.PT)).ParseTime
 	if !reflect.DeepEqual(ins.data[0], *expectedValues) {
 		fmt.Printf("Here is expected    : %v\n", expectedValues)
 		fmt.Printf("Here is what is real: %v\n", ins.data[0])

--- a/parser/ss.go
+++ b/parser/ss.go
@@ -66,7 +66,7 @@ func (buf *RowBuffer) Annotate(tableBase string) {
 		geoSlice[i+i+1] = &connSpec.Remote_geolocation
 	}
 	// Just use the logtime of the first row.
-	logTime := time.Unix(buf.rows[0].(*schema.SS).Web100_log_entry.Log_time, 0)
+	logTime := time.Unix(buf.rows[0].(*schema.SS).Web100_log_entry.LogTime, 0)
 	start := time.Now()
 	// TODO - are there any errors we should process from Fetch?
 	annotation.FetchGeoAnnotations(ipSlice, logTime, geoSlice)
@@ -189,7 +189,7 @@ func PackDataIntoSchema(ssValue map[string]string, logTime time.Time, testName s
 		return schema.SS{}, err
 	}
 	web100Log := &schema.Web100LogEntry{
-		Log_time:        logTime.Unix(), // TODO: Should use timestamp, not integer
+		LogTime:         logTime.Unix(), // TODO: Should use timestamp, not integer
 		Version:         "unknown",
 		Group_name:      "read", // TODO: Use Camelcase, with json annotations?
 		Connection_spec: *connSpec,
@@ -197,8 +197,8 @@ func PackDataIntoSchema(ssValue map[string]string, logTime time.Time, testName s
 	}
 
 	ssTest := &schema.SS{
-		Test_id:          testName,
-		Log_time:         logTime.Unix(),
+		TestID:           testName,
+		LogTime:          logTime.Unix(),
 		Type:             int64(1),
 		Project:          int64(2),
 		Web100_log_entry: *web100Log,

--- a/schema/pt_schema.go
+++ b/schema/pt_schema.go
@@ -1,7 +1,11 @@
 // This files contains schema for Paris TraceRoute tests.
 package schema
 
-import "github.com/m-lab/etl/annotation"
+import (
+	"time"
+
+	"github.com/m-lab/etl/annotation"
+)
 
 // TODO(dev): use mixed case Go variable names throughout
 
@@ -29,9 +33,12 @@ type MLabConnectionSpecification struct {
 }
 
 type PT struct {
-	Test_id              string                      `json:"test_id,string"`
+	TestID               string                      `json:"test_id,string"`
 	Project              int32                       `json:"project,int32"`
-	Log_time             int64                       `json:"log_time,int64"`
+	TaskFilename         string                      `json:"task_filename,string"`
+	ParseTime            time.Time                   `json:"parse_time"`
+	ParserVersion        string                      `json:"parser_version,string"`
+	LogTime              int64                       `json:"log_time,int64"`
 	Connection_spec      MLabConnectionSpecification `json:"connection_spec"`
 	Paris_traceroute_hop ParisTracerouteHop          `json:"paris_traceroute_hop"`
 	Type                 int32                       `json:"type,int32"`

--- a/schema/ss_schema.go
+++ b/schema/ss_schema.go
@@ -172,7 +172,7 @@ type Web100Snap struct {
 }
 
 type Web100LogEntry struct {
-	Log_time        int64                         `json:"log_time,int64"`
+	LogTime         int64                         `json:"log_time,int64"`
 	Version         string                        `json:"version,string"`
 	Group_name      string                        `json:"group_name,string"`
 	Connection_spec Web100ConnectionSpecification `json:"connection_spec"`
@@ -180,9 +180,9 @@ type Web100LogEntry struct {
 }
 
 type SS struct {
-	Test_id       string    `json:"test_id,string"`
+	TestID        string    `json:"test_id,string"`
 	Project       int64     `json:"project,int64"`
-	Log_time      int64     `json:"log_time,int64"`
+	LogTime       int64     `json:"log_time,int64"`
 	ParseTime     time.Time `bigquery:"parse_time"`
 	ParserVersion string    `bigquery:"parser_version"`
 	TaskFileName  string    `bigquery:"task_filename"`


### PR DESCRIPTION
In service of https://github.com/m-lab/etl/issues/285 and following https://github.com/m-lab/etl-schema/pull/7 this change adds new logic to set standard column values in NDT and Paris Traceroute parsers.

With this change:

* NDT will set the parser_version column.
* Paris-Traceroute will set the parser_version and parse_time columns, with task_filename left as a TODO.

As well, this change includes minor variable name changes in the SS and PTR parsers to use Go naming conventions. i.e. Test_id -> TestID. These changes should have no effect on output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/552)
<!-- Reviewable:end -->
