### PR TITLE
Enable tcpinfo parsing

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -49,6 +49,8 @@ func NewParser(dt etl.DataType, ins etl.Inserter) etl.Parser {
 		return NewPTParser(ins)
 	case etl.SW:
 		return NewDiscoParser(ins)
+	case etl.TCPINFO:
+		return NewTCPInfoParser(ins)
 	default:
 		return nil
 	}

--- a/parser/tcpinfo.go
+++ b/parser/tcpinfo.go
@@ -120,13 +120,20 @@ func (p *TCPInfoParser) ParseAndInsert(fileMetadata map[string]bigquery.Value, t
 	if row.FinalSnapshot.InetDiagMsg != nil {
 		row.SockID = row.FinalSnapshot.InetDiagMsg.ID.GetSockID()
 	}
+	row.CopySocketInfo()
+
 	row.UUID = testMetadata.UUID
 	row.TestTime = testMetadata.StartTime
 
 	row.ParseInfo = &schema.ParseInfo{ParseTime: time.Now(), ParserVersion: Version()}
 
 	if fileMetadata["filename"] != nil {
-		row.ParseInfo.TaskFileName = fileMetadata["filename"].(string)
+		fn, ok := fileMetadata["filename"].(string)
+		if ok {
+			row.ParseInfo.TaskFileName = fn
+			row.Server.IATA = etl.GetIATACode(fn)
+			// TODO - should populate other ServerInfo fields from siteinfo API.
+		}
 	}
 
 	err = p.AddRow(&row)

--- a/schema/tcpinfo.go
+++ b/schema/tcpinfo.go
@@ -59,6 +59,13 @@ type TCPRow struct {
 	Snapshots []*snapshot.Snapshot
 }
 
+// CopySocketInfo creates ServerInfo and ClientInfo with IP and port.
+// Should only be called after SockID is populated.
+func (row *TCPRow) CopySocketInfo() {
+	row.Server = &ServerInfo{IP: row.SockID.SrcIP, Port: row.SockID.SPort}
+	row.Client = &ClientInfo{IP: row.SockID.DstIP, Port: row.SockID.DPort}
+}
+
 func assertTCPRowIsValueSaver(r *TCPRow) {
 	func(bigquery.ValueSaver) {}(r)
 }


### PR DESCRIPTION
This adds handling of the etl.TCPINFO type for NewParser, which enables parsing of tcpinfo through the normal request mechanism.

This PR also makes some tweaks to the tcpinfo parser and schema to improve handling of the SockID and ClientInfo and ServerInfo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/673)
<!-- Reviewable:end -->
