### PR TITLE
boost sidestream rate back up

### DIFF
--- a/appengine/queue.yaml
+++ b/appengine/queue.yaml
@@ -255,10 +255,10 @@ queue:
 
 - name: etl-sidestream-batch-0
   target: etl-batch-parser
-  rate: 1/s
+  rate: 2/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 10
+  max_concurrent_requests: 25
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -268,10 +268,10 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-1
   target: etl-batch-parser
-  rate: 1/s
+  rate: 2/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 10
+  max_concurrent_requests: 25
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -281,10 +281,10 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-2
   target: etl-batch-parser
-  rate: 1/s
+  rate: 2/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 10
+  max_concurrent_requests: 25
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -294,10 +294,10 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-3
   target: etl-batch-parser
-  rate: 1/s
+  rate: 2/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 10
+  max_concurrent_requests: 25
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -307,10 +307,10 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-4
   target: etl-batch-parser
-  rate: 1/s
+  rate: 2/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 10
+  max_concurrent_requests: 25
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -320,10 +320,10 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-5
   target: etl-batch-parser
-  rate: 1/s
+  rate: 2/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 10
+  max_concurrent_requests: 25
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -333,10 +333,10 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-6
   target: etl-batch-parser
-  rate: 1/s
+  rate: 2/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 10
+  max_concurrent_requests: 25
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -346,10 +346,10 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-7
   target: etl-batch-parser
-  rate: 1/s
+  rate: 2/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 10
+  max_concurrent_requests: 25
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -359,10 +359,10 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-8
   target: etl-batch-parser
-  rate: 1/s
+  rate: 2/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 10
+  max_concurrent_requests: 25
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -372,10 +372,10 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-9
   target: etl-batch-parser
-  rate: 1/s
+  rate: 2/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 10
+  max_concurrent_requests: 25
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -385,10 +385,10 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-10
   target: etl-batch-parser
-  rate: 1/s
+  rate: 2/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 10
+  max_concurrent_requests: 25
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -398,10 +398,10 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-11
   target: etl-batch-parser
-  rate: 1/s
+  rate: 2/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 10
+  max_concurrent_requests: 25
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -411,10 +411,10 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-12
   target: etl-batch-parser
-  rate: 1/s
+  rate: 2/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 10
+  max_concurrent_requests: 25
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -424,10 +424,10 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-13
   target: etl-batch-parser
-  rate: 1/s
+  rate: 2/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 10
+  max_concurrent_requests: 25
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -437,10 +437,10 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-14
   target: etl-batch-parser
-  rate: 1/s
+  rate: 2/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 10
+  max_concurrent_requests: 25
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained
@@ -450,10 +450,10 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-15
   target: etl-batch-parser
-  rate: 1/s
+  rate: 2/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
-  max_concurrent_requests: 10
+  max_concurrent_requests: 25
   retry_parameters:
     task_age_limit: 12h
     # min and max are same, so that queue rate only diminishes as tasks are drained


### PR DESCRIPTION
Sidestream slowed down a lot this morning.  Might be due to something else, but in case it is just related to changes to the task queue configs, this PR boosts the sidestream settings about half-way back to where they were before.