### PR TITLE
Use the new annotation-service/api.GetAnnotations

### DIFF
--- a/annotation/export_test.go
+++ b/annotation/export_test.go
@@ -1,0 +1,5 @@
+package annotation
+
+var (
+	BatchParseJSONGeoDataResponse = batchParseJSONGeoDataResponse
+)

--- a/annotation/geo.go
+++ b/annotation/geo.go
@@ -67,7 +67,6 @@ func FetchGeoAnnotations(ips []string, timestamp time.Time, geoDest []*api.Geolo
 	for i := range normalized {
 		data, ok := resp.Annotations[normalized[i]]
 		if !ok || data.Geo == nil {
-			// TODO(gfr) These should be warning, else we have error > request
 			metrics.AnnotationWarningCount.With(prometheus.
 				Labels{"source": "Missing or empty data for IP Address!!!"}).Inc()
 			continue

--- a/annotation/geo.go
+++ b/annotation/geo.go
@@ -61,7 +61,8 @@ func FetchGeoAnnotations(ips []string, timestamp time.Time, geoDest []*api.Geolo
 	resp, err := v2.GetAnnotations(context.Background(), BatchURL, timestamp, normalized)
 	if err != nil {
 		log.Println(err)
-		// TODO
+		// TODO should ensure that there aren't too many error types.
+		metrics.AnnotationErrorCount.With(prometheus.Labels{"source": err.Error()}).Inc()
 	}
 
 	for i := range normalized {

--- a/annotation/geo_test.go
+++ b/annotation/geo_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-test/deep"
 	"github.com/m-lab/annotation-service/api"
 	"github.com/m-lab/etl/annotation"
 )
@@ -51,15 +52,17 @@ func TestFetchGeoAnnotations(t *testing.T) {
 			},
 		},
 	}
+	responseJSON := `{"AnnotatorDate":"2018-12-05T00:00:00Z",
+	                  "Annotations":{"127.0.0.1":{"Geo":{"postal_code":"10583"}},
+	                                 "127.0.0.2":{"Geo":{"postal_code":"10584"}}}}`
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, `{"127.0.0.10" : {"Geo":{"postal_code":"10583"},"ASN":{}}`+
-			`,"2.2.2.20" : {"Geo":null,"ASN":null}}`)
+		fmt.Fprint(w, responseJSON)
 	}))
 	for _, test := range tests {
 		annotation.BatchURL = ts.URL
 		annotation.FetchGeoAnnotations(test.ips, test.timestamp, test.geoDest)
-		if !reflect.DeepEqual(test.geoDest, test.res) {
-			t.Errorf("Expected %v, got %v", test.res, test.geoDest)
+		if diff := deep.Equal(test.geoDest, test.res); diff != nil {
+			t.Error(diff)
 		}
 	}
 }

--- a/parser/geo_annotation_test.go
+++ b/parser/geo_annotation_test.go
@@ -72,8 +72,6 @@ func TestAddGeoDataSSConnSpec(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, responseJSON)
-		// `{"127.0.0.1" : {"Geo":{"postal_code":"10583"},"ASN":{}}`+
-		//`,"127.0.0.2" : {"Geo":{"postal_code":"10584"},"ASN":{}}}`)
 	}))
 	for _, test := range tests {
 		annotation.BatchURL = ts.URL + test.url

--- a/parser/geo_annotation_test.go
+++ b/parser/geo_annotation_test.go
@@ -1,5 +1,7 @@
 package parser_test
 
+// NOTE: Only the new V2 batch API is now tested.
+
 import (
 	"fmt"
 	"io/ioutil"
@@ -12,6 +14,7 @@ import (
 
 	"cloud.google.com/go/bigquery"
 
+	"github.com/go-test/deep"
 	"github.com/m-lab/annotation-service/api"
 	"github.com/m-lab/etl/annotation"
 	p "github.com/m-lab/etl/parser"
@@ -63,15 +66,20 @@ func TestAddGeoDataSSConnSpec(t *testing.T) {
 			},
 		},
 	}
+	responseJSON := `{"AnnotatorDate":"2018-12-05T00:00:00Z",
+	                  "Annotations":{"127.0.0.1":{"Geo":{"postal_code":"10583"}},
+	                                 "127.0.0.2":{"Geo":{"postal_code":"10584"}}}}`
+
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, `{"127.0.0.10" : {"Geo":{"postal_code":"10583"},"ASN":{}}`+
-			`,"127.0.0.20" : {"Geo":{"postal_code":"10584"},"ASN":{}}}`)
+		fmt.Fprint(w, responseJSON)
+		// `{"127.0.0.1" : {"Geo":{"postal_code":"10583"},"ASN":{}}`+
+		//`,"127.0.0.2" : {"Geo":{"postal_code":"10584"},"ASN":{}}}`)
 	}))
 	for _, test := range tests {
 		annotation.BatchURL = ts.URL + test.url
 		p.AddGeoDataSSConnSpec(&test.conspec, test.timestamp)
-		if !reflect.DeepEqual(test.conspec, test.res) {
-			t.Errorf("Expected %v, got %v for test %s", test.res, test.conspec, test.url)
+		if diff := deep.Equal(test.res, test.conspec); diff != nil {
+			t.Error(test.url, diff)
 		}
 	}
 }
@@ -119,15 +127,17 @@ func TestAddGeoDataPTConnSpec(t *testing.T) {
 			},
 		},
 	}
+	responseJSON := `{"AnnotatorDate":"2018-12-05T00:00:00Z",
+	                  "Annotations":{"127.0.0.1":{"Geo":{"postal_code":"10583"}},
+	                                 "127.0.0.2":{"Geo":{"postal_code":"10584"}}}}`
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, `{"127.0.0.10" : {"Geo":{"postal_code":"10583"},"ASN":{}}`+
-			`,"127.0.0.20" : {"Geo":{"postal_code":"10584"},"ASN":{}}}`)
+		fmt.Fprint(w, responseJSON)
 	}))
 	for _, test := range tests {
 		annotation.BatchURL = ts.URL + test.url
 		p.AddGeoDataPTConnSpec(&test.conspec, test.timestamp)
-		if !reflect.DeepEqual(test.conspec, test.res) {
-			t.Errorf("Expected %v, got %v for test %s", test.res, test.conspec, test.url)
+		if diff := deep.Equal(test.conspec, test.res); diff != nil {
+			t.Error(test.url, diff)
 		}
 	}
 }
@@ -476,8 +486,8 @@ func TestCopyStructToMap(t *testing.T) {
 	}
 	for _, test := range tests {
 		p.CopyStructToMap(test.source, test.dest)
-		if !reflect.DeepEqual(test.dest, test.res) {
-			t.Errorf("Expected %+v, got %+v for data: %+v\n", test.res, test.dest, test.source)
+		if diff := deep.Equal(test.dest, test.res); diff != nil {
+			t.Error(diff)
 		}
 	}
 
@@ -535,8 +545,8 @@ func TestGetAndInsertTwoSidedGeoIntoNDTConnSpec(t *testing.T) {
 	for _, test := range tests {
 		annotation.BatchURL = ts.URL + test.url
 		p.GetAndInsertTwoSidedGeoIntoNDTConnSpec(test.spec, test.timestamp)
-		if !reflect.DeepEqual(test.spec, test.res) {
-			t.Errorf("Expected %+v, got %+v from data %s", test.res, test.spec, test.url)
+		if diff := deep.Equal(test.spec, test.res); diff != nil {
+			t.Error(test.url, diff)
 		}
 	}
 }


### PR DESCRIPTION
I've created a GetAnnotations function in annotation-service/api/v2 that wraps the http request and retries on ServiceUnavailable failures.  This keeps more of the repo specific code in the same annotation-service repo, though it does require a recompile of ETL to get new changes.

One question this raises - should we use dep to vendor the specific version of annotation-service used?  This is demonstrated in the batch-sandbox-retry-v2 branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/600)
<!-- Reviewable:end -->
