### PR TITLE
Use generic BATCH_SERVICE env to tell parser it is batch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -253,7 +253,7 @@ deploy:
 ######################################################################
 
 ###################### ALL ETL SERVICES ###############################
-# Deploys all staging services: NDT, NDT_BATCH, PT, SS, DISCO, QUEUE_PUSHER, GARDENER
+# Deploys all staging services: NDT, BATCH, PT, SS, DISCO, QUEUE_PUSHER, GARDENER
 # NOTE:
 #  Failure in one of the deployments will terminate the deployment sequence, leaving
 #  the system in a mixed state.  This should be manually addresses ASAP.

--- a/cmd/etl_worker/app-batch.yaml
+++ b/cmd/etl_worker/app-batch.yaml
@@ -48,8 +48,8 @@ env_variables:
   RELEASE_TAG: ${TRAVIS_TAG}
   COMMIT_HASH: ${TRAVIS_COMMIT}
 
-  NDT_BATCH: 'true'  # Allow instances to discover they are NDT_BATCH instances.
-  MAX_WORKERS: 15  # 12 is good for NDT, but 20 is good for SS.
+  BATCH_SERVICE: 'true'   # Allow instances to discover they are BATCH instances.
+  MAX_WORKERS: 15         # 12 is good for NDT, but 20 is good for SS.
   # BIGQUERY_PROJECT: ''  # Overrides computed project name based on GCLOUD_PROJECT
   # BIGQUERY_DATASET: 'base_tables' # Overrided computed dataset.
   ANNOTATE_IP: 'true'

--- a/etl/globals.go
+++ b/etl/globals.go
@@ -20,7 +20,7 @@ var IsBatch bool
 var OmitDeltas bool
 
 func init() {
-	IsBatch, _ = strconv.ParseBool(os.Getenv("NDT_BATCH"))
+	IsBatch, _ = strconv.ParseBool(os.Getenv("BATCH_SERVICE"))
 	OmitDeltas, _ = strconv.ParseBool(os.Getenv("NDT_OMIT_DELTAS"))
 }
 
@@ -117,8 +117,7 @@ func (fn *DataPath) TableBase() string {
 	return fn.GetDataType().Table()
 }
 
-// IsBatchService return true if this is a NDT batch service.
-// TODO - update this to BATCH_SERVICE, so it makes sense for other pipelines.
+// IsBatchService return true if this is a batch service.
 func IsBatchService() bool {
 	return IsBatch
 }


### PR DESCRIPTION
Now that the batch parser is generic, rename the environment variable used to tell the parser that it is batch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/557)
<!-- Reviewable:end -->
