### PR TITLE
Update ndt to use v2 annotator API

### DIFF
--- a/annotation/geo.go
+++ b/annotation/geo.go
@@ -166,11 +166,13 @@ func ParseJSONGeoDataResponse(jsonBuffer []byte) (*api.GeoData, error) {
 // ip-timestamp strings to GeoData structs, or a nil map if it
 // encounters any error and cannot get the data for any reason
 // TODO - dedup common code in GetGeoData
+// TODO Deprecated - update all clients to use FetchGeoAnnotations
 func GetBatchGeoData(url string, data []api.RequestData) map[string]api.GeoData {
 	// Query the service and grab the response safely
 	// All errors are recorded to metrics, so OK to ignore them here.
 	annotatorResponse, err := BatchQueryAnnotationService(url, data)
 	if err != nil {
+		// This is now very spammy, since we added ServiceUnavailable status.
 		log.Println("BatchQueryAnnotationService Error:", err)
 		return nil
 	}

--- a/parser/geo_annotation.go
+++ b/parser/geo_annotation.go
@@ -21,6 +21,8 @@ import (
 // MLabConnectionSpecification struct and a timestamp. With these, it
 // will fetch the appropriate geo data and add it to the hop struct
 // referenced by the pointer.
+// DEPRECATED.  Should use batch annotation, with FetchAnnotations, as is done for SS
+// in ss.Annotate prior to inserter.PutAsync.
 func AddGeoDataPTConnSpec(spec *schema.MLabConnectionSpecification, timestamp time.Time) {
 	if spec == nil {
 		metrics.AnnotationErrorCount.With(prometheus.
@@ -42,6 +44,8 @@ func AddGeoDataPTConnSpec(spec *schema.MLabConnectionSpecification, timestamp ti
 // AddGeoDataPTHopBatch takes a slice of pointers to
 // schema.ParisTracerouteHops and will annotate all of them or fail
 // silently. It sends them all in a single remote request.
+// DEPRECATED.  Should use batch annotation, with FetchAnnotations, as is done for SS
+// in ss.Annotate prior to inserter.PutAsync.
 func AddGeoDataPTHopBatch(hops []*schema.ParisTracerouteHop, timestamp time.Time) {
 	// Time the response
 	timerStart := time.Now()
@@ -58,6 +62,8 @@ func AddGeoDataPTHopBatch(hops []*schema.ParisTracerouteHop, timestamp time.Time
 // AnnotatePTHops takes a slice of hop pointers, the annotation data
 // mapping ip addresses to geo data and a timestamp. It will then use
 // these to attach the appropriate geo data to the PT hops.
+// DEPRECATED.  Should use batch annotation, with FetchAnnotations, as is done for SS
+// in ss.Annotate prior to inserter.PutAsync.
 func AnnotatePTHops(hops []*schema.ParisTracerouteHop, annotationData map[string]api.GeoData, timestamp time.Time) {
 	if annotationData == nil {
 		return
@@ -123,6 +129,8 @@ func CreateRequestDataFromPTHops(hops []*schema.ParisTracerouteHop, timestamp ti
 // AddGeoDataPTHop takes a pointer to a ParisTracerouteHop and a
 // timestamp. With these, it will fetch the appropriate geo data and
 // add it to the hop struct referenced by the pointer.
+// DEPRECATED.  Should use batch annotation, with FetchAnnotations, as is done for SS
+// in ss.Annotate prior to inserter.PutAsync.
 func AddGeoDataPTHop(hop *schema.ParisTracerouteHop, timestamp time.Time) {
 	if hop == nil {
 		metrics.AnnotationErrorCount.With(prometheus.
@@ -154,6 +162,8 @@ func AddGeoDataPTHop(hop *schema.ParisTracerouteHop, timestamp time.Time) {
 // annotates the connection spec with geo data associated with each IP
 // Address. It will either sucessfully add the geo data or fail
 // silently and make no changes.
+// DEPRECATED.  Should use batch annotation, with FetchAnnotations, as is done for SS
+// in ss.Annotate prior to inserter.PutAsync.
 func AddGeoDataNDTConnSpec(spec schema.Web100ValueMap, timestamp time.Time) {
 	// Time the response
 	timerStart := time.Now()
@@ -203,6 +213,8 @@ func CopyStructToMap(sourceStruct interface{}, destinationMap map[string]bigquer
 // GetAndInsertTwoSidedGeoIntoNDTConnSpec takes a timestamp and an
 // NDT connection spec. It will either insert the data into the
 // connection spec or silently fail.
+// DEPRECATED.  Should use batch annotation, with FetchAnnotations, as is done for SS
+// in ss.Annotate prior to inserter.PutAsync.
 func GetAndInsertTwoSidedGeoIntoNDTConnSpec(spec schema.Web100ValueMap, timestamp time.Time) {
 	// TODO: Make metrics for sok and cok failures. And double check metrics for cleanliness.
 	cip, cok := spec.GetString([]string{"client_ip"})

--- a/parser/geo_annotation_test.go
+++ b/parser/geo_annotation_test.go
@@ -5,6 +5,7 @@ package parser_test
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -386,16 +387,16 @@ func TestAddGeoDataNDTConnSpec(t *testing.T) {
 	}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Note: the "h3d0c0" in the IP strings is the appended timestamp.
-		fmt.Fprint(w, `{"127.0.0.1h3d0c0" : {"Geo":{"continent_code":"","country_code":"US","country_code3":"USA","country_name":"United States of America","region":"NY","metro_code":0,"city":"Scarsdale","area_code":10583,"postal_code":"10583","latitude":41.0051,"longitude":73.7846},"ASN":{}}`+
-			`,"1.0.0.127h3d0c0" : {"Geo":{"continent_code":"","country_code":"US","country_code3":"USA","country_name":"United States of America","region":"NY","metro_code":0,"city":"Scarsdale","area_code":10584,"postal_code":"10584","latitude":41.0051,"longitude":73.7846},"ASN":{}}}`)
+		fmt.Fprint(w, `{"AnnotatorDate": "2018-12-05T00:00:00Z", "Annotations": {"127.0.0.1" : {"Geo":{"continent_code":"","country_code":"US","country_code3":"USA","country_name":"United States of America","region":"NY","metro_code":0,"city":"Scarsdale","area_code":10583,"postal_code":"10583","latitude":41.0051,"longitude":73.7846},"ASN":{}}`+
+			`,"1.0.0.127" : {"Geo":{"continent_code":"","country_code":"US","country_code3":"USA","country_name":"United States of America","region":"NY","metro_code":0,"city":"Scarsdale","area_code":10584,"postal_code":"10584","latitude":41.0051,"longitude":73.7846},"ASN":{}}}}`)
 	}))
 	defer ts.Close()
 	for _, test := range tests {
 		annotation.BatchURL = ts.URL + test.url
 		p.AddGeoDataNDTConnSpec(test.spec, test.timestamp)
-		if !reflect.DeepEqual(test.spec, test.res) {
-			t.Errorf("Expected %+v, got %+v from data %s", test.res, test.spec, test.url)
+		if diff := deep.Equal(test.spec, test.res); diff != nil {
+			log.Println(test.spec)
+			t.Error(test.spec, diff)
 		}
 	}
 }
@@ -483,8 +484,8 @@ func TestGetAndInsertTwoSidedGeoIntoNDTConnSpec(t *testing.T) {
 		},
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, `{"127.0.0.1h3d0c0" : {"Geo":{"continent_code":"","country_code":"US","country_code3":"USA","country_name":"United States of America","region":"NY","metro_code":0,"city":"Scarsdale","area_code":10583,"postal_code":"10583","latitude":41.0051,"longitude":73.7846},"ASN":{}}`+
-			`,"1.0.0.127h3d0c0" : {"Geo":{"continent_code":"","country_code":"US","country_code3":"USA","country_name":"United States of America","region":"NY","metro_code":0,"city":"Scarsdale","area_code":10584,"postal_code":"10584","latitude":41.0051,"longitude":73.7846},"ASN":{}}}`)
+		fmt.Fprint(w, `{"AnnotatorDate": "2018-12-05T00:00:00Z", "Annotations": {"127.0.0.1" : {"Geo":{"continent_code":"","country_code":"US","country_code3":"USA","country_name":"United States of America","region":"NY","metro_code":0,"city":"Scarsdale","area_code":10583,"postal_code":"10583","latitude":41.0051,"longitude":73.7846},"ASN":{}}`+
+			`,"1.0.0.127" : {"Geo":{"continent_code":"","country_code":"US","country_code3":"USA","country_name":"United States of America","region":"NY","metro_code":0,"city":"Scarsdale","area_code":10584,"postal_code":"10584","latitude":41.0051,"longitude":73.7846},"ASN":{}}}}`)
 	}))
 	defer ts.Close()
 	for _, test := range tests {

--- a/parser/geo_annotation_test.go
+++ b/parser/geo_annotation_test.go
@@ -72,6 +72,7 @@ func TestAddGeoDataPTConnSpec(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, responseJSON)
 	}))
+	defer ts.Close()
 	for _, test := range tests {
 		annotation.BatchURL = ts.URL + test.url
 		p.AddGeoDataPTConnSpec(&test.conspec, test.timestamp)
@@ -113,6 +114,7 @@ func TestAddGeoDataPTHopBatchBadIPv6(t *testing.T) {
 		fmt.Fprint(w, `{"fe80::301f:d5b0:3fb7:3a000" : {"Geo":{"area_code":10583},"ASN":{}}`+
 			`,"2620:0:1003:415:b33e:9d6a:81bf:87a10" : {"Geo":{"area_code":10584},"ASN":{}}}`)
 	}))
+	defer ts.Close()
 	for _, test := range tests {
 		annotation.BatchURL = ts.URL + "?foobar"
 		p.AddGeoDataPTHopBatch(test.hops, test.timestamp)
@@ -155,6 +157,7 @@ func TestAddGeoDataPTHopBatch(t *testing.T) {
 		fmt.Fprint(w, `{"127.0.0.10" : {"Geo":{"area_code":914},"ASN":{}}`+
 			`,"1.0.0.1270" : {"Geo":{"area_code":212},"ASN":{}}}`)
 	}))
+	defer ts.Close()
 	for _, test := range tests {
 		annotation.BatchURL = ts.URL + test.url
 		p.AddGeoDataPTHopBatch(test.hops, test.timestamp)
@@ -285,6 +288,7 @@ func TestAddGeoDataPTHop(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `{"Geo":{"postal_code":"10583"},"ASN":{}}`)
 	}))
+	defer ts.Close()
 	for _, test := range tests {
 		annotation.BaseURL = ts.URL + test.url
 		p.AddGeoDataPTHop(&test.hop, test.timestamp)
@@ -386,6 +390,7 @@ func TestAddGeoDataNDTConnSpec(t *testing.T) {
 		fmt.Fprint(w, `{"127.0.0.1h3d0c0" : {"Geo":{"continent_code":"","country_code":"US","country_code3":"USA","country_name":"United States of America","region":"NY","metro_code":0,"city":"Scarsdale","area_code":10583,"postal_code":"10583","latitude":41.0051,"longitude":73.7846},"ASN":{}}`+
 			`,"1.0.0.127h3d0c0" : {"Geo":{"continent_code":"","country_code":"US","country_code3":"USA","country_name":"United States of America","region":"NY","metro_code":0,"city":"Scarsdale","area_code":10584,"postal_code":"10584","latitude":41.0051,"longitude":73.7846},"ASN":{}}}`)
 	}))
+	defer ts.Close()
 	for _, test := range tests {
 		annotation.BatchURL = ts.URL + test.url
 		p.AddGeoDataNDTConnSpec(test.spec, test.timestamp)
@@ -481,6 +486,7 @@ func TestGetAndInsertTwoSidedGeoIntoNDTConnSpec(t *testing.T) {
 		fmt.Fprint(w, `{"127.0.0.1h3d0c0" : {"Geo":{"continent_code":"","country_code":"US","country_code3":"USA","country_name":"United States of America","region":"NY","metro_code":0,"city":"Scarsdale","area_code":10583,"postal_code":"10583","latitude":41.0051,"longitude":73.7846},"ASN":{}}`+
 			`,"1.0.0.127h3d0c0" : {"Geo":{"continent_code":"","country_code":"US","country_code3":"USA","country_name":"United States of America","region":"NY","metro_code":0,"city":"Scarsdale","area_code":10584,"postal_code":"10584","latitude":41.0051,"longitude":73.7846},"ASN":{}}}`)
 	}))
+	defer ts.Close()
 	for _, test := range tests {
 		annotation.BatchURL = ts.URL + test.url
 		p.GetAndInsertTwoSidedGeoIntoNDTConnSpec(test.spec, test.timestamp)


### PR DESCRIPTION
This updates NDT to use FetchAnnotations, which in turn uses the v2 annotation-service API.
This provided better metrics in etl, and reduces the number of code paths in annotation-service.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/619)
<!-- Reviewable:end -->
