### PR TITLE
Cleanup

### DIFF
--- a/bq/bq_test.go
+++ b/bq/bq_test.go
@@ -364,23 +364,29 @@ func TestUpdateMetrics(t *testing.T) {
 		t.Error(in)
 	}
 
+	// Try adding 11 rows, with a PutMultiError on all rows.
 	fakeUploader.SetErr(make(bigquery.PutMultiError, 11))
 	bqi.InsertRows(make([]interface{}, 11))
 	bqi.Flush()
+	// There should now be 13 failed rows.
 	if bqi.Failed() != 13 {
 		t.Error(in)
 	}
 
+	// Try adding 1 row with a simple error.
 	fakeUploader.SetErr(&url.Error{Err: errors.New("random error")})
 	bqi.InsertRows(make([]interface{}, 1))
 	bqi.Flush()
+	// There should now be 14 failures.
 	if bqi.Failed() != 14 {
 		t.Error(in)
 	}
 
+	// Try adding 1 row with a googleapi.Error.
 	fakeUploader.SetErr(&googleapi.Error{Code: 404})
 	bqi.InsertRows(make([]interface{}, 1))
 	bqi.Flush()
+	// Should now be 15 failures.
 	if bqi.Failed() != 15 || bqi.Committed() != 0 {
 		t.Error(in)
 	}

--- a/bq/insert.go
+++ b/bq/insert.go
@@ -245,7 +245,7 @@ func (in *BQInserter) updateMetrics(err error) error {
 		if len(typedErr) > 10 && len(typedErr) == in.pending {
 			log.Printf("Insert error: %v\n", err)
 			metrics.ErrorCount.WithLabelValues(
-				in.TableBase(), "unknown", "insert row error").
+				in.TableBase(), "PutMultiError", "insert row error").
 				Add(float64(len(typedErr)))
 		} else {
 			// Handle each error individually.
@@ -257,7 +257,7 @@ func (in *BQInserter) updateMetrics(err error) error {
 				for _, oneErr := range rowError.Errors {
 					log.Printf("Insert error: %v\n", oneErr)
 					metrics.ErrorCount.WithLabelValues(
-						in.TableBase(), "unknown", "insert row error").Inc()
+						in.TableBase(), "PutMultiError", "insert row error").Inc()
 				}
 			}
 		}
@@ -270,7 +270,7 @@ func (in *BQInserter) updateMetrics(err error) error {
 		metrics.BackendFailureCount.WithLabelValues(
 			in.TableBase(), "failed insert").Inc()
 		metrics.ErrorCount.WithLabelValues(
-			in.TableBase(), "unknown", "UNHANDLED insert error").Inc()
+			in.TableBase(), "url.Error", "UNHANDLED insert error").Inc()
 		// TODO - Conservative, but possibly not correct.
 		// This at least preserves the count invariance.
 		in.inserted -= in.pending
@@ -281,7 +281,7 @@ func (in *BQInserter) updateMetrics(err error) error {
 		metrics.BackendFailureCount.WithLabelValues(
 			in.TableBase(), "failed insert").Inc()
 		metrics.ErrorCount.WithLabelValues(
-			in.TableBase(), "unknown", "UNHANDLED insert error").Inc()
+			in.TableBase(), "googleapi.Error", "UNHANDLED insert error").Inc()
 		// TODO - Conservative, but possibly not correct.
 		// This at least preserves the count invariance.
 		in.inserted -= in.pending

--- a/bq/insert.go
+++ b/bq/insert.go
@@ -19,12 +19,15 @@ import (
 	"encoding/json"
 	"log"
 	"math/rand"
+	"net/url"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"cloud.google.com/go/bigquery"
+	"google.golang.org/api/googleapi"
 
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/metrics"
@@ -261,8 +264,33 @@ func (in *BQInserter) updateMetrics(err error) error {
 		in.inserted -= len(typedErr)
 		in.badRows += len(typedErr)
 		err = nil
+	case *url.Error:
+		log.Printf("Unhandled url.Error on insert %v Project: %s, Dataset: %s, Table: %s\n",
+			typedErr, in.Project(), in.Dataset(), in.FullTableName())
+		metrics.BackendFailureCount.WithLabelValues(
+			in.TableBase(), "failed insert").Inc()
+		metrics.ErrorCount.WithLabelValues(
+			in.TableBase(), "unknown", "UNHANDLED insert error").Inc()
+		// TODO - Conservative, but possibly not correct.
+		// This at least preserves the count invariance.
+		in.inserted -= in.pending
+		in.badRows += in.pending
+		err = nil
+	case *googleapi.Error:
+		log.Printf("Unhandled googleapi.Error on insert %v\n", typedErr)
+		metrics.BackendFailureCount.WithLabelValues(
+			in.TableBase(), "failed insert").Inc()
+		metrics.ErrorCount.WithLabelValues(
+			in.TableBase(), "unknown", "UNHANDLED insert error").Inc()
+		// TODO - Conservative, but possibly not correct.
+		// This at least preserves the count invariance.
+		in.inserted -= in.pending
+		in.badRows += in.pending
+		err = nil
+
 	default:
-		log.Printf("Unhandled insert error %v\n", typedErr)
+		log.Printf("Unhandled %v on insert %v Project: %s, Table: %s\n", reflect.TypeOf(typedErr).Elem(),
+			typedErr, in.Project(), in.FullTableName())
 		metrics.BackendFailureCount.WithLabelValues(
 			in.TableBase(), "failed insert").Inc()
 		metrics.ErrorCount.WithLabelValues(

--- a/parser/base_test.go
+++ b/parser/base_test.go
@@ -48,7 +48,7 @@ func (row *Row) GetLogTime() time.Time {
 	return time.Now()
 }
 
-func assertAnnotatable(r *Row) {
+func assertTestRowAnnotatable(r *Row) {
 	func(parser.Annotatable) {}(r)
 }
 
@@ -160,8 +160,10 @@ func TestAsyncPut(t *testing.T) {
 		t.Error(err)
 	}
 
+	b.Inserter.Flush() // To synchronize after the PutAsync.
+
 	if ins.Committed() != 1 {
-		t.Fatalf("Expected %d, Got %d.", 0, ins.Committed())
+		t.Fatalf("Expected %d, Got %d.", 1, ins.Committed())
 	}
 
 	if len(ins.data) < 1 {

--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -728,10 +728,6 @@ type NDTTest struct {
 	schema.Web100ValueMap
 }
 
-func assertAnnotatable(r NDTTest) {
-	func(Annotatable) {}(r)
-}
-
 // Only valid on top level
 func (ndt NDTTest) getConnSpec() schema.Web100ValueMap {
 	return ndt.GetMap([]string{"connection_spec"})

--- a/parser/ndt_test.go
+++ b/parser/ndt_test.go
@@ -18,6 +18,15 @@ import (
 	"cloud.google.com/go/bigquery"
 )
 
+func assertNDTTestIsAnnotatable(r parser.NDTTest) {
+	func(parser.Annotatable) {}(r)
+}
+
+func assertNDTTestIsValueSaver(r parser.NDTTest) {
+	func(bigquery.ValueSaver) {}(r)
+}
+
+
 // A handful of file names from a single ndt tar file.
 var testFileNames []string = []string{
 	`20170509T00:05:13.863119000Z_45.56.98.222.c2s_ndttrace`,

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -18,7 +18,7 @@ func init() {
 var gParserVersion string
 
 // initParserVersion initializes the gParserVersion variable for use by all parsers.
-func initParserVersion() {
+func initParserVersion() string {
 	release, ok := os.LookupEnv("RELEASE_TAG")
 	if ok && release != "empty_tag" {
 		gParserVersion = "https://github.com/m-lab/etl/tree/" + release
@@ -30,6 +30,7 @@ func initParserVersion() {
 			gParserVersion = "local development"
 		}
 	}
+	return gParserVersion
 }
 
 // Version returns the parser version used by parsers to annotate data rows.

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -268,7 +268,6 @@ func GetStorageClient(writeAccess bool) (*storage.Client, error) {
 
 	// This cannot include a defer cancel, as the client then doesn't work after
 	// the cancel.
-	// client, err := google.DefaultClient(context.Background(), scope)
 	client, err := storage.NewClient(context.Background(), option.WithScopes(scope))
 	if err != nil {
 		return nil, err

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -8,6 +8,10 @@ import (
 	"cloud.google.com/go/storage"
 )
 
+var testBucket = "mlab-testing.appspot.com"
+var tarFile = "gs://" + testBucket + "/test.tar"
+var tgzFile = "gs://" + testBucket + "/test.tgz"
+
 func TestGetReader(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping tests that access GCS")
@@ -16,7 +20,8 @@ func TestGetReader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rdr, cancel, err := getReader(client, "m-lab-sandbox", "testfile", 60*time.Second)
+	rdr, cancel, err := getReader(client, testBucket, "test.tar", 60*time.Second)
+
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,7 +30,10 @@ func TestGetReader(t *testing.T) {
 }
 
 func TestNewTarReader(t *testing.T) {
-	src, err := NewETLSource(client, "gs://m-lab-sandbox/test.tar")
+	if testing.Short() {
+		t.Skip("Skipping tests that access GCS")
+	}
+	src, err := NewETLSource(client, tarFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,7 +52,10 @@ func TestNewTarReader(t *testing.T) {
 }
 
 func TestNewTarReaderGzip(t *testing.T) {
-	src, err := NewETLSource(client, "gs://m-lab-sandbox/test.tgz")
+	if testing.Short() {
+		t.Skip("Skipping tests that access GCS")
+	}
+	src, err := NewETLSource(client, tgzFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +86,7 @@ func init() {
 
 func BenchmarkNewTarReader(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		src, err := NewETLSource(client, "gs://m-lab-sandbox/test.tar")
+		src, err := NewETLSource(client, tarFile)
 		if err == nil {
 			src.Close()
 		}
@@ -84,7 +95,7 @@ func BenchmarkNewTarReader(b *testing.B) {
 
 func BenchmarkNewTarReaderGzip(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		src, err := NewETLSource(client, "gs://m-lab-sandbox/test.tgz")
+		src, err := NewETLSource(client, tgzFile)
 		if err == nil {
 			src.Close()
 		}


### PR DESCRIPTION
Various small cleanups.
1. improve bq insert error logs
2. move assertXXX to test files.
3. use vars instead of literals in storage_test.go

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/666)
<!-- Reviewable:end -->
