### PR TITLE
add annotation timeout

### DIFF
--- a/annotation/geo.go
+++ b/annotation/geo.go
@@ -58,7 +58,9 @@ func FetchGeoAnnotations(ips []string, timestamp time.Time, geoDest []*api.Geolo
 				Labels{"source": "NormalizeIPv6 Error"}).Inc()
 		}
 	}
-	resp, err := v2.GetAnnotations(context.Background(), BatchURL, timestamp, normalized)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	resp, err := v2.GetAnnotations(ctx, BatchURL, timestamp, normalized)
 	if err != nil {
 		log.Println(err)
 		// TODO should ensure that there aren't too many error types.


### PR DESCRIPTION
See Bug #602

This PR just adds a 2 minute timeout to the GetAnnotations context.  This may be too long.  Probably 30 seconds would be better, since annotators usually take less than 20 seconds to load, and loading is the primary (or possibly) only cause of retry loops.

This DOES NOT resolve the bug, as there is some other reason on the annotator side that the annotator was never being loaded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/603)
<!-- Reviewable:end -->
