### PR TITLE
Rollback instance & rate increases to unblock k8s platform work while…

### DIFF
--- a/appengine/queue.yaml
+++ b/appengine/queue.yaml
@@ -95,7 +95,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 150
+  max_concurrent_requests: 30
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -106,7 +106,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 150
+  max_concurrent_requests: 30
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -116,7 +116,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 150
+  max_concurrent_requests: 30
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -126,7 +126,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 150
+  max_concurrent_requests: 30
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -136,7 +136,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 150
+  max_concurrent_requests: 30
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -146,7 +146,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 150
+  max_concurrent_requests: 30
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -156,7 +156,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 150
+  max_concurrent_requests: 30
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -166,7 +166,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 150
+  max_concurrent_requests: 30
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -176,7 +176,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 150
+  max_concurrent_requests: 30
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -186,7 +186,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 150
+  max_concurrent_requests: 30
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -196,7 +196,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 150
+  max_concurrent_requests: 30
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -206,7 +206,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 150
+  max_concurrent_requests: 30
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -216,7 +216,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 150
+  max_concurrent_requests: 30
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -226,7 +226,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 150
+  max_concurrent_requests: 30
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -236,7 +236,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 150
+  max_concurrent_requests: 30
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -246,7 +246,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 150
+  max_concurrent_requests: 30
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -258,7 +258,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -271,7 +271,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -284,7 +284,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -297,7 +297,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -310,7 +310,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -323,7 +323,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -336,7 +336,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -349,7 +349,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -362,7 +362,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -375,7 +375,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -388,7 +388,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -401,7 +401,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -414,7 +414,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -427,7 +427,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -440,7 +440,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -453,7 +453,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -467,7 +467,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 100
+  max_concurrent_requests: 20
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -479,7 +479,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 100
+  max_concurrent_requests: 20
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -488,7 +488,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 100
+  max_concurrent_requests: 20
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -497,7 +497,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 100
+  max_concurrent_requests: 20
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -506,7 +506,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 100
+  max_concurrent_requests: 20
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -515,7 +515,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 100
+  max_concurrent_requests: 20
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -524,7 +524,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 100
+  max_concurrent_requests: 20
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -533,7 +533,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 100
+  max_concurrent_requests: 20
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -542,7 +542,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 100
+  max_concurrent_requests: 20
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -551,7 +551,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 100
+  max_concurrent_requests: 20
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -560,7 +560,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 100
+  max_concurrent_requests: 20
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -569,7 +569,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 100
+  max_concurrent_requests: 20
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -578,7 +578,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 100
+  max_concurrent_requests: 20
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -587,7 +587,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 100
+  max_concurrent_requests: 20
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -596,7 +596,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 100
+  max_concurrent_requests: 20
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -605,7 +605,7 @@ queue:
   target: etl-batch-parser
   rate: 5/s
   bucket_size: 10
-  max_concurrent_requests: 100
+  max_concurrent_requests: 20
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -616,7 +616,7 @@ queue:
   rate: 2/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 5
+  max_concurrent_requests: 2
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -628,7 +628,7 @@ queue:
   target: etl-batch-parser
   rate: 2/s
   bucket_size: 10
-  max_concurrent_requests: 5
+  max_concurrent_requests: 2
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -637,7 +637,7 @@ queue:
   target: etl-batch-parser
   rate: 2/s
   bucket_size: 10
-  max_concurrent_requests: 5
+  max_concurrent_requests: 2
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -646,7 +646,7 @@ queue:
   target: etl-batch-parser
   rate: 2/s
   bucket_size: 10
-  max_concurrent_requests: 5
+  max_concurrent_requests: 2
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20

--- a/cmd/etl_worker/app-batch.yaml
+++ b/cmd/etl_worker/app-batch.yaml
@@ -22,7 +22,7 @@ resources:
 automatic_scaling:
   # This is intended for batch jobs.
   min_num_instances: 20
-  max_num_instances: 250
+  max_num_instances: 50
   # Very long cool down period, to reduce the likelihood of tasks being truncated.
   cool_down_period_sec: 1800
   # We don't care much about latency, so a high utilization is desireable.


### PR DESCRIPTION
DO NOT SUBMIT.

This PR reverts the increase instance and rates for the batch pipeline because the excess resource utilization was preventing development work on the k8s platform while we wait for quota increases for IP addresses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/579)
<!-- Reviewable:end -->
