### PR TITLE
Update schemas with explicit bigquery tags

### DIFF
--- a/schema/pt_schema.go
+++ b/schema/pt_schema.go
@@ -33,12 +33,12 @@ type MLabConnectionSpecification struct {
 }
 
 type PT struct {
-	TestID               string                      `json:"test_id,string"`
-	Project              int32                       `json:"project,int32"`
-	TaskFilename         string                      `json:"task_filename,string"`
-	ParseTime            time.Time                   `json:"parse_time"`
-	ParserVersion        string                      `json:"parser_version,string"`
-	LogTime              int64                       `json:"log_time,int64"`
+	TestID               string                      `json:"test_id,string" bigquery:"test_id"`
+	Project              int32                       `json:"project,int32" bigquery:"project"`
+	TaskFilename         string                      `json:"task_filename,string" bigquery:"task_filename"`
+	ParseTime            time.Time                   `json:"parse_time" bigquery:"parse_time"`
+	ParserVersion        string                      `json:"parser_version,string" bigquery:"parser_version"`
+	LogTime              int64                       `json:"log_time,int64" bigquery:"log_time"`
 	Connection_spec      MLabConnectionSpecification `json:"connection_spec"`
 	Paris_traceroute_hop ParisTracerouteHop          `json:"paris_traceroute_hop"`
 	Type                 int32                       `json:"type,int32"`

--- a/schema/ss_schema.go
+++ b/schema/ss_schema.go
@@ -172,7 +172,7 @@ type Web100Snap struct {
 }
 
 type Web100LogEntry struct {
-	LogTime         int64                         `json:"log_time,int64"`
+	LogTime         int64                         `json:"log_time,int64" bigquery:"log_time"`
 	Version         string                        `json:"version,string"`
 	Group_name      string                        `json:"group_name,string"`
 	Connection_spec Web100ConnectionSpecification `json:"connection_spec"`
@@ -180,12 +180,12 @@ type Web100LogEntry struct {
 }
 
 type SS struct {
-	TestID        string    `json:"test_id,string"`
-	Project       int64     `json:"project,int64"`
-	LogTime       int64     `json:"log_time,int64"`
-	ParseTime     time.Time `bigquery:"parse_time"`
-	ParserVersion string    `bigquery:"parser_version"`
-	TaskFileName  string    `bigquery:"task_filename"`
+	TestID        string    `json:"test_id,string" bigquery:"test_id"`
+	Project       int64     `json:"project,int64" bigquery:"project"`
+	LogTime       int64     `json:"log_time,int64" bigquery:"log_time"`
+	ParseTime     time.Time `bigquery:"parse_time" bigquery:"parse_time"`
+	ParserVersion string    `bigquery:"parser_version" bigquery:"parser_version"`
+	TaskFileName  string    `bigquery:"task_filename" bigquery:"task_filename"`
 
 	Type             int64          `json:"type,int64"`
 	Web100_log_entry Web100LogEntry `json:"web100_log_entry"`


### PR DESCRIPTION
Evidently, without explicit `bigquery` tagging on field names, bigquery uses an automated conversion that is incompatible with the schema changed in https://github.com/m-lab/etl/pull/552

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/559)
<!-- Reviewable:end -->
