### PR TITLE
reduce max instances to 100

### DIFF
--- a/cmd/etl_worker/app-batch.yaml
+++ b/cmd/etl_worker/app-batch.yaml
@@ -22,7 +22,7 @@ resources:
 automatic_scaling:
   # This is intended for batch jobs.
   min_num_instances: 20
-  max_num_instances: 250
+  max_num_instances: 100
   # Very long cool down period, to reduce the likelihood of tasks being truncated.
   cool_down_period_sec: 1800
   # We don't care much about latency, so a high utilization is desireable.


### PR DESCRIPTION
We are having some stability problems around 150 instances in sandbox.  Staging seems to be working ok with 250 instances, though we are hitting bigquery streaming quota caps.  Staging is running etl commit 37639eb, with 250 instances, but with modest throughput, with only about 3 or 4 workers per instance active.  So that probably accounts for the better stability.  Not clear why the number of workers is lower.

Anyhow, this PR changes the max instances to 100.  When we have worked out the scaling kinks, we can gradually increase the max again.

This PR does NOT changes the task queue configs, so the queues will likely max out the workers, and cause high task rejection rates from the pipeline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/581)
<!-- Reviewable:end -->
