### PR TITLE
Add sync_tables_with_schema.sh to deployements

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "travis"]
 	path = travis
 	url = https://github.com/m-lab/travis.git
+[submodule "etl-schema"]
+	path = etl-schema
+	url = https://github.com/m-lab/etl-schema

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,14 @@ before_install:
 - $TRAVIS_BUILD_DIR/travis/install_gcloud.sh
 - source "${HOME}/google-cloud-sdk/path.bash.inc"
 
+- if [[ -n "$TEST_SERVICE_ACCOUNT_mlab_sandbox" ]] ; then
+  echo $TEST_SERVICE_ACCOUNT_mlab_sandbox | base64 -d > travis-sandbox.key ;
+  gcloud auth activate-service-account --key-file=travis-sandbox.key ;
+  fi
+- bq --project mlab-sandbox show base_tables.ndt
+# TODO: try --headless
+- exit 1
+
 # Install test credentials.
 # Note that anyone with github ACLs to push to a branch can hack .travis.yml
 # and discover these credentials in the travis logs.
@@ -43,9 +51,6 @@ before_install:
   echo $TEST_SERVICE_ACCOUNT_mlab_testing | base64 -d > travis-testing.key ;
   gcloud auth activate-service-account --key-file=travis-testing.key ;
   fi
-- bq --project mlab-sandbox show base_tables.ndt
-# TODO: try --headless
-- exit 1
 
 # These directories will be cached on successful "script" builds, and restored,
 # if available, to save time on future builds.

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_install:
   gcloud auth activate-service-account --key-file=travis-sandbox.key ;
   fi
 # Trick bq into setting up auth so sync_tables_with_schema.sh works correctly.
-- bq --project mlab-sandbox ls fake-dataset
+- bq --project mlab-sandbox ls fake-dataset || :
 
 # Install test credentials.
 # Note that anyone with github ACLs to push to a branch can hack .travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,14 +36,6 @@ before_install:
 - $TRAVIS_BUILD_DIR/travis/install_gcloud.sh
 - source "${HOME}/google-cloud-sdk/path.bash.inc"
 
-# TODO: remove this after merging https://github.com/m-lab/etl-schema/pull/10
-- if [[ -n "$SERVICE_ACCOUNT_mlab_sandbox" ]] ; then
-  echo $SERVICE_ACCOUNT_mlab_sandbox > travis-sandbox.key ;
-  gcloud auth activate-service-account --key-file=travis-sandbox.key ;
-  fi
-# Trick bq into setting up auth so sync_tables_with_schema.sh works correctly.
-- bq --project mlab-sandbox ls fake-dataset || true
-
 # Install test credentials.
 # Note that anyone with github ACLs to push to a branch can hack .travis.yml
 # and discover these credentials in the travis logs.

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_install:
   gcloud auth activate-service-account --key-file=travis-sandbox.key ;
   fi
 # Trick bq into setting up auth so sync_tables_with_schema.sh works correctly.
-- bq --project mlab-sandbox ls fake-dataset || :
+- bq --project mlab-sandbox ls fake-dataset || true
 
 # Install test credentials.
 # Note that anyone with github ACLs to push to a branch can hack .travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
   echo $SERVICE_ACCOUNT_mlab_sandbox > travis-sandbox.key ;
   gcloud auth activate-service-account --key-file=travis-sandbox.key ;
   fi
-- bq --project mlab-sandbox show base_tables.ndt
+- bq --headless --project mlab-sandbox show --format=prettyjson base_tables.ndt
 # TODO: try --headless
 - exit 1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ before_install:
 - $TRAVIS_BUILD_DIR/travis/install_gcloud.sh
 - source "${HOME}/google-cloud-sdk/path.bash.inc"
 
-- if [[ -n "$TEST_SERVICE_ACCOUNT_mlab_sandbox" ]] ; then
-  echo $TEST_SERVICE_ACCOUNT_mlab_sandbox | base64 -d > travis-sandbox.key ;
+- if [[ -n "$SERVICE_ACCOUNT_mlab_sandbox" ]] ; then
+  echo $SERVICE_ACCOUNT_mlab_sandbox | base64 -d > travis-sandbox.key ;
   gcloud auth activate-service-account --key-file=travis-sandbox.key ;
   fi
 - bq --project mlab-sandbox show base_tables.ndt

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ before_install:
 # Install gcloud, for integration tests.
 - $TRAVIS_BUILD_DIR/travis/install_gcloud.sh
 - source "${HOME}/google-cloud-sdk/path.bash.inc"
+- bq --project mlab-sandbox show base_tables.ndt
+# TODO: try --headless
+- exit 1
 
 # Install test credentials.
 # Note that anyone with github ACLs to push to a branch can hack .travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -146,6 +146,7 @@ deploy:
     all_branches: true
     condition: $TRAVIS_BRANCH == qp-sandbox-* || $TRAVIS_BRANCH == sandbox-*
 
+
 ## Service: cloud function -- AppEngine Flexible Environment.
 - provider: script
   script:
@@ -164,6 +165,7 @@ deploy:
 - provider: script
   script:
     $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_sandbox
+    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-sandbox batch
     && gcloud app deploy --project=mlab-sandbox $TRAVIS_BUILD_DIR/appengine/queue.yaml
     && $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-sandbox
     SERVICE_ACCOUNT_mlab_sandbox $TRAVIS_BUILD_DIR/cmd/etl_worker app-batch.yaml
@@ -172,6 +174,22 @@ deploy:
     repo: m-lab/etl
     all_branches: true
     condition: $TRAVIS_BRANCH == batch-sandbox-* || $TRAVIS_BRANCH == sandbox-*
+
+## Synchronize base_tables with etl-schemas.
+- provider: script
+  script:
+    $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_sandbox
+    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-sandbox base_tables
+  skip_cleanup: true
+  on:
+    repo: m-lab/etl
+    all_branches: true
+    condition: $TRAVIS_BRANCH == sandbox-* ||
+               $TRAVIS_BRANCH == ndt-sandbox-* ||
+               $TRAVIS_BRANCH == ss-sandbox-* ||
+               $TRAVIS_BRANCH == fast-sandbox-* ||
+               $TRAVIS_BRANCH == pt-sandbox-* ||
+               $TRAVIS_BRANCH == disco-sandbox-*
 
 ## Service: etl-ndt-parser -- AppEngine Flexible Environment.
 - provider: script
@@ -258,6 +276,8 @@ deploy:
   script:
     $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_staging
     && gcloud app deploy --project=mlab-staging $TRAVIS_BUILD_DIR/appengine/queue.yaml
+    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-staging batch
+    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-staging base_tables
     && $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
     SERVICE_ACCOUNT_mlab_staging $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt.yaml
     && $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
@@ -281,6 +301,7 @@ deploy:
   on:
     repo: m-lab/etl
     branch: master
+
 
 ## Service: etl-fast-ss-parser -- AppEngine Flexible Environment.
 ## Hack for demo
@@ -326,7 +347,9 @@ deploy:
 #       leaving the system in a mixed state.  This should be manually addresses ASAP.
 - provider: script
   script:
-    INJECTED_PROJECT=measurement-lab
+    $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_oti
+    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-oti base_tables
+    && INJECTED_PROJECT=measurement-lab
     $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
     SERVICE_ACCOUNT_mlab_oti $TRAVIS_BUILD_DIR/cmd/etl_worker app-traceroute.yaml
     && INJECTED_PROJECT=measurement-lab
@@ -347,6 +370,7 @@ deploy:
 - provider: script
   script:
     $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_oti
+    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-oti batch
     && gcloud app deploy --project=mlab-oti $TRAVIS_BUILD_DIR/appengine/queue.yaml
     && $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
     SERVICE_ACCOUNT_mlab_oti $TRAVIS_BUILD_DIR/cmd/etl_worker app-batch.yaml
@@ -362,6 +386,7 @@ deploy:
 - provider: script
   script:
     $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_oti
+    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-oti base_tables
     && gcloud app deploy --project=mlab-oti $TRAVIS_BUILD_DIR/appengine/queue.yaml
     && INJECTED_PROJECT=measurement-lab
     $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,6 @@ before_install:
 # Install gcloud, for integration tests.
 - $TRAVIS_BUILD_DIR/travis/install_gcloud.sh
 - source "${HOME}/google-cloud-sdk/path.bash.inc"
-- bq --project mlab-sandbox show base_tables.ndt
-# TODO: try --headless
-- exit 1
 
 # Install test credentials.
 # Note that anyone with github ACLs to push to a branch can hack .travis.yml
@@ -46,6 +43,9 @@ before_install:
   echo $TEST_SERVICE_ACCOUNT_mlab_testing | base64 -d > travis-testing.key ;
   gcloud auth activate-service-account --key-file=travis-testing.key ;
   fi
+- bq --project mlab-sandbox show base_tables.ndt
+# TODO: try --headless
+- exit 1
 
 # These directories will be cached on successful "script" builds, and restored,
 # if available, to save time on future builds.

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
 - source "${HOME}/google-cloud-sdk/path.bash.inc"
 
 - if [[ -n "$SERVICE_ACCOUNT_mlab_sandbox" ]] ; then
-  echo $SERVICE_ACCOUNT_mlab_sandbox | base64 -d > travis-sandbox.key ;
+  echo $SERVICE_ACCOUNT_mlab_sandbox > travis-sandbox.key ;
   gcloud auth activate-service-account --key-file=travis-sandbox.key ;
   fi
 - bq --project mlab-sandbox show base_tables.ndt

--- a/.travis.yml
+++ b/.travis.yml
@@ -147,7 +147,6 @@ deploy:
     all_branches: true
     condition: $TRAVIS_BRANCH == qp-sandbox-* || $TRAVIS_BRANCH == sandbox-*
 
-
 ## Service: cloud function -- AppEngine Flexible Environment.
 - provider: script
   script:
@@ -166,7 +165,7 @@ deploy:
 - provider: script
   script:
     $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_sandbox
-    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-sandbox batch
+    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-sandbox batch nodryrun
     && gcloud app deploy --project=mlab-sandbox $TRAVIS_BUILD_DIR/appengine/queue.yaml
     && $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-sandbox
     SERVICE_ACCOUNT_mlab_sandbox $TRAVIS_BUILD_DIR/cmd/etl_worker app-batch.yaml
@@ -180,7 +179,7 @@ deploy:
 - provider: script
   script:
     $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_sandbox
-    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-sandbox base_tables
+    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-sandbox base_tables nodryrun
   skip_cleanup: true
   on:
     repo: m-lab/etl
@@ -277,8 +276,8 @@ deploy:
   script:
     $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_staging
     && gcloud app deploy --project=mlab-staging $TRAVIS_BUILD_DIR/appengine/queue.yaml
-    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-staging batch
-    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-staging base_tables
+    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-staging batch nodryrun
+    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-staging base_tables nodryrun
     && $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
     SERVICE_ACCOUNT_mlab_staging $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt.yaml
     && $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
@@ -302,7 +301,6 @@ deploy:
   on:
     repo: m-lab/etl
     branch: master
-
 
 ## Service: etl-fast-ss-parser -- AppEngine Flexible Environment.
 ## Hack for demo
@@ -349,7 +347,7 @@ deploy:
 - provider: script
   script:
     $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_oti
-    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-oti base_tables
+    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-oti base_tables nodryrun
     && INJECTED_PROJECT=measurement-lab
     $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
     SERVICE_ACCOUNT_mlab_oti $TRAVIS_BUILD_DIR/cmd/etl_worker app-traceroute.yaml
@@ -371,7 +369,7 @@ deploy:
 - provider: script
   script:
     $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_oti
-    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-oti batch
+    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-oti batch nodryrun
     && gcloud app deploy --project=mlab-oti $TRAVIS_BUILD_DIR/appengine/queue.yaml
     && $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
     SERVICE_ACCOUNT_mlab_oti $TRAVIS_BUILD_DIR/cmd/etl_worker app-batch.yaml
@@ -387,7 +385,7 @@ deploy:
 - provider: script
   script:
     $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_oti
-    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-oti base_tables
+    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-oti base_tables nodryrun
     && gcloud app deploy --project=mlab-oti $TRAVIS_BUILD_DIR/appengine/queue.yaml
     && INJECTED_PROJECT=measurement-lab
     $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,13 +36,13 @@ before_install:
 - $TRAVIS_BUILD_DIR/travis/install_gcloud.sh
 - source "${HOME}/google-cloud-sdk/path.bash.inc"
 
+# TODO: remove this after merging https://github.com/m-lab/etl-schema/pull/10
 - if [[ -n "$SERVICE_ACCOUNT_mlab_sandbox" ]] ; then
   echo $SERVICE_ACCOUNT_mlab_sandbox > travis-sandbox.key ;
   gcloud auth activate-service-account --key-file=travis-sandbox.key ;
   fi
-- bq --headless --project mlab-sandbox show --format=prettyjson base_tables.ndt
-# TODO: try --headless
-- exit 1
+# Trick bq into setting up auth so sync_tables_with_schema.sh works correctly.
+- bq --project mlab-sandbox ls fake-dataset
 
 # Install test credentials.
 # Note that anyone with github ACLs to push to a branch can hack .travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@
 language: go
 
 before_install:
+- apt-get install -y jq  # Dependency for sync_tables_with_schema.sh.
 # Install javascript libraries
 - pushd $TRAVIS_BUILD_DIR/functions
 - npm install --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@
 language: go
 
 before_install:
-- apt-get install -y jq  # Dependency for sync_tables_with_schema.sh.
+- sudo apt-get install -y jq  # Dependency for sync_tables_with_schema.sh.
 # Install javascript libraries
 - pushd $TRAVIS_BUILD_DIR/functions
 - npm install --verbose


### PR DESCRIPTION
This change adds sync_tables_with_schema.sh to the relevant sections for all etl deployments. This change also adds the etl-schema repo as a submodule.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/578)
<!-- Reviewable:end -->
