### PR TITLE
Tcpinfo schema

### DIFF
--- a/schema/tcpinfo.go
+++ b/schema/tcpinfo.go
@@ -12,7 +12,6 @@ import (
 	"github.com/m-lab/tcp-info/snapshot"
 )
 
-// TODO move to schema/tcpinfo.go
 type ServerInfo struct {
 	IP   string
 	Port uint16
@@ -69,9 +68,7 @@ var tcpSchema bigquery.Schema
 // Save implements bigquery.ValueSaver
 func (r *TCPRow) Save() (map[string]bigquery.Value, string, error) {
 	ss := bigquery.StructSaver{Schema: tcpSchema, InsertID: r.UUID, Struct: r}
-	m, insertID, err := ss.Save()
-
-	return m, insertID, err
+	return ss.Save()
 }
 
 // Schema returns the Bigquery schema for TCPRow.

--- a/schema/tcpinfo.go
+++ b/schema/tcpinfo.go
@@ -12,6 +12,7 @@ import (
 	"github.com/m-lab/tcp-info/snapshot"
 )
 
+// ServerInfo details various information about the server.
 type ServerInfo struct {
 	IP   string
 	Port uint16
@@ -21,6 +22,7 @@ type ServerInfo struct {
 	Network *api.ASData // NOTE: dominant ASN is available at top level.
 }
 
+// ClientInfo details various information about the client.
 type ClientInfo struct {
 	IP   string
 	Port uint16
@@ -29,21 +31,24 @@ type ClientInfo struct {
 	Network *api.ASData // NOTE: dominant ASN is available at top level.
 }
 
+// ParseInfo provides details about the parsing of this row.
 type ParseInfo struct {
 	TaskFileName  string // The tar file containing this test.
 	ParseTime     time.Time
 	ParserVersion string
 }
 
+// TCPRow describes a single BQ row of TCPInfo data.
 type TCPRow struct {
 	UUID     string    // Top level just because
 	TestTime time.Time // Must be top level for partitioning
 
-	SockID    inetdiag.SockID
 	ClientASN uint32 // Top level for clustering
 	ServerASN uint32 // Top level for clustering
 
 	ParseInfo *ParseInfo
+
+	SockID inetdiag.SockID
 
 	Server *ServerInfo
 	Client *ClientInfo

--- a/schema/tcpinfo.go
+++ b/schema/tcpinfo.go
@@ -1,0 +1,127 @@
+package schema
+
+import (
+	"time"
+
+	"cloud.google.com/go/bigquery"
+
+	"github.com/m-lab/annotation-service/api"
+	"github.com/m-lab/go/bqx"
+	"github.com/m-lab/go/rtx"
+	"github.com/m-lab/tcp-info/snapshot"
+)
+
+// TODO move to schema/tcpinfo.go
+type ServerInfo struct {
+	IP   string
+	Port uint16
+	IATA string
+
+	Geo     *api.GeolocationIP
+	Network *api.ASData // NOTE: dominant ASN is available at top level.
+}
+
+type ClientInfo struct {
+	IP   string
+	Port uint16
+
+	Geo     *api.GeolocationIP
+	Network *api.ASData // NOTE: dominant ASN is available at top level.
+}
+
+type ParseInfo struct {
+	TaskFileName  string // The tar file containing this test.
+	ParseTime     time.Time
+	ParserVersion string
+}
+
+type TCPRow struct {
+	UUID     string    // Top level just because
+	TestTime time.Time // Must be top level for partitioning
+
+	ClientASN uint32 // Top level for clustering
+	ServerASN uint32 // Top level for clustering
+
+	ParseInfo *ParseInfo
+
+	Server *ServerInfo
+	Client *ClientInfo
+
+	FinalSnapshot *snapshot.Snapshot
+
+	Snapshots []*snapshot.Snapshot
+}
+
+func assertTCPRowIsValueSaver(r *TCPRow) {
+	func(bigquery.ValueSaver) {}(r)
+}
+
+func init() {
+	var err error
+	tcpSchema, err = (&TCPRow{}).Schema()
+	rtx.Must(err, "Error generating tcp schema")
+}
+
+var tcpSchema bigquery.Schema
+
+// Save implements bigquery.ValueSaver
+// This is a rather messy work around the fact that the snapshot SockID
+// has byte slice fields that have to be converted to the appropriate type.
+// Tried writing Save() function just for the SockID, but that didn't work as expected.
+// TODO - consider substituting the InetDiagMsg with a struct containing the desired SockID format.
+func (r *TCPRow) Save() (map[string]bigquery.Value, string, error) {
+	ss := bigquery.StructSaver{Schema: tcpSchema, InsertID: "", Struct: r}
+	m, insertID, err := ss.Save()
+	w := Web100ValueMap(m)
+
+	if w["FinalSnapshot"] != nil {
+		idm := w.GetMap([]string{"FinalSnapshot", "InetDiagMsg"})
+		idSrc := r.FinalSnapshot.InetDiagMsg.ID
+		idm["ID"], _, _ = idSrc.Save()
+	}
+
+	if r.Snapshots != nil {
+		snapMaps := m["Snapshots"].([]bigquery.Value)
+		for i := range r.Snapshots {
+			snap := r.Snapshots[i]
+			if i >= len(snapMaps) || snap == nil || snap.InetDiagMsg == nil {
+				continue
+			}
+			idSrc := snap.InetDiagMsg.ID
+			sm := snapMaps[i]
+			snapMap, ok := sm.(map[string]bigquery.Value)
+			if !ok {
+				continue
+			}
+			idm, ok := snapMap["InetDiagMsg"]
+			if !ok {
+				continue
+			}
+			idmMap, ok := idm.(map[string]bigquery.Value)
+			if ok {
+				idmMap["ID"], _, _ = idSrc.Save()
+			}
+		}
+	}
+	return m, insertID, err
+}
+
+// Schema returns the Bigquery schema for TCPRow.
+func (r *TCPRow) Schema() (bigquery.Schema, error) {
+	sch, err := bigquery.InferSchema(r)
+	if err != nil {
+		return bigquery.Schema{}, err
+	}
+	subs := map[string]bigquery.FieldSchema{
+		"IDiagSPort":  bigquery.FieldSchema{Name: "IDiagSPort", Description: "", Type: "INTEGER"},
+		"IDiagDPort":  bigquery.FieldSchema{Name: "IDiagDPort", Description: "", Type: "INTEGER"},
+		"IDiagSrc":    bigquery.FieldSchema{Name: "IDiagSrc", Description: "", Type: "STRING"},
+		"IDiagDst":    bigquery.FieldSchema{Name: "IDiagDst", Description: "", Type: "STRING"},
+		"IDiagIf":     bigquery.FieldSchema{Name: "IDiagIf", Description: "", Type: "INTEGER"},
+		"IDiagCookie": bigquery.FieldSchema{Name: "IDiagCookie", Description: "", Type: "INTEGER"},
+	}
+
+	c := bqx.Customize(sch, subs)
+	rr := bqx.RemoveRequired(c)
+	return rr, nil
+}

--- a/schema/tcpinfo_test.go
+++ b/schema/tcpinfo_test.go
@@ -65,7 +65,7 @@ func TestBQSaver(t *testing.T) {
 	if fs != nil {
 		idm := fs["InetDiagMsg"].(map[string]bigquery.Value)
 		id := idm["ID"].(map[string]bigquery.Value)
-		if id["SPort"] != int64(123) {
+		if id["IDiagSPort"] != int64(123) {
 			t.Error(id)
 		}
 	} else {

--- a/schema/tcpinfo_test.go
+++ b/schema/tcpinfo_test.go
@@ -1,0 +1,91 @@
+package schema_test
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+
+	"github.com/m-lab/tcp-info/inetdiag"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/m-lab/etl/schema"
+	"github.com/m-lab/etl/storage"
+	"github.com/m-lab/tcp-info/snapshot"
+)
+
+func localETLSource(fn string) (*storage.ETLSource, error) {
+	if !(strings.HasSuffix(fn, ".tgz") || strings.HasSuffix(fn, ".tar") ||
+		strings.HasSuffix(fn, ".tar.gz")) {
+		return nil, errors.New("not tar or tgz: " + fn)
+	}
+
+	var rdr io.ReadCloser
+	var raw io.ReadCloser
+	raw, err := os.Open(fn)
+	if err != nil {
+		return nil, err
+	}
+	// Handle .tar.gz, .tgz files.
+	if strings.HasSuffix(strings.ToLower(fn), "gz") {
+		rdr, err = gzip.NewReader(raw)
+		if err != nil {
+			raw.Close()
+			return nil, err
+		}
+	} else {
+		rdr = raw
+	}
+	tarReader := tar.NewReader(rdr)
+
+	timeout := 16 * time.Millisecond
+	return &storage.ETLSource{TarReader: tarReader, Closer: raw, RetryBaseTime: timeout, TableBase: "test"}, nil
+}
+
+func TestBQSaver(t *testing.T) {
+	row := schema.TCPRow{UUID: "foobar"}
+	row.FinalSnapshot = &snapshot.Snapshot{InetDiagMsg: &inetdiag.InetDiagMsg{}}
+	row.FinalSnapshot.InetDiagMsg.ID.IDiagSPort[1] = 123
+	row.Snapshots = make([]*snapshot.Snapshot, 2)
+	row.Snapshots[0] = &snapshot.Snapshot{InetDiagMsg: &inetdiag.InetDiagMsg{}}
+	row.Snapshots[1] = &snapshot.Snapshot{} // Leave this without InetDiagMsg to test nil handling
+
+	rowMap, _, _ := row.Save()
+	if rowMap["UUID"] != "foobar" {
+		t.Error(spew.Sdump(rowMap))
+	}
+
+	fs := rowMap["FinalSnapshot"].(map[string]bigquery.Value)
+	if fs != nil {
+		idm := fs["InetDiagMsg"].(map[string]bigquery.Value)
+		id := idm["ID"].(map[string]bigquery.Value)
+		if id["SPort"] != int64(123) {
+			t.Error(id)
+		}
+	} else {
+		t.Error("Nil FinalSnapshot")
+	}
+	snapMaps, ok := rowMap["Snapshots"].([]bigquery.Value)
+	if !ok || snapMaps == nil {
+		t.Fatal("Nil snapshots")
+	}
+	sm := snapMaps[0]
+	snapMap, ok := sm.(map[string]bigquery.Value)
+	if snapMap == nil || !ok {
+		t.Fatal("Problem with first snapshot")
+	}
+	idm, ok := snapMap["InetDiagMsg"]
+	if !ok {
+		t.Fatal("problem with idm")
+	}
+	_, ok = idm.(map[string]bigquery.Value)
+	if !ok {
+		t.Fatal("problem with idm")
+	}
+}

--- a/schema/web100.go
+++ b/schema/web100.go
@@ -5,6 +5,7 @@ package schema
 // TODO(prod) Improve unit test coverage.
 import (
 	"log"
+	"reflect"
 
 	"cloud.google.com/go/bigquery"
 )
@@ -23,18 +24,20 @@ func assertSaver(ms Web100ValueMap) {
 	func(bigquery.ValueSaver) {}(ms)
 }
 
-// Returns the contained map, or nil if it doesn't exist.
+// Get returns the contained map, or nil if it doesn't exist.
+// This works for either Web100ValueMap or map[string]bigquery.Value
 func (vm Web100ValueMap) Get(name string) Web100ValueMap {
 	wl, ok := vm[name]
 	if !ok {
-		log.Println("nil")
 		return nil
 	}
-	m, ok := wl.(map[string]bigquery.Value)
-	if !ok {
-		return nil
+	switch wl.(type) {
+	case map[string]bigquery.Value:
+		return Web100ValueMap(wl.(map[string]bigquery.Value))
+	default:
+		log.Println(reflect.TypeOf(wl))
+		return wl.(Web100ValueMap)
 	}
-	return Web100ValueMap(m)
 }
 
 // Get the string at a path in the nested map.  Return value, true if found,

--- a/schema/web100.go
+++ b/schema/web100.go
@@ -27,9 +27,14 @@ func assertSaver(ms Web100ValueMap) {
 func (vm Web100ValueMap) Get(name string) Web100ValueMap {
 	wl, ok := vm[name]
 	if !ok {
+		log.Println("nil")
 		return nil
 	}
-	return wl.(Web100ValueMap)
+	m, ok := wl.(map[string]bigquery.Value)
+	if !ok {
+		return nil
+	}
+	return Web100ValueMap(m)
 }
 
 // Get the string at a path in the nested map.  Return value, true if found,


### PR DESCRIPTION
This introduces the go structs for the new tcpinfo table rows.

It includes some rather hacky code for handling the embedded SockID structs for the short term.  I am working on an alternative that substitutes the SockID struct in the ArchivalRecord decoding, but this is the shorter path to getting something running in staging.

Feedback welcome on the overall row schema implied in the structs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/669)
<!-- Reviewable:end -->
