### PR TITLE
Tq sandbox faster ndt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -161,12 +161,25 @@ deploy:
     all_branches: true
     condition: $TRAVIS_BRANCH == cf-sandbox-* || $TRAVIS_BRANCH == sandbox-*
 
+## Task Queues
+- provider: script
+  script:
+    $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_sandbox
+    && gcloud app deploy --project=mlab-sandbox $TRAVIS_BUILD_DIR/appengine/queue.yaml
+  skip_cleanup: true
+  on:
+    repo: m-lab/etl
+    all_branches: true
+    condition: $TRAVIS_BRANCH == tq-sandbox-* ||
+               $TRAVIS_BRANCH == ndt-sandbox-* ||
+               $TRAVIS_BRANCH == batch-sandbox-* ||
+               $TRAVIS_BRANCH == sandbox-*
+
 ## Service: etl-batch-parser -- AppEngine Flexible Environment.
 - provider: script
   script:
     $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_sandbox
     && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-sandbox batch nodryrun
-    && gcloud app deploy --project=mlab-sandbox $TRAVIS_BUILD_DIR/appengine/queue.yaml
     && $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-sandbox
     SERVICE_ACCOUNT_mlab_sandbox $TRAVIS_BUILD_DIR/cmd/etl_worker app-batch.yaml
   skip_cleanup: true
@@ -195,7 +208,6 @@ deploy:
 - provider: script
   script:
     $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_sandbox
-    && gcloud app deploy --project=mlab-sandbox $TRAVIS_BUILD_DIR/appengine/queue.yaml
     && $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-sandbox
     SERVICE_ACCOUNT_mlab_sandbox $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt.yaml
   skip_cleanup: true

--- a/appengine/queue.yaml
+++ b/appengine/queue.yaml
@@ -93,7 +93,7 @@ queue:
 #
 - name: etl-ndt-batch-0
   target: etl-batch-parser
-  rate: 5/s
+  rate: 10/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -104,7 +104,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-1
   target: etl-batch-parser
-  rate: 5/s
+  rate: 10/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -114,7 +114,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-2
   target: etl-batch-parser
-  rate: 5/s
+  rate: 10/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -124,7 +124,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-3
   target: etl-batch-parser
-  rate: 5/s
+  rate: 10/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -134,7 +134,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-4
   target: etl-batch-parser
-  rate: 5/s
+  rate: 10/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -144,7 +144,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-5
   target: etl-batch-parser
-  rate: 5/s
+  rate: 10/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -154,7 +154,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-6
   target: etl-batch-parser
-  rate: 5/s
+  rate: 10/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -164,7 +164,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-7
   target: etl-batch-parser
-  rate: 5/s
+  rate: 10/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -174,7 +174,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-8
   target: etl-batch-parser
-  rate: 5/s
+  rate: 10/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -184,7 +184,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-9
   target: etl-batch-parser
-  rate: 5/s
+  rate: 10/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -194,7 +194,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-10
   target: etl-batch-parser
-  rate: 5/s
+  rate: 10/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -204,7 +204,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-11
   target: etl-batch-parser
-  rate: 5/s
+  rate: 10/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -214,7 +214,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-12
   target: etl-batch-parser
-  rate: 5/s
+  rate: 10/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -224,7 +224,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-13
   target: etl-batch-parser
-  rate: 5/s
+  rate: 10/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -258,7 +258,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -271,7 +271,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -284,7 +284,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -297,7 +297,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -310,7 +310,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -323,7 +323,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -336,7 +336,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -349,7 +349,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -362,7 +362,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -375,7 +375,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -388,7 +388,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -401,7 +401,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -414,7 +414,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -427,7 +427,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -440,7 +440,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -453,7 +453,7 @@ queue:
   rate: 5/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 50
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained

--- a/appengine/queue.yaml
+++ b/appengine/queue.yaml
@@ -255,7 +255,7 @@ queue:
 
 - name: etl-sidestream-batch-0
   target: etl-batch-parser
-  rate: 5/s
+  rate: 1/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 10
@@ -268,7 +268,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-1
   target: etl-batch-parser
-  rate: 5/s
+  rate: 1/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 10
@@ -281,7 +281,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-2
   target: etl-batch-parser
-  rate: 5/s
+  rate: 1/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 10
@@ -294,7 +294,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-3
   target: etl-batch-parser
-  rate: 5/s
+  rate: 1/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 10
@@ -307,7 +307,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-4
   target: etl-batch-parser
-  rate: 5/s
+  rate: 1/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 10
@@ -320,7 +320,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-5
   target: etl-batch-parser
-  rate: 5/s
+  rate: 1/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 10
@@ -333,7 +333,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-6
   target: etl-batch-parser
-  rate: 5/s
+  rate: 1/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 10
@@ -346,7 +346,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-7
   target: etl-batch-parser
-  rate: 5/s
+  rate: 1/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 10
@@ -359,7 +359,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-8
   target: etl-batch-parser
-  rate: 5/s
+  rate: 1/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 10
@@ -372,7 +372,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-9
   target: etl-batch-parser
-  rate: 5/s
+  rate: 1/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 10
@@ -385,7 +385,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-10
   target: etl-batch-parser
-  rate: 5/s
+  rate: 1/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 10
@@ -398,7 +398,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-11
   target: etl-batch-parser
-  rate: 5/s
+  rate: 1/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 10
@@ -411,7 +411,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-12
   target: etl-batch-parser
-  rate: 5/s
+  rate: 1/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 10
@@ -424,7 +424,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-13
   target: etl-batch-parser
-  rate: 5/s
+  rate: 1/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 10
@@ -437,7 +437,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-14
   target: etl-batch-parser
-  rate: 5/s
+  rate: 1/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 10
@@ -450,7 +450,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-15
   target: etl-batch-parser
-  rate: 5/s
+  rate: 1/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 10

--- a/appengine/queue.yaml
+++ b/appengine/queue.yaml
@@ -234,7 +234,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-14
   target: etl-batch-parser
-  rate: 5/s
+  rate: 10/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -244,7 +244,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-15
   target: etl-batch-parser
-  rate: 5/s
+  rate: 10/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:


### PR DESCRIPTION
This tweaks the queues to make sidestream run slower, and ndt run faster.
Also adds a tq target, so we can adjust the queues in sandbox without restarting batch pipeline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/607)
<!-- Reviewable:end -->
