### PR TITLE
Use static metric label for annotator post errors

### DIFF
--- a/annotation/geo.go
+++ b/annotation/geo.go
@@ -217,7 +217,11 @@ func ParseJSONGeoDataResponse(jsonBuffer []byte) (*GeoData, error) {
 func GetBatchGeoData(url string, data []RequestData) map[string]GeoData {
 	// Query the service and grab the response safely
 	// All errors are recorded to metrics, so OK to ignore them here.
-	annotatorResponse, _ := BatchQueryAnnotationService(url, data)
+	annotatorResponse, err := BatchQueryAnnotationService(url, data)
+	if err != nil {
+		log.Println("BatchQueryAnnotationService Error:", err)
+		return nil
+	}
 
 	// Safely parse the JSON response and pass it back to the caller
 	geoDataFromResponse, err := BatchParseJSONGeoDataResponse(annotatorResponse)
@@ -257,7 +261,7 @@ func BatchQueryAnnotationService(url string, data []RequestData) ([]byte, error)
 	// Catch http errors
 	if err != nil {
 		metrics.AnnotationErrorCount.
-			With(prometheus.Labels{"source": err.Error()}).Inc()
+			With(prometheus.Labels{"source": "Post Error"}).Inc()
 		return nil, err
 	}
 


### PR DESCRIPTION
This change reduces label noise from the AnnotationErrorCount metric and logs the error.

Fixes: https://github.com/m-lab/etl/issues/586

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/587)
<!-- Reviewable:end -->
