### PR TITLE
Buffer only 10 rows for tcpinfo

### DIFF
--- a/etl/globals.go
+++ b/etl/globals.go
@@ -236,7 +236,7 @@ var (
 	dataTypeToBQBufferSize = map[DataType]int{
 		NDT:             10,
 		NDT_OMIT_DELTAS: 50,
-		TCPINFO:         20,  // TODO We really should make this adaptive.
+		TCPINFO:         10,  // TODO We really should make this adaptive.
 		SS:              500, // Average json size is 2.5K
 		PT:              300,
 		SW:              100,


### PR DESCRIPTION
tcpinfo parser is failing inserts because the buffer is sometimes too big.  This buffers fewer rows to reduce likelihood of that happening.

TODO: should probably also limit the number of snapshots in any given test, to avoid excessively large individual tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/674)
<!-- Reviewable:end -->
