### PR TITLE
more memory to prevent oom

### DIFF
--- a/cmd/etl_worker/app-batch.yaml
+++ b/cmd/etl_worker/app-batch.yaml
@@ -14,7 +14,8 @@ resources:
   # Instances support between [(cpu * 0.9) - 0.4, (cpu * 6.5) - 0.4]
   # Actual memory available is exposed via GAE_MEMORY_MB environment variable.
   # Recent observation with 20 workers per instance hovers around 1.5 GB.
-  memory_gb: 3
+  # However, we see some OOMs at 3 GB, so let's try 6
+  memory_gb: 6
 
   # TODO - Adjust once we understand requirements.
   disk_size_gb: 10

--- a/cmd/etl_worker/app-disco.yaml
+++ b/cmd/etl_worker/app-disco.yaml
@@ -11,7 +11,8 @@ resources:
   cpu: 2
   # Instances support between [(cpu * 0.9) - 0.4, (cpu * 6.5) - 0.4]
   # Actual memory available is exposed via GAE_MEMORY_MB environment variable.
-  memory_gb: 3.0
+  # We see some OOMs at 3 GB, so let's try 6
+  memory_gb: 6
 
 automatic_scaling:
   # We expect fairly small load, so a low minimum should reduce costs.

--- a/cmd/etl_worker/app-traceroute.yaml
+++ b/cmd/etl_worker/app-traceroute.yaml
@@ -14,7 +14,8 @@ resources:
   # Actual memory available is exposed via GAE_MEMORY_MB environment variable.
   # even though the parser has extremely limited RAM requirements, the
   # minimum RAM assignable to 2 CPUs is around 1.5GB
-  memory_gb: 1.5
+  # We see some OOMs at 3 GB (in etl-batch-parser), so let's try 6
+  memory_gb: 6
 
 automatic_scaling:
   # We expect fairly steady load, so a modest minimum will rarely cost us anything.


### PR DESCRIPTION
We are seeing frequent OOMs in etl-batch-parser in prod.
This increases memory to 6GB, which will likely resolve the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/611)
<!-- Reviewable:end -->
