### PR TITLE
Correct typo on INJECTED_PROJECT for sidestream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -329,7 +329,7 @@ deploy:
     INJECTED_PROJECT=measurement-lab
     $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
     SERVICE_ACCOUNT_mlab_oti $TRAVIS_BUILD_DIR/cmd/etl_worker app-traceroute.yaml
-    && INJECTED_BUCKET=measurement-lab
+    && INJECTED_PROJECT=measurement-lab
     $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
     SERVICE_ACCOUNT_mlab_oti $TRAVIS_BUILD_DIR/cmd/etl_worker app-sidestream.yaml
     && INJECTED_PROJECT=measurement-lab


### PR DESCRIPTION
This change fixes a typo (no idea how I missed it) for INJECTED_PROJECT for sidestream parser in mlab-oti.

Currently etl-sidestream-parser is writing to tables in mlab-oti instead of measurement-lab.

This only affects the daily pipeline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/572)
<!-- Reviewable:end -->
