### PR TITLE
improve to support injected annotator and PT multiple hops

### DIFF
--- a/parser/base_test.go
+++ b/parser/base_test.go
@@ -46,6 +46,10 @@ func (row *Row) GetLogTime() time.Time {
 	return time.Now()
 }
 
+func assertAnnotatable(r *Row) {
+	func(parser.Annotatable) {}(r)
+}
+
 func TestBase(t *testing.T) {
 	os.Setenv("RELEASE_TAG", "foobar")
 	parser.InitParserVersionForTest()


### PR DESCRIPTION
This adds several refinements:
1.  Rename GeoData to Annotations, and add alias for backward compatibility.
2.  Add Annotator interface, and support injection of Annotator into parser.Base.
3.  Tweak the Annotatable interface to support multiple hops in PT.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/658)
<!-- Reviewable:end -->
