### PR TITLE
Add update schema tool

### DIFF
--- a/cmd/update-schema/update.go
+++ b/cmd/update-schema/update.go
@@ -1,5 +1,10 @@
 package main
 
+// This command requires the GCLOUD_PROJECT environment variable, and takes an optional
+// single -updateType flag to specify "all" or "tcpinfo".
+// Currently, it handles only the tcpinfo type.
+// The specific table to update is currently hardcoded based on the updateType.
+
 import (
 	"context"
 	"flag"

--- a/cmd/update-schema/update.go
+++ b/cmd/update-schema/update.go
@@ -4,6 +4,10 @@ package main
 // single -updateType flag to specify "all" or "tcpinfo".
 // Currently, it handles only the tcpinfo type.
 // The specific table to update is currently hardcoded based on the updateType.
+//
+// Examples:
+//  GCLOUD_PROJECT=mlab-sandbox go run cmd/update-schema/update.go
+//  GCLOUD_PROJECT=mlab-sandbox go run cmd/update-schema/update.go -updateType=tcpinfo
 
 import (
 	"context"

--- a/cmd/update-schema/update.go
+++ b/cmd/update-schema/update.go
@@ -52,4 +52,6 @@ func main() {
 	CreateOrUpdateTCP("mlab-sandbox", "batch", "tcpinfo")
 	CreateOrUpdateTCP("mlab-staging", "base_tables", "tcpinfo")
 	CreateOrUpdateTCP("mlab-staging", "batch", "tcpinfo")
+	CreateOrUpdateTCP("mlab-oti", "base_tables", "tcpinfo")
+	CreateOrUpdateTCP("mlab-oti", "batch", "tcpinfo")
 }

--- a/cmd/update-schema/update.go
+++ b/cmd/update-schema/update.go
@@ -13,12 +13,12 @@ import (
 	"google.golang.org/api/googleapi"
 )
 
-func CreateOrUpdateTCP(project string) {
+func CreateOrUpdateTCP(project string, dataset string, table string) {
 	row := schema.TCPRow{}
 	schema, err := row.Schema()
 	rtx.Must(err, "TCPRow.Schema")
 
-	name := project + ".base_tables.tcpinfo"
+	name := project + "." + dataset + "." + table
 	log.Println("Using:", name)
 	pdt, err := bqx.ParsePDT(name)
 	rtx.Must(err, "ParsePDT")
@@ -48,6 +48,8 @@ func CreateOrUpdateTCP(project string) {
 
 func main() {
 	//CreateOrUpdateTCP("mlab-testing")
-	CreateOrUpdateTCP("mlab-sandbox")
-	CreateOrUpdateTCP("mlab-staging")
+	CreateOrUpdateTCP("mlab-sandbox", "base_tables", "tcpinfo")
+	CreateOrUpdateTCP("mlab-sandbox", "batch", "tcpinfo")
+	CreateOrUpdateTCP("mlab-staging", "base_tables", "tcpinfo")
+	CreateOrUpdateTCP("mlab-staging", "batch", "tcpinfo")
 }

--- a/cmd/update-schema/update.go
+++ b/cmd/update-schema/update.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/m-lab/etl/schema"
+	"github.com/m-lab/go/rtx"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/m-lab/go/bqx"
+	"google.golang.org/api/googleapi"
+)
+
+func CreateOrUpdateTCP(project string) {
+	row := schema.TCPRow{}
+	schema, err := row.Schema()
+	rtx.Must(err, "TCPRow.Schema")
+
+	name := project + ".base_tables.tcpinfo"
+	log.Println("Using:", name)
+	pdt, err := bqx.ParsePDT(name)
+	rtx.Must(err, "ParsePDT")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	client, err := bigquery.NewClient(ctx, pdt.Project)
+	rtx.Must(err, "NewClient")
+
+	log.Println("Trying Update")
+	// Update non-existing table
+	err = pdt.UpdateTable(ctx, client, schema)
+	if err != nil {
+		apiErr, ok := err.(*googleapi.Error)
+		if !ok || apiErr.Code != 404 {
+		}
+
+		log.Println("UpdateTable failed:", err)
+
+		log.Println("Trying Create")
+		err = pdt.CreateTable(ctx, client, schema, "description",
+			&bigquery.TimePartitioning{ /*Field: "TestTime"*/ }, nil)
+
+		rtx.Must(err, "CreateTable")
+	}
+}
+
+func main() {
+	//CreateOrUpdateTCP("mlab-testing")
+	CreateOrUpdateTCP("mlab-sandbox")
+	CreateOrUpdateTCP("mlab-staging")
+}


### PR DESCRIPTION
This is a quick and dirty update/create tool for the tcp-info schema.
For now it only handles tcpinfo.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/671)
<!-- Reviewable:end -->
