### PR TITLE
Unconitionally return false for "shouldEmbargo"

### DIFF
--- a/functions/embargo/transfer.js
+++ b/functions/embargo/transfer.js
@@ -134,9 +134,8 @@ exports.makeMoveWithAuth = function (file, destBucket, done) {
  * @param {object} file The file under consideration
  */
 exports.shouldEmbargo = function (file) {
-    // Only sidestream files need to be embargoed.  All others can be
-    // transferred.
-    return (file.name.substring(0, 11) === 'sidestream/');
+    // Unconditionally return false.
+    return false;
 };
 
 /**


### PR DESCRIPTION
This change updates the embargo criteria in `shouldEmbargo` to unconditionally return false.

The consequence of this change is that the sidestream archives will be copied, unmodified from scraper-<project> to archive-<project> just like all other files.

This change also preserves the embargo frame work in case we want to add new experiments to it in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/564)
<!-- Reviewable:end -->
