### PR TITLE
Use annotator structs

### DIFF
--- a/annotation/geo_test.go
+++ b/annotation/geo_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/m-lab/annotation-service/api"
 	"github.com/m-lab/etl/annotation"
 )
 
@@ -26,27 +27,27 @@ func TestFetchGeoAnnotations(t *testing.T) {
 	tests := []struct {
 		ips       []string
 		timestamp time.Time
-		geoDest   []*annotation.GeolocationIP
-		res       []*annotation.GeolocationIP
+		geoDest   []*api.GeolocationIP
+		res       []*api.GeolocationIP
 	}{
 		{
 			ips:       []string{},
 			timestamp: epoch,
-			geoDest:   []*annotation.GeolocationIP{},
-			res:       []*annotation.GeolocationIP{},
+			geoDest:   []*api.GeolocationIP{},
+			res:       []*api.GeolocationIP{},
 		},
 		{
 			ips:       []string{"", "127.0.0.1", "2.2.2.2"},
 			timestamp: epoch,
-			geoDest: []*annotation.GeolocationIP{
-				&annotation.GeolocationIP{},
-				&annotation.GeolocationIP{},
-				&annotation.GeolocationIP{},
+			geoDest: []*api.GeolocationIP{
+				&api.GeolocationIP{},
+				&api.GeolocationIP{},
+				&api.GeolocationIP{},
 			},
-			res: []*annotation.GeolocationIP{
-				&annotation.GeolocationIP{},
-				&annotation.GeolocationIP{PostalCode: "10583"},
-				&annotation.GeolocationIP{},
+			res: []*api.GeolocationIP{
+				&api.GeolocationIP{},
+				&api.GeolocationIP{PostalCode: "10583"},
+				&api.GeolocationIP{},
 			},
 		},
 	}
@@ -65,24 +66,24 @@ func TestFetchGeoAnnotations(t *testing.T) {
 
 func TestGetAndInsertGeolocationIPStruct(t *testing.T) {
 	tests := []struct {
-		geo       *annotation.GeolocationIP
+		geo       *api.GeolocationIP
 		ip        string
 		timestamp time.Time
 		url       string
-		res       *annotation.GeolocationIP
+		res       *api.GeolocationIP
 	}{
 		{
-			geo:       &annotation.GeolocationIP{},
+			geo:       &api.GeolocationIP{},
 			ip:        "123.123.123.001",
 			timestamp: time.Now(),
 			url:       "portGarbage",
-			res:       &annotation.GeolocationIP{},
+			res:       &api.GeolocationIP{},
 		},
 		{
-			geo: &annotation.GeolocationIP{},
+			geo: &api.GeolocationIP{},
 			ip:  "127.0.0.1",
 			url: "/10583",
-			res: &annotation.GeolocationIP{PostalCode: "10583"},
+			res: &api.GeolocationIP{PostalCode: "10583"},
 		},
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -101,7 +102,7 @@ func TestGetAndInsertGeolocationIPStruct(t *testing.T) {
 func TestGetGeoData(t *testing.T) {
 	tests := []struct {
 		url string
-		res *annotation.GeoData
+		res *api.GeoData
 	}{
 		{
 			url: "portGarbage",
@@ -113,7 +114,7 @@ func TestGetGeoData(t *testing.T) {
 		},
 		{
 			url: "/goodJson",
-			res: &annotation.GeoData{},
+			res: &api.GeoData{},
 		},
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -179,12 +180,12 @@ func TestQueryAnnotationService(t *testing.T) {
 func TestParseJSONGeoDataResponse(t *testing.T) {
 	tests := []struct {
 		testBuffer  []byte
-		resultData  *annotation.GeoData
+		resultData  *api.GeoData
 		resultError error
 	}{
 		{
 			testBuffer:  []byte(`{"Geo":null,"ASN":null}`),
-			resultData:  &annotation.GeoData{Geo: nil, ASN: nil},
+			resultData:  &api.GeoData{Geo: nil, ASN: nil},
 			resultError: nil,
 		},
 		{
@@ -213,7 +214,7 @@ func TestParseJSONGeoDataResponse(t *testing.T) {
 func TestGetBatchGeoData(t *testing.T) {
 	tests := []struct {
 		url string
-		res map[string]annotation.GeoData
+		res map[string]api.GeoData
 	}{
 		{
 			url: "portGarbage",
@@ -225,7 +226,7 @@ func TestGetBatchGeoData(t *testing.T) {
 		},
 		{
 			url: "/goodJson",
-			res: map[string]annotation.GeoData{"127.0.0.1xyz": {Geo: nil, ASN: nil}},
+			res: map[string]api.GeoData{"127.0.0.1xyz": {Geo: nil, ASN: nil}},
 		},
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -291,7 +292,7 @@ func TestBatchQueryAnnotationService(t *testing.T) {
 func TestBatchParseJSONGeoDataResponse(t *testing.T) {
 	tests := []struct {
 		testBuffer  []byte
-		resultData  map[string]annotation.GeoData
+		resultData  map[string]api.GeoData
 		resultError error
 	}{
 		{
@@ -299,7 +300,7 @@ func TestBatchParseJSONGeoDataResponse(t *testing.T) {
 			// addresses. The xyz could be a base36
 			// encoded timestamp.
 			testBuffer:  []byte(`{"127.0.0.1xyz": {"Geo":null,"ASN":null}}`),
-			resultData:  map[string]annotation.GeoData{"127.0.0.1xyz": {Geo: nil, ASN: nil}},
+			resultData:  map[string]api.GeoData{"127.0.0.1xyz": {Geo: nil, ASN: nil}},
 			resultError: nil,
 		},
 		{

--- a/parser/geo_annotation_test.go
+++ b/parser/geo_annotation_test.go
@@ -12,6 +12,7 @@ import (
 
 	"cloud.google.com/go/bigquery"
 
+	"github.com/m-lab/annotation-service/api"
 	"github.com/m-lab/etl/annotation"
 	p "github.com/m-lab/etl/parser"
 	"github.com/m-lab/etl/schema"
@@ -38,7 +39,7 @@ func TestAddGeoDataSSConnSpec(t *testing.T) {
 			url:       "/src",
 			res: schema.Web100ConnectionSpecification{
 				Local_ip:          "127.0.0.1",
-				Local_geolocation: annotation.GeolocationIP{PostalCode: "10583"},
+				Local_geolocation: api.GeolocationIP{PostalCode: "10583"},
 			},
 		},
 		{
@@ -47,7 +48,7 @@ func TestAddGeoDataSSConnSpec(t *testing.T) {
 			url:       "/dest",
 			res: schema.Web100ConnectionSpecification{
 				Remote_ip:          "127.0.0.1",
-				Remote_geolocation: annotation.GeolocationIP{PostalCode: "10583"},
+				Remote_geolocation: api.GeolocationIP{PostalCode: "10583"},
 			},
 		},
 		{
@@ -56,9 +57,9 @@ func TestAddGeoDataSSConnSpec(t *testing.T) {
 			url:       "/both",
 			res: schema.Web100ConnectionSpecification{
 				Local_ip:           "127.0.0.1",
-				Local_geolocation:  annotation.GeolocationIP{PostalCode: "10583"},
+				Local_geolocation:  api.GeolocationIP{PostalCode: "10583"},
 				Remote_ip:          "127.0.0.2",
-				Remote_geolocation: annotation.GeolocationIP{PostalCode: "10584"},
+				Remote_geolocation: api.GeolocationIP{PostalCode: "10584"},
 			},
 		},
 	}
@@ -94,7 +95,7 @@ func TestAddGeoDataPTConnSpec(t *testing.T) {
 			url:       "/src",
 			res: schema.MLabConnectionSpecification{
 				Server_ip:          "127.0.0.1",
-				Server_geolocation: annotation.GeolocationIP{PostalCode: "10583"},
+				Server_geolocation: api.GeolocationIP{PostalCode: "10583"},
 			},
 		},
 		{
@@ -103,7 +104,7 @@ func TestAddGeoDataPTConnSpec(t *testing.T) {
 			url:       "/dest",
 			res: schema.MLabConnectionSpecification{
 				Client_ip:          "127.0.0.1",
-				Client_geolocation: annotation.GeolocationIP{PostalCode: "10583"},
+				Client_geolocation: api.GeolocationIP{PostalCode: "10583"},
 			},
 		},
 		{
@@ -112,9 +113,9 @@ func TestAddGeoDataPTConnSpec(t *testing.T) {
 			url:       "/both",
 			res: schema.MLabConnectionSpecification{
 				Server_ip:          "127.0.0.1",
-				Server_geolocation: annotation.GeolocationIP{PostalCode: "10583"},
+				Server_geolocation: api.GeolocationIP{PostalCode: "10583"},
 				Client_ip:          "127.0.0.2",
-				Client_geolocation: annotation.GeolocationIP{PostalCode: "10584"},
+				Client_geolocation: api.GeolocationIP{PostalCode: "10584"},
 			},
 		},
 	}
@@ -149,9 +150,9 @@ func TestAddGeoDataPTHopBatchBadIPv6(t *testing.T) {
 			res: []*schema.ParisTracerouteHop{
 				&schema.ParisTracerouteHop{
 					Src_ip:           "fe80::301f:d5b0:3fb7:3a00",
-					Src_geolocation:  annotation.GeolocationIP{AreaCode: 10583},
+					Src_geolocation:  api.GeolocationIP{AreaCode: 10583},
 					Dest_ip:          "2620:0:1003:415:b33e:9d6a:81bf:87a1",
-					Dest_geolocation: annotation.GeolocationIP{AreaCode: 10584},
+					Dest_geolocation: api.GeolocationIP{AreaCode: 10584},
 				},
 			},
 		},
@@ -194,9 +195,9 @@ func TestAddGeoDataPTHopBatch(t *testing.T) {
 			res: []*schema.ParisTracerouteHop{
 				&schema.ParisTracerouteHop{
 					Src_ip:           "127.0.0.1",
-					Src_geolocation:  annotation.GeolocationIP{AreaCode: 914},
+					Src_geolocation:  api.GeolocationIP{AreaCode: 914},
 					Dest_ip:          "1.0.0.127",
-					Dest_geolocation: annotation.GeolocationIP{AreaCode: 212},
+					Dest_geolocation: api.GeolocationIP{AreaCode: 212},
 				},
 			},
 		},
@@ -217,7 +218,7 @@ func TestAddGeoDataPTHopBatch(t *testing.T) {
 func TestAnnotatePTHops(t *testing.T) {
 	tests := []struct {
 		hops           []*schema.ParisTracerouteHop
-		annotationData map[string]annotation.GeoData
+		annotationData map[string]api.GeoData
 		timestamp      time.Time
 		res            []*schema.ParisTracerouteHop
 	}{
@@ -229,25 +230,25 @@ func TestAnnotatePTHops(t *testing.T) {
 		},
 		{
 			hops:           []*schema.ParisTracerouteHop{nil},
-			annotationData: map[string]annotation.GeoData{},
+			annotationData: map[string]api.GeoData{},
 			timestamp:      epoch,
 			res:            []*schema.ParisTracerouteHop{nil},
 		},
 		{
 			hops: []*schema.ParisTracerouteHop{&schema.ParisTracerouteHop{Src_ip: "127.0.0.1"}},
-			annotationData: map[string]annotation.GeoData{"127.0.0.10": annotation.GeoData{
-				Geo: &annotation.GeolocationIP{}, ASN: nil}},
+			annotationData: map[string]api.GeoData{"127.0.0.10": api.GeoData{
+				Geo: &api.GeolocationIP{}, ASN: nil}},
 			timestamp: epoch,
 			res: []*schema.ParisTracerouteHop{&schema.ParisTracerouteHop{Src_ip: "127.0.0.1",
-				Src_geolocation: annotation.GeolocationIP{}}},
+				Src_geolocation: api.GeolocationIP{}}},
 		},
 		{
 			hops: []*schema.ParisTracerouteHop{&schema.ParisTracerouteHop{Dest_ip: "1.0.0.127"}},
-			annotationData: map[string]annotation.GeoData{"1.0.0.1270": annotation.GeoData{
-				Geo: &annotation.GeolocationIP{}, ASN: nil}},
+			annotationData: map[string]api.GeoData{"1.0.0.1270": api.GeoData{
+				Geo: &api.GeolocationIP{}, ASN: nil}},
 			timestamp: epoch,
 			res: []*schema.ParisTracerouteHop{&schema.ParisTracerouteHop{Dest_ip: "1.0.0.127",
-				Dest_geolocation: annotation.GeolocationIP{}}},
+				Dest_geolocation: api.GeolocationIP{}}},
 		},
 	}
 	for _, test := range tests {
@@ -263,22 +264,22 @@ func TestCreateRequestDataFromPTHops(t *testing.T) {
 	tests := []struct {
 		hops      []*schema.ParisTracerouteHop
 		timestamp time.Time
-		res       []annotation.RequestData
+		res       []api.RequestData
 	}{
 		{
 			hops:      []*schema.ParisTracerouteHop{},
 			timestamp: epoch,
-			res:       []annotation.RequestData{},
+			res:       []api.RequestData{},
 		},
 		{
 			hops:      []*schema.ParisTracerouteHop{&schema.ParisTracerouteHop{Dest_ip: "1.0.0.127"}},
 			timestamp: epoch,
-			res:       []annotation.RequestData{annotation.RequestData{"1.0.0.127", 0, epoch}},
+			res:       []api.RequestData{api.RequestData{"1.0.0.127", 0, epoch}},
 		},
 		{
 			hops:      []*schema.ParisTracerouteHop{&schema.ParisTracerouteHop{Src_ip: "127.0.0.1"}},
 			timestamp: epoch,
-			res:       []annotation.RequestData{annotation.RequestData{"127.0.0.1", 0, epoch}},
+			res:       []api.RequestData{api.RequestData{"127.0.0.1", 0, epoch}},
 		},
 	}
 	for _, test := range tests {
@@ -308,7 +309,7 @@ func TestAddGeoDataPTHop(t *testing.T) {
 			url:       "/src",
 			res: schema.ParisTracerouteHop{
 				Src_ip:          "127.0.0.1",
-				Src_geolocation: annotation.GeolocationIP{PostalCode: "10583"},
+				Src_geolocation: api.GeolocationIP{PostalCode: "10583"},
 			},
 		},
 		{
@@ -317,7 +318,7 @@ func TestAddGeoDataPTHop(t *testing.T) {
 			url:       "/dest",
 			res: schema.ParisTracerouteHop{
 				Dest_ip:          "127.0.0.1",
-				Dest_geolocation: annotation.GeolocationIP{PostalCode: "10583"},
+				Dest_geolocation: api.GeolocationIP{PostalCode: "10583"},
 			},
 		},
 		{
@@ -326,9 +327,9 @@ func TestAddGeoDataPTHop(t *testing.T) {
 			url:       "/both",
 			res: schema.ParisTracerouteHop{
 				Src_ip:           "127.0.0.1",
-				Src_geolocation:  annotation.GeolocationIP{PostalCode: "10583"},
+				Src_geolocation:  api.GeolocationIP{PostalCode: "10583"},
 				Dest_ip:          "127.0.0.2",
-				Dest_geolocation: annotation.GeolocationIP{PostalCode: "10583"},
+				Dest_geolocation: api.GeolocationIP{PostalCode: "10583"},
 			},
 		},
 	}
@@ -350,105 +351,87 @@ func testTime() time.Time {
 	return tst
 }
 
-var tests = []struct {
-	spec      schema.Web100ValueMap
-	timestamp time.Time
-	url       string
-	res       schema.Web100ValueMap
-}{
-	{
-		spec: func() schema.Web100ValueMap {
-			spec := schema.EmptyConnectionSpec()
-			spec["client_ip"] = "127.0.0.1"
-			spec["server_ip"] = "1.0.0.127"
-			return spec
-		}(),
-		timestamp: testTime(),
-		url:       "/10583?",
-		res: func() schema.Web100ValueMap {
-			spec := schema.EmptyConnectionSpec()
-			spec["client_ip"] = "127.0.0.1"
-			spec["server_ip"] = "1.0.0.127"
-			geoc := spec.Get("client_geolocation")
-			geoc["country_code"] = "US"
-			geoc["country_code3"] = "USA"
-			geoc["country_name"] = "United States of America"
-			geoc["region"] = "NY"
-			geoc["city"] = "Scarsdale"
-			geoc["area_code"] = int64(10583)
-			geoc["postal_code"] = "10583"
-			geoc["latitude"] = float64(41.0051)
-			geoc["longitude"] = float64(73.7846)
-			geos := spec.Get("server_geolocation")
-			geos["country_code"] = "US"
-			geos["country_code3"] = "USA"
-			geos["country_name"] = "United States of America"
-			geos["region"] = "NY"
-			geos["city"] = "Scarsdale"
-			geos["area_code"] = int64(10584)
-			geos["postal_code"] = "10584"
-			geos["latitude"] = float64(41.0051)
-			geos["longitude"] = float64(73.7846)
-			return spec
-		}(),
-	},
-	{ // This test exercises the error path one missing IP
-		spec: func() schema.Web100ValueMap {
-			spec := schema.EmptyConnectionSpec()
-			spec["client_ip"] = "127.0.0.1"
-			return spec
-		}(),
-		timestamp: testTime(),
-		url:       "/10583?",
-		res: func() schema.Web100ValueMap {
-			spec := schema.EmptyConnectionSpec()
-			spec["client_ip"] = "127.0.0.1"
-			geoc := spec.Get("client_geolocation")
-			geoc["country_code"] = "US"
-			geoc["country_code3"] = "USA"
-			geoc["country_name"] = "United States of America"
-			geoc["region"] = "NY"
-			geoc["city"] = "Scarsdale"
-			geoc["area_code"] = int64(10583)
-			geoc["postal_code"] = "10583"
-			geoc["latitude"] = float64(41.0051)
-			geoc["longitude"] = float64(73.7846)
-			return spec
-		}(),
-	},
-	{ // This test exercises the error path for missing IP addresses.
-		spec: func() schema.Web100ValueMap {
-			spec := schema.EmptyConnectionSpec()
-			return spec
-		}(),
-		timestamp: testTime(),
-		url:       "/10583?",
-		res: func() schema.Web100ValueMap {
-			spec := schema.EmptyConnectionSpec()
-			return spec
-		}(),
-	},
-}
-
-func TestDisabledAnnotation(t *testing.T) {
-	callCount := 0
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		callCount += 1
-		// Note: the "h3d0c0" in the IP strings is the appended timestamp.
-		fmt.Fprint(w, `{"127.0.0.1h3d0c0" : {"Geo":{"continent_code":"","country_code":"US","country_code3":"USA","country_name":"United States of America","region":"NY","metro_code":0,"city":"Scarsdale","area_code":10583,"postal_code":"10583","latitude":41.0051,"longitude":73.7846},"ASN":{}}`+
-			`,"1.0.0.127h3d0c0" : {"Geo":{"continent_code":"","country_code":"US","country_code3":"USA","country_name":"United States of America","region":"NY","metro_code":0,"city":"Scarsdale","area_code":10584,"postal_code":"10584","latitude":41.0051,"longitude":73.7846},"ASN":{}}}`)
-	}))
-	for _, test := range tests {
-		annotation.BatchURL = ts.URL + test.url
-		p.AddGeoDataNDTConnSpec(test.spec, test.timestamp)
-	}
-	if callCount != 0 {
-		t.Errorf("Annotator should not have been called.  Call count: %d", callCount)
-	}
-}
-
 func TestAddGeoDataNDTConnSpec(t *testing.T) {
-	annotation.EnableAnnotation()
+	var tests = []struct {
+		spec      schema.Web100ValueMap
+		timestamp time.Time
+		url       string
+		res       schema.Web100ValueMap
+	}{
+		{
+			spec: func() schema.Web100ValueMap {
+				spec := schema.EmptyConnectionSpec()
+				spec["client_ip"] = "127.0.0.1"
+				spec["server_ip"] = "1.0.0.127"
+				return spec
+			}(),
+			timestamp: testTime(),
+			url:       "/10583?",
+			res: func() schema.Web100ValueMap {
+				spec := schema.EmptyConnectionSpec()
+				spec["client_ip"] = "127.0.0.1"
+				spec["server_ip"] = "1.0.0.127"
+				geoc := spec.Get("client_geolocation")
+				geoc["country_code"] = "US"
+				geoc["country_code3"] = "USA"
+				geoc["country_name"] = "United States of America"
+				geoc["region"] = "NY"
+				geoc["city"] = "Scarsdale"
+				geoc["area_code"] = int64(10583)
+				geoc["postal_code"] = "10583"
+				geoc["latitude"] = float64(41.0051)
+				geoc["longitude"] = float64(73.7846)
+				geos := spec.Get("server_geolocation")
+				geos["country_code"] = "US"
+				geos["country_code3"] = "USA"
+				geos["country_name"] = "United States of America"
+				geos["region"] = "NY"
+				geos["city"] = "Scarsdale"
+				geos["area_code"] = int64(10584)
+				geos["postal_code"] = "10584"
+				geos["latitude"] = float64(41.0051)
+				geos["longitude"] = float64(73.7846)
+				return spec
+			}(),
+		},
+		{ // This test exercises the error path one missing IP
+			spec: func() schema.Web100ValueMap {
+				spec := schema.EmptyConnectionSpec()
+				spec["client_ip"] = "127.0.0.1"
+				return spec
+			}(),
+			timestamp: testTime(),
+			url:       "/10583?",
+			res: func() schema.Web100ValueMap {
+				spec := schema.EmptyConnectionSpec()
+				spec["client_ip"] = "127.0.0.1"
+				geoc := spec.Get("client_geolocation")
+				geoc["country_code"] = "US"
+				geoc["country_code3"] = "USA"
+				geoc["country_name"] = "United States of America"
+				geoc["region"] = "NY"
+				geoc["city"] = "Scarsdale"
+				geoc["area_code"] = int64(10583)
+				geoc["postal_code"] = "10583"
+				geoc["latitude"] = float64(41.0051)
+				geoc["longitude"] = float64(73.7846)
+				return spec
+			}(),
+		},
+		{ // This test exercises the error path for missing IP addresses.
+			spec: func() schema.Web100ValueMap {
+				spec := schema.EmptyConnectionSpec()
+				return spec
+			}(),
+			timestamp: testTime(),
+			url:       "/10583?",
+			res: func() schema.Web100ValueMap {
+				spec := schema.EmptyConnectionSpec()
+				return spec
+			}(),
+		},
+	}
+
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Note: the "h3d0c0" in the IP strings is the appended timestamp.
 		fmt.Fprint(w, `{"127.0.0.1h3d0c0" : {"Geo":{"continent_code":"","country_code":"US","country_code3":"USA","country_name":"United States of America","region":"NY","metro_code":0,"city":"Scarsdale","area_code":10583,"postal_code":"10583","latitude":41.0051,"longitude":73.7846},"ASN":{}}`+

--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -600,11 +600,9 @@ func (n *NDTParser) getAndInsertValues(test *fileInfoAndData, testType string) {
 		// TODO: This is an insert error, that might be recoverable if we try again.
 		log.Println("insert-err: " + err.Error())
 		return
-	} else {
-		metrics.TestCount.WithLabelValues(
-			n.TableName(), testType, "ok").Inc()
-		return
 	}
+	metrics.TestCount.WithLabelValues(
+		n.TableName(), testType, "ok").Inc()
 }
 
 const (

--- a/parser/pt.go
+++ b/parser/pt.go
@@ -13,11 +13,9 @@ import (
 
 	"cloud.google.com/go/bigquery"
 
-	"github.com/m-lab/etl/annotation"
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/metrics"
 	"github.com/m-lab/etl/schema"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 type PTFileName struct {
@@ -573,13 +571,8 @@ func Parse(meta map[string]bigquery.Value, testName string, testId string, rawCo
 	}
 
 	// Only annotate if flag enabled...
-	if !annotation.IPAnnotationEnabled {
-		metrics.AnnotationErrorCount.With(prometheus.Labels{
-			"source": "IP Annotation Disabled."}).Inc()
-	} else {
-		AddGeoDataPTConnSpec(connSpec, logTime)
-		AddGeoDataPTHopBatch(PTHops, logTime)
-	}
+	AddGeoDataPTConnSpec(connSpec, logTime)
+	AddGeoDataPTHopBatch(PTHops, logTime)
 
 	return cachedPTData{
 		TestID:           testId,

--- a/parser/ss.go
+++ b/parser/ss.go
@@ -12,6 +12,7 @@ import (
 
 	"cloud.google.com/go/bigquery"
 
+	"github.com/m-lab/annotation-service/api"
 	"github.com/m-lab/etl/annotation"
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/metrics"
@@ -56,7 +57,7 @@ func (buf *RowBuffer) Annotate(tableBase string) {
 	}
 
 	ipSlice := make([]string, 2*len(buf.rows))
-	geoSlice := make([]*annotation.GeolocationIP, 2*len(buf.rows))
+	geoSlice := make([]*api.GeolocationIP, 2*len(buf.rows))
 	for i := range buf.rows {
 		row := buf.rows[i].(*schema.SS)
 		connSpec := &row.Web100_log_entry.Connection_spec

--- a/schema/pt_schema.go
+++ b/schema/pt_schema.go
@@ -4,32 +4,32 @@ package schema
 import (
 	"time"
 
-	"github.com/m-lab/etl/annotation"
+	"github.com/m-lab/annotation-service/api"
 )
 
 // TODO(dev): use mixed case Go variable names throughout
 
 type ParisTracerouteHop struct {
-	Protocol         string                   `json:"protocal,string"`
-	Src_ip           string                   `json:"src_ip,string"`
-	Src_af           int32                    `json:"src_af,int32"`
-	Dest_ip          string                   `json:"dest_ip,string"`
-	Dest_af          int32                    `json:"dest_af,int32"`
-	Src_hostname     string                   `json:"src_hostname,string"`
-	Dest_hostname    string                   `json:"dest_hostname,string"`
-	Rtt              []float64                `json:"rtt,[]float64"`
-	Src_geolocation  annotation.GeolocationIP `json:"src_geolocation"`
-	Dest_geolocation annotation.GeolocationIP `json:"dest_geolocation"`
+	Protocol         string            `json:"protocal,string"`
+	Src_ip           string            `json:"src_ip,string"`
+	Src_af           int32             `json:"src_af,int32"`
+	Dest_ip          string            `json:"dest_ip,string"`
+	Dest_af          int32             `json:"dest_af,int32"`
+	Src_hostname     string            `json:"src_hostname,string"`
+	Dest_hostname    string            `json:"dest_hostname,string"`
+	Rtt              []float64         `json:"rtt,[]float64"`
+	Src_geolocation  api.GeolocationIP `json:"src_geolocation"`
+	Dest_geolocation api.GeolocationIP `json:"dest_geolocation"`
 }
 
 type MLabConnectionSpecification struct {
-	Server_ip          string                   `json:"server_ip,string"`
-	Server_af          int32                    `json:"server_af,int32"`
-	Client_ip          string                   `json:"client_ip,string"`
-	Client_af          int32                    `json:"client_af,int32"`
-	Data_direction     int32                    `json:"data_direction,int32"`
-	Server_geolocation annotation.GeolocationIP `json:"server_geolocation"`
-	Client_geolocation annotation.GeolocationIP `json:"client_geolocation"`
+	Server_ip          string            `json:"server_ip,string"`
+	Server_af          int32             `json:"server_af,int32"`
+	Client_ip          string            `json:"client_ip,string"`
+	Client_af          int32             `json:"client_af,int32"`
+	Data_direction     int32             `json:"data_direction,int32"`
+	Server_geolocation api.GeolocationIP `json:"server_geolocation"`
+	Client_geolocation api.GeolocationIP `json:"client_geolocation"`
 }
 
 type PT struct {

--- a/schema/ss_schema.go
+++ b/schema/ss_schema.go
@@ -5,17 +5,17 @@ package schema
 import (
 	"time"
 
-	"github.com/m-lab/etl/annotation"
+	"github.com/m-lab/annotation-service/api"
 )
 
 type Web100ConnectionSpecification struct {
-	Local_ip           string                   `json:"local_ip,string"`
-	Local_af           int64                    `json:"local_af,int64"`
-	Local_port         int64                    `json:"local_port,int64"`
-	Remote_ip          string                   `json:"remote_ip,string"`
-	Remote_port        int64                    `json:"remote_port,int64"`
-	Local_geolocation  annotation.GeolocationIP `json:"local_geolocation"`
-	Remote_geolocation annotation.GeolocationIP `json:"remote_geolocation"`
+	Local_ip           string            `json:"local_ip,string"`
+	Local_af           int64             `json:"local_af,int64"`
+	Local_port         int64             `json:"local_port,int64"`
+	Remote_ip          string            `json:"remote_ip,string"`
+	Remote_port        int64             `json:"remote_port,int64"`
+	Local_geolocation  api.GeolocationIP `json:"local_geolocation"`
+	Remote_geolocation api.GeolocationIP `json:"remote_geolocation"`
 }
 
 type Web100Snap struct {


### PR DESCRIPTION
Now that json tags are respected, we can switch to the annotator/api structs.

This also removes the EnableAnnotation, since we haven't used it in over a year.
(HMM - need to check with Stephen about disco, which has annotation disabled.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/596)
<!-- Reviewable:end -->
