### PR TITLE
Remove prometheus client from etl & queue_pusher dependencies

### DIFF
--- a/appengine/queue_pusher/queue_pusher.go
+++ b/appengine/queue_pusher/queue_pusher.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 
 	"github.com/m-lab/etl/etl"
-	"github.com/m-lab/etl/storage"
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/taskqueue"
 )
@@ -95,7 +94,7 @@ func receiver(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	decodedFilename, err := storage.GetFilename(filename)
+	decodedFilename, err := etl.GetFilename(filename)
 	if err != nil {
 		http.Error(w, `{"message": "Could not base64decode filename"}`, http.StatusBadRequest)
 		return

--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -105,7 +105,7 @@ func worker(rwr http.ResponseWriter, rq *http.Request) {
 	// This will add metric count and log message from any panic.
 	// The panic will still propagate, and http will report it.
 	defer func() {
-		etl.CountPanics(recover(), "worker")
+		metrics.CountPanics(recover(), "worker")
 	}()
 
 	// Throttle by grabbing a semaphore from channel.
@@ -154,7 +154,7 @@ func subworker(rawFileName string, executionCount, retryCount int) (status int, 
 
 	var err error
 	// This handles base64 encoding, and requires a gs:// prefix.
-	fn, err := storage.GetFilename(rawFileName)
+	fn, err := etl.GetFilename(rawFileName)
 	if err != nil {
 		metrics.TaskCount.WithLabelValues("unknown", "worker", "BadRequest").Inc()
 		log.Printf("Invalid filename: %s\n", fn)

--- a/etl/globals.go
+++ b/etl/globals.go
@@ -1,16 +1,13 @@
 package etl
 
 import (
+	"encoding/base64"
 	"errors"
-	"fmt"
-	"log"
 	"net"
 	"os"
 	"regexp"
-	"runtime/debug"
 	"strconv"
-
-	"github.com/m-lab/etl/metrics"
+	"strings"
 )
 
 // IsBatch indicates this process is a batch processing service.
@@ -269,60 +266,21 @@ func (dt DataType) Table() string {
 	return dataTypeToTable[dt]
 }
 
-// CountPanics updates the PanicCount metric, then repanics.
-// It must be wrapped in a defer.
-// Examples:
-//  For function that returns an error:
-//    func foobar() () {
-//        defer func() {
-//		      etl.AddPanicMetric(recover(), "foobar")
-// 	      }()
-//        ...
-//        ...
-//    }
-// TODO - possibly move this to metrics.go
-func CountPanics(r interface{}, tag string) {
-	if r != nil {
-		err, ok := r.(error)
-		if !ok {
-			log.Println("bad recovery conversion")
-			err = fmt.Errorf("pkg: %v", r)
-		}
-		log.Println("Adding metrics for panic:", err)
-		metrics.PanicCount.WithLabelValues(tag).Inc()
-		panic(r)
+// GetFilename converts request received from the queue into a filename.
+// TODO(dev) Add unit test
+func GetFilename(filename string) (string, error) {
+	if strings.HasPrefix(filename, "gs://") {
+		return filename, nil
 	}
-}
 
-// PanicToErr captures panics and converts them to
-// errors.  Use with extreme care, as panic may mean that
-// state is corrupted, and continuing to execut may result
-// in undefined behavior.
-// It must be wrapped in a defer.
-// Example:
-//    // err must be a named return value to be captured.
-//    func foobar() (err error) {
-//        defer func() {
-//			  // Possibly do something with existing error
-//            // before calling PanicToErr
-//		      err = etl.PanicToErr(err, recover(), "foobar")
-// 	      }()
-//        ...
-//        ...
-//    }
-func PanicToErr(err error, r interface{}, tag string) error {
-	if r != nil {
-		var ok bool
-		err, ok = r.(error)
-		// TODO - Check if err == runtime.Error, and treat
-		// differently ?
-		if !ok {
-			log.Println("bad recovery conversion")
-			err = fmt.Errorf("pkg: %v", r)
-		}
-		log.Println("Recovered from panic:", err)
-		metrics.PanicCount.WithLabelValues(tag).Inc()
-		fmt.Printf("%s\n", debug.Stack())
+	decode, err := base64.StdEncoding.DecodeString(filename)
+	if err != nil {
+		return "", errors.New("invalid file path: " + filename)
 	}
-	return err
+	fn := string(decode[:])
+	if strings.HasPrefix(fn, "gs://") {
+		return fn, nil
+	}
+
+	return "", errors.New("invalid base64 encoded file path: " + fn)
 }

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -1,0 +1,73 @@
+package metrics_test
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"runtime/debug"
+	"testing"
+
+	"github.com/m-lab/etl/metrics"
+)
+
+func panicAndRecover() (err error) {
+	defer func() {
+		err = metrics.PanicToErr(nil, recover(), "foobar")
+	}()
+	a := []int{1, 2, 3}
+	log.Println(a[4])
+	// This is never reached.
+	return
+}
+
+func errorWithoutPanic(prior error) (err error) {
+	err = prior
+	defer func() {
+		err = metrics.PanicToErr(err, recover(), "foobar")
+	}()
+	return
+}
+
+func TestHandlePanic(t *testing.T) {
+	err := panicAndRecover()
+	log.Println("Actually did recover")
+	if err == nil {
+		t.Fatal("Should have errored")
+	}
+}
+
+func TestNoPanic(t *testing.T) {
+	err := errorWithoutPanic(nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = errorWithoutPanic(errors.New("prior"))
+	if err.Error() != "prior" {
+		t.Error("Should have returned prior error.")
+	}
+}
+
+func rePanic() {
+	defer func() {
+		metrics.CountPanics(recover(), "foobar")
+	}()
+	a := []int{1, 2, 3}
+	log.Println(a[4])
+	// This is never reached.
+	return
+}
+
+func TestCountPanics(t *testing.T) {
+	// When we call RePanic, the panic should cause a log and a metric
+	// increment, but should still panic.  This intercepts the panic,
+	// and errors if the panic doesn't happen.
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("The code did not panic")
+		}
+		fmt.Printf("%s\n", debug.Stack())
+	}()
+
+	rePanic()
+}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -10,7 +10,6 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"context"
-	"encoding/base64"
 	"errors"
 	"io"
 	"io/ioutil"
@@ -265,25 +264,6 @@ func GetStorageClient(writeAccess bool) (*http.Client, error) {
 		return nil, err
 	}
 	return client, nil
-}
-
-// GetFilename converts request received from the queue into a filename.
-// TODO(dev) Add unit test
-func GetFilename(filename string) (string, error) {
-	if strings.HasPrefix(filename, "gs://") {
-		return filename, nil
-	}
-
-	decode, err := base64.StdEncoding.DecodeString(filename)
-	if err != nil {
-		return "", errors.New("invalid file path: " + filename)
-	}
-	fn := string(decode[:])
-	if strings.HasPrefix(fn, "gs://") {
-		return fn, nil
-	}
-
-	return "", errors.New("invalid base64 encoded file path: " + fn)
 }
 
 //---------------------------------------------------------------------------------


### PR DESCRIPTION
queue_pusher imports github.com/m-lab/etl/etl and github.com/m-lab/etl/storage.
Both packages import metrics, which imports the prometheus client libraries
which now include `syscall` imports, which are forbidden in AppEngine SE. As a
result the queue_pusher build fails.

This change moves etl.CountPanic to `metrics`, since this seemed like the next logical place.
This change moves storage.GetFilename to etl globals.go and adds a unit test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/570)
<!-- Reviewable:end -->
