### PR TITLE
Decrease insert buffer size for tcpinfo

### DIFF
--- a/bq/insert.go
+++ b/bq/insert.go
@@ -284,7 +284,8 @@ func (in *BQInserter) updateMetrics(err error) error {
 		err = nil
 
 	default:
-		log.Printf("Unhandled %v on insert %v Project: %s, Table: %s\n", reflect.TypeOf(typedErr).Elem(),
+		// With Elem(), this was causing panics.
+		log.Printf("Unhandled %v on insert %v Project: %s, Table: %s\n", reflect.TypeOf(typedErr),
 			typedErr, in.Project(), in.FullTableName())
 		metrics.BackendFailureCount.WithLabelValues(
 			in.TableBase(), "failed insert").Inc()

--- a/etl/globals.go
+++ b/etl/globals.go
@@ -242,7 +242,7 @@ var (
 	dataTypeToBQBufferSize = map[DataType]int{
 		NDT:             10,
 		NDT_OMIT_DELTAS: 50,
-		TCPINFO:         10,  // TODO We really should make this adaptive.
+		TCPINFO:         5,   // TODO We really should make this adaptive.
 		SS:              500, // Average json size is 2.5K
 		PT:              300,
 		SW:              100,


### PR DESCRIPTION
Reduces tcpinfo insert buffer to reduce rejected inserts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/680)
<!-- Reviewable:end -->
