### PR TITLE
Use tags for map names

### DIFF
--- a/annotation/geo.go
+++ b/annotation/geo.go
@@ -44,17 +44,18 @@ func EnableAnnotation() {
 // capitalized for exporting, although the originals in the DB schema
 // are not.
 type GeolocationIP struct {
-	Continent_code string  `json:"continent_code,,omitempty"` // Gives a shorthand for the continent
-	Country_code   string  `json:"country_code,,omitempty"`   // Gives a shorthand for the country
-	Country_code3  string  `json:"country_code3,,omitempty"`  // Gives a shorthand for the country
-	Country_name   string  `json:"country_name,,omitempty"`   // Name of the country
-	Region         string  `json:"region,,omitempty"`         // Region or State within the country
-	Metro_code     int64   `json:"metro_code,,omitempty"`     // Metro code within the country
-	City           string  `json:"city,,omitempty"`           // City within the region
-	Area_code      int64   `json:"area_code,,omitempty"`      // Area code, similar to metro code
-	Postal_code    string  `json:"postal_code,,omitempty"`    // Postal code, again similar to metro
-	Latitude       float64 `json:"latitude"`                  // Latitude
-	Longitude      float64 `json:"longitude"`                 // Longitude
+	// TODO - Are these correct?  Looks like double ,, should be single ,
+	ContinentCode string  `json:"continent_code,,omitempty"` // Gives a shorthand for the continent
+	CountryCode   string  `json:"country_code,,omitempty"`   // Gives a shorthand for the country
+	CountryCode3  string  `json:"country_code3,,omitempty"`  // Gives a shorthand for the country
+	CountryName   string  `json:"country_name,,omitempty"`   // Name of the country
+	Region        string  `json:"region,,omitempty"`         // Region or State within the country
+	MetroCode     int64   `json:"metro_code,,omitempty"`     // Metro code within the country
+	City          string  `json:"city,,omitempty"`           // City within the region
+	AreaCode      int64   `json:"area_code,,omitempty"`      // Area code, similar to metro code
+	PostalCode    string  `json:"postal_code,,omitempty"`    // Postal code, again similar to metro
+	Latitude      float64 `json:"latitude"`                  // Latitude
+	Longitude     float64 `json:"longitude"`                 // Longitude
 
 }
 

--- a/annotation/geo_test.go
+++ b/annotation/geo_test.go
@@ -45,7 +45,7 @@ func TestFetchGeoAnnotations(t *testing.T) {
 			},
 			res: []*annotation.GeolocationIP{
 				&annotation.GeolocationIP{},
-				&annotation.GeolocationIP{Postal_code: "10583"},
+				&annotation.GeolocationIP{PostalCode: "10583"},
 				&annotation.GeolocationIP{},
 			},
 		},
@@ -82,7 +82,7 @@ func TestGetAndInsertGeolocationIPStruct(t *testing.T) {
 			geo: &annotation.GeolocationIP{},
 			ip:  "127.0.0.1",
 			url: "/10583",
-			res: &annotation.GeolocationIP{Postal_code: "10583"},
+			res: &annotation.GeolocationIP{PostalCode: "10583"},
 		},
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/parser/geo_annotation.go
+++ b/parser/geo_annotation.go
@@ -206,9 +206,11 @@ func CopyStructToMap(sourceStruct interface{}, destinationMap map[string]bigquer
 	structToCopy := reflect.ValueOf(sourceStruct).Elem()
 	typeOfStruct := structToCopy.Type()
 	for i := 0; i < typeOfStruct.NumField(); i++ {
-		v := structToCopy.Field(i).Interface()
+		f := structToCopy.Field(i)
+		v := f.Interface()
 		switch t := v.(type) {
 		case string:
+			// TODO - are these still needed?  Does the omitempty cover it?
 			if t == "" {
 				continue
 			}
@@ -217,7 +219,15 @@ func CopyStructToMap(sourceStruct interface{}, destinationMap map[string]bigquer
 				continue
 			}
 		}
-		destinationMap[strings.ToLower(typeOfStruct.Field(i).Name)] = v
+		jsonTag, ok := typeOfStruct.Field(i).Tag.Lookup("json")
+		name := strings.ToLower(typeOfStruct.Field(i).Name)
+		if ok {
+			tags := strings.Split(jsonTag, ",")
+			if len(tags) > 0 && tags[0] != "" {
+				name = tags[0]
+			}
+		}
+		destinationMap[strings.ToLower(name)] = v
 	}
 }
 

--- a/parser/geo_annotation_test.go
+++ b/parser/geo_annotation_test.go
@@ -38,7 +38,7 @@ func TestAddGeoDataSSConnSpec(t *testing.T) {
 			url:       "/src",
 			res: schema.Web100ConnectionSpecification{
 				Local_ip:          "127.0.0.1",
-				Local_geolocation: annotation.GeolocationIP{Postal_code: "10583"},
+				Local_geolocation: annotation.GeolocationIP{PostalCode: "10583"},
 			},
 		},
 		{
@@ -47,7 +47,7 @@ func TestAddGeoDataSSConnSpec(t *testing.T) {
 			url:       "/dest",
 			res: schema.Web100ConnectionSpecification{
 				Remote_ip:          "127.0.0.1",
-				Remote_geolocation: annotation.GeolocationIP{Postal_code: "10583"},
+				Remote_geolocation: annotation.GeolocationIP{PostalCode: "10583"},
 			},
 		},
 		{
@@ -56,9 +56,9 @@ func TestAddGeoDataSSConnSpec(t *testing.T) {
 			url:       "/both",
 			res: schema.Web100ConnectionSpecification{
 				Local_ip:           "127.0.0.1",
-				Local_geolocation:  annotation.GeolocationIP{Postal_code: "10583"},
+				Local_geolocation:  annotation.GeolocationIP{PostalCode: "10583"},
 				Remote_ip:          "127.0.0.2",
-				Remote_geolocation: annotation.GeolocationIP{Postal_code: "10584"},
+				Remote_geolocation: annotation.GeolocationIP{PostalCode: "10584"},
 			},
 		},
 	}
@@ -94,7 +94,7 @@ func TestAddGeoDataPTConnSpec(t *testing.T) {
 			url:       "/src",
 			res: schema.MLabConnectionSpecification{
 				Server_ip:          "127.0.0.1",
-				Server_geolocation: annotation.GeolocationIP{Postal_code: "10583"},
+				Server_geolocation: annotation.GeolocationIP{PostalCode: "10583"},
 			},
 		},
 		{
@@ -103,7 +103,7 @@ func TestAddGeoDataPTConnSpec(t *testing.T) {
 			url:       "/dest",
 			res: schema.MLabConnectionSpecification{
 				Client_ip:          "127.0.0.1",
-				Client_geolocation: annotation.GeolocationIP{Postal_code: "10583"},
+				Client_geolocation: annotation.GeolocationIP{PostalCode: "10583"},
 			},
 		},
 		{
@@ -112,9 +112,9 @@ func TestAddGeoDataPTConnSpec(t *testing.T) {
 			url:       "/both",
 			res: schema.MLabConnectionSpecification{
 				Server_ip:          "127.0.0.1",
-				Server_geolocation: annotation.GeolocationIP{Postal_code: "10583"},
+				Server_geolocation: annotation.GeolocationIP{PostalCode: "10583"},
 				Client_ip:          "127.0.0.2",
-				Client_geolocation: annotation.GeolocationIP{Postal_code: "10584"},
+				Client_geolocation: annotation.GeolocationIP{PostalCode: "10584"},
 			},
 		},
 	}
@@ -149,9 +149,9 @@ func TestAddGeoDataPTHopBatchBadIPv6(t *testing.T) {
 			res: []*schema.ParisTracerouteHop{
 				&schema.ParisTracerouteHop{
 					Src_ip:           "fe80::301f:d5b0:3fb7:3a00",
-					Src_geolocation:  annotation.GeolocationIP{Area_code: 10583},
+					Src_geolocation:  annotation.GeolocationIP{AreaCode: 10583},
 					Dest_ip:          "2620:0:1003:415:b33e:9d6a:81bf:87a1",
-					Dest_geolocation: annotation.GeolocationIP{Area_code: 10584},
+					Dest_geolocation: annotation.GeolocationIP{AreaCode: 10584},
 				},
 			},
 		},
@@ -194,9 +194,9 @@ func TestAddGeoDataPTHopBatch(t *testing.T) {
 			res: []*schema.ParisTracerouteHop{
 				&schema.ParisTracerouteHop{
 					Src_ip:           "127.0.0.1",
-					Src_geolocation:  annotation.GeolocationIP{Area_code: 914},
+					Src_geolocation:  annotation.GeolocationIP{AreaCode: 914},
 					Dest_ip:          "1.0.0.127",
-					Dest_geolocation: annotation.GeolocationIP{Area_code: 212},
+					Dest_geolocation: annotation.GeolocationIP{AreaCode: 212},
 				},
 			},
 		},
@@ -308,7 +308,7 @@ func TestAddGeoDataPTHop(t *testing.T) {
 			url:       "/src",
 			res: schema.ParisTracerouteHop{
 				Src_ip:          "127.0.0.1",
-				Src_geolocation: annotation.GeolocationIP{Postal_code: "10583"},
+				Src_geolocation: annotation.GeolocationIP{PostalCode: "10583"},
 			},
 		},
 		{
@@ -317,7 +317,7 @@ func TestAddGeoDataPTHop(t *testing.T) {
 			url:       "/dest",
 			res: schema.ParisTracerouteHop{
 				Dest_ip:          "127.0.0.1",
-				Dest_geolocation: annotation.GeolocationIP{Postal_code: "10583"},
+				Dest_geolocation: annotation.GeolocationIP{PostalCode: "10583"},
 			},
 		},
 		{
@@ -326,9 +326,9 @@ func TestAddGeoDataPTHop(t *testing.T) {
 			url:       "/both",
 			res: schema.ParisTracerouteHop{
 				Src_ip:           "127.0.0.1",
-				Src_geolocation:  annotation.GeolocationIP{Postal_code: "10583"},
+				Src_geolocation:  annotation.GeolocationIP{PostalCode: "10583"},
 				Dest_ip:          "127.0.0.2",
-				Dest_geolocation: annotation.GeolocationIP{Postal_code: "10583"},
+				Dest_geolocation: annotation.GeolocationIP{PostalCode: "10583"},
 			},
 		},
 	}


### PR DESCRIPTION
ETL code currently depends on GeoLocationIP field names, instead of json tags.
This fixes that, so that we can use common annotation-service/api/api.go in next PR.

See #593

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/594)
<!-- Reviewable:end -->
