### PR TITLE
Replace commented code with historical comment

### DIFF
--- a/parser/geo_annotation.go
+++ b/parser/geo_annotation.go
@@ -17,29 +17,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// AddGeoDataSSConnSpec takes a pointer to a
-// Web100ConnectionSpecification struct and a timestamp. With these,
-// it will fetch the appropriate geo data and add it to the hop struct
-// referenced by the pointer.
-func AddGeoDataSSConnSpec(spec *schema.Web100ConnectionSpecification, timestamp time.Time) {
-	if spec == nil {
-		metrics.AnnotationErrorCount.With(prometheus.
-			Labels{"source": "SS ConnSpec was nil!!!"}).Inc()
-		return
-	}
-	// Time the response
-	timerStart := time.Now()
-	defer func(tStart time.Time) {
-		metrics.AnnotationTimeSummary.
-			With(prometheus.Labels{"test_type": "SS"}).
-			Observe(float64(time.Since(tStart).Nanoseconds()))
-	}(timerStart)
-
-	ipSlice := []string{spec.Local_ip, spec.Remote_ip}
-	geoSlice := []*api.GeolocationIP{&spec.Local_geolocation, &spec.Remote_geolocation}
-	annotation.FetchGeoAnnotations(ipSlice, timestamp, geoSlice)
-}
-
 // AddGeoDataPTConnSpec takes a pointer to a
 // MLabConnectionSpecification struct and a timestamp. With these, it
 // will fetch the appropriate geo data and add it to the hop struct

--- a/parser/geo_annotation_test.go
+++ b/parser/geo_annotation_test.go
@@ -23,65 +23,6 @@ import (
 
 var epoch time.Time = time.Unix(0, 0)
 
-func TestAddGeoDataSSConnSpec(t *testing.T) {
-	tests := []struct {
-		conspec   schema.Web100ConnectionSpecification
-		timestamp time.Time
-		url       string
-		res       schema.Web100ConnectionSpecification
-	}{
-		{
-			conspec:   schema.Web100ConnectionSpecification{},
-			timestamp: epoch,
-			url:       "/notCalled",
-			res:       schema.Web100ConnectionSpecification{},
-		},
-		{
-			conspec:   schema.Web100ConnectionSpecification{Local_ip: "127.0.0.1"},
-			timestamp: epoch,
-			url:       "/src",
-			res: schema.Web100ConnectionSpecification{
-				Local_ip:          "127.0.0.1",
-				Local_geolocation: api.GeolocationIP{PostalCode: "10583"},
-			},
-		},
-		{
-			conspec:   schema.Web100ConnectionSpecification{Remote_ip: "127.0.0.1"},
-			timestamp: epoch,
-			url:       "/dest",
-			res: schema.Web100ConnectionSpecification{
-				Remote_ip:          "127.0.0.1",
-				Remote_geolocation: api.GeolocationIP{PostalCode: "10583"},
-			},
-		},
-		{
-			conspec:   schema.Web100ConnectionSpecification{Local_ip: "127.0.0.1", Remote_ip: "127.0.0.2"},
-			timestamp: epoch,
-			url:       "/both",
-			res: schema.Web100ConnectionSpecification{
-				Local_ip:           "127.0.0.1",
-				Local_geolocation:  api.GeolocationIP{PostalCode: "10583"},
-				Remote_ip:          "127.0.0.2",
-				Remote_geolocation: api.GeolocationIP{PostalCode: "10584"},
-			},
-		},
-	}
-	responseJSON := `{"AnnotatorDate":"2018-12-05T00:00:00Z",
-	                  "Annotations":{"127.0.0.1":{"Geo":{"postal_code":"10583"}},
-	                                 "127.0.0.2":{"Geo":{"postal_code":"10584"}}}}`
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, responseJSON)
-	}))
-	for _, test := range tests {
-		annotation.BatchURL = ts.URL + test.url
-		p.AddGeoDataSSConnSpec(&test.conspec, test.timestamp)
-		if diff := deep.Equal(test.res, test.conspec); diff != nil {
-			t.Error(test.url, diff)
-		}
-	}
-}
-
 func TestAddGeoDataPTConnSpec(t *testing.T) {
 	tests := []struct {
 		conspec   schema.MLabConnectionSpecification

--- a/parser/ss.go
+++ b/parser/ss.go
@@ -183,8 +183,8 @@ func PackDataIntoSchema(ssValue map[string]string, logTime time.Time, testName s
 		Remote_port: int64(remotePort),
 	}
 
-	// TODO: Move this annotation
-	//AddGeoDataSSConnSpec(conn_spec, logTime)
+	// NOTE: Annotation was previously done here, using AddGeoDataSS...(), but it now done
+	// in ss.Annotate, prior to inserter.PutAsync
 	snap, err := PopulateSnap(ssValue)
 	if err != nil {
 		return schema.SS{}, err


### PR DESCRIPTION
Merge #524 included commenting out this AddGeoData...().  Merge #527 replaced this with batch annotation, so this commented code is obsolete since then.

This cleans that up so we won't be mislead in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/609)
<!-- Reviewable:end -->
