### PR TITLE
Fix regexp to handle traceroute filenames

### DIFF
--- a/appengine/queue_pusher/queue_pusher.go
+++ b/appengine/queue_pusher/queue_pusher.go
@@ -5,12 +5,12 @@ package pushqueue
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"net/url"
 
 	"github.com/m-lab/etl/etl"
 	"google.golang.org/appengine"
+	"google.golang.org/appengine/log"
 	"google.golang.org/appengine/taskqueue"
 )
 
@@ -57,7 +57,8 @@ func queueStats(w http.ResponseWriter, r *http.Request) {
 
 	if queuename == "" {
 		http.Error(w, `{"message": "Bad request parameters"}`, http.StatusBadRequest)
-		log.Printf("%+v\n", w)
+		ctx := appengine.NewContext(r)
+		log.Errorf(ctx, "%+v\n", w)
 		return
 	}
 
@@ -103,7 +104,8 @@ func receiver(w http.ResponseWriter, r *http.Request) {
 	// Validate filename.
 	fnData, err := etl.ValidateTestPath(decodedFilename)
 	if err != nil {
-		log.Println(err)
+		ctx := appengine.NewContext(r)
+		log.Errorf(ctx, "%v\n", err)
 		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprintf(w, `{"message": "Invalid filename."}`)
 		return

--- a/appengine/queue_pusher/queue_pusher_test.go
+++ b/appengine/queue_pusher/queue_pusher_test.go
@@ -76,13 +76,13 @@ func TestStats(t *testing.T) {
 			r, err := inst.NewRequest(`GET`, `http://foobar.com/stats?queuename=`+tt.queue+`&test-bypass=true`, nil)
 			if err != nil {
 				t.Error(err)
-			} else {
-				queueStats(w, r)
-				if w.Result().StatusCode != tt.status {
-					b, _ := ioutil.ReadAll(w.Body)
-					t.Log(string(b))
-					t.Error(w.Result().StatusCode)
-				}
+				return
+			}
+			queueStats(w, r)
+			if w.Result().StatusCode != tt.status {
+				b, _ := ioutil.ReadAll(w.Body)
+				t.Log(string(b))
+				t.Error(w.Result().StatusCode)
 			}
 		})
 	}
@@ -144,13 +144,13 @@ func TestReceiver(t *testing.T) {
 			r, err := inst.NewRequest("GET", "http://foobar.com/receiver"+reqStr, nil)
 			if err != nil {
 				t.Error(err)
-			} else {
-				receiver(w, r)
-				if w.Result().StatusCode != tt.status {
-					b, _ := ioutil.ReadAll(w.Body)
-					t.Log(string(b))
-					t.Error(w.Result().StatusCode)
-				}
+				return
+			}
+			receiver(w, r)
+			if w.Result().StatusCode != tt.status {
+				b, _ := ioutil.ReadAll(w.Body)
+				t.Log(string(b))
+				t.Error(w.Result().StatusCode)
 			}
 		})
 	}

--- a/appengine/queue_pusher/queue_pusher_test.go
+++ b/appengine/queue_pusher/queue_pusher_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"google.golang.org/appengine/aetest"
 )
 
 func init() {
@@ -61,15 +63,26 @@ func TestStats(t *testing.T) {
 			status: http.StatusOK,
 		},
 	}
+
+	inst, err := aetest.NewInstance(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer inst.Close()
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
-			r := httptest.NewRequest(`GET`, `http://foobar.com/stats?queuename=`+tt.queue+`&test-bypass=true`, nil)
-			queueStats(w, r)
-			if w.Result().StatusCode != tt.status {
-				b, _ := ioutil.ReadAll(w.Body)
-				t.Log(string(b))
-				t.Error(w.Result().StatusCode)
+			r, err := inst.NewRequest(`GET`, `http://foobar.com/stats?queuename=`+tt.queue+`&test-bypass=true`, nil)
+			if err != nil {
+				t.Error(err)
+			} else {
+				queueStats(w, r)
+				if w.Result().StatusCode != tt.status {
+					b, _ := ioutil.ReadAll(w.Body)
+					t.Log(string(b))
+					t.Error(w.Result().StatusCode)
+				}
 			}
 		})
 	}
@@ -117,17 +130,27 @@ func TestReceiver(t *testing.T) {
 		},
 	}
 
+	inst, err := aetest.NewInstance(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer inst.Close()
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var reqStr string
 			reqStr = "?filename=" + tt.filename + "&test-bypass=true"
 			w := httptest.NewRecorder()
-			r := httptest.NewRequest("GET", "http://foobar.com/receiver"+reqStr, nil)
-			receiver(w, r)
-			if w.Result().StatusCode != tt.status {
-				b, _ := ioutil.ReadAll(w.Body)
-				t.Log(string(b))
-				t.Error(w.Result().StatusCode)
+			r, err := inst.NewRequest("GET", "http://foobar.com/receiver"+reqStr, nil)
+			if err != nil {
+				t.Error(err)
+			} else {
+				receiver(w, r)
+				if w.Result().StatusCode != tt.status {
+					b, _ := ioutil.ReadAll(w.Body)
+					t.Log(string(b))
+					t.Error(w.Result().StatusCode)
+				}
 			}
 		})
 	}
@@ -167,17 +190,27 @@ func TestReceiverWithQueue(t *testing.T) {
 		},
 	}
 
+	inst, err := aetest.NewInstance(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer inst.Close()
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var reqStr string
 			reqStr = "?filename=" + tt.filename + "&queue=" + tt.queue + "&test-bypass=true"
 			w := httptest.NewRecorder()
-			r := httptest.NewRequest("GET", "http://foobar.com/receiver"+reqStr, nil)
-			receiver(w, r)
-			if w.Result().StatusCode != tt.status {
-				b, _ := ioutil.ReadAll(w.Body)
-				t.Log(string(b))
-				t.Error(w.Result().StatusCode)
+			r, err := inst.NewRequest("GET", "http://foobar.com/receiver"+reqStr, nil)
+			if err != nil {
+				t.Error(err)
+			} else {
+				receiver(w, r)
+				if w.Result().StatusCode != tt.status {
+					b, _ := ioutil.ReadAll(w.Body)
+					t.Log(string(b))
+					t.Error(w.Result().StatusCode)
+				}
 			}
 		})
 	}

--- a/etl/globals.go
+++ b/etl/globals.go
@@ -44,7 +44,7 @@ const dateTime = `(\d{4}[01]\d[0123]\d)T(\d{6})(\.\d{0,6})?Z`
 
 const type2 = `(?:-([a-z-]+))?` // optional datatype string
 const mlabNSiteNN = `-(mlab\d)-([a-z]{3}\d[0-9t])-`
-const expNNNNE = `([a-z]+)(?:-(\d{4}))?(-e)?`
+const expNNNNE = `([a-z-]+)(?:-(\d{4}))?(-e)?`
 const suffix = `(\.tar|\.tar.gz|\.tgz)$`
 
 // These are here to facilitate use across queue-pusher and parsing components.

--- a/etl/globals.go
+++ b/etl/globals.go
@@ -36,7 +36,7 @@ const YYYYMMDD = `\d{4}[01]\d[0123]\d`
 const MlabDomain = `measurement-lab.org`
 
 const bucket = `gs://([^/]*)/`
-const expType = `(?:([a-z-]+)/)?([a-z-]+)/` // experiment OR experiment/type
+const expType = `(?:([a-z-]+)/)?([a-z-]+)/` // experiment OR experiment/type.
 
 const datePath = `(\d{4}/[01]\d/[0123]\d)/`
 
@@ -44,6 +44,8 @@ const dateTime = `(\d{4}[01]\d[0123]\d)T(\d{6})(\.\d{0,6})?Z`
 
 const type2 = `(?:-([a-z-]+))?` // optional datatype string
 const mlabNSiteNN = `-(mlab\d)-([a-z]{3}\d[0-9t])-`
+
+// This parses the experiment name, optional -NNNN sequence number, and optional -e (for old embargoed files)
 const expNNNNE = `([a-z-]+)(?:-(\d{4}))?(-e)?`
 const suffix = `(\.tar|\.tar.gz|\.tgz)$`
 
@@ -53,7 +55,11 @@ var (
 		`(?P<preamble>.*)` + dateTime + `(?P<postamble>.*)`)
 
 	startPattern = regexp.MustCompile(`^` + bucket + expType + datePath + `$`)
-	endPattern   = regexp.MustCompile(`^` + type2 + mlabNSiteNN + expNNNNE + suffix + `$`)
+	endPattern   = regexp.MustCompile(`^` +
+		type2 + // 1
+		mlabNSiteNN + // 2,3
+		expNNNNE + // 4,5,6
+		suffix + `$`) // 7
 
 	dateTimePattern = regexp.MustCompile(dateTime)
 	sitePattern     = regexp.MustCompile(type2 + mlabNSiteNN)

--- a/etl/globals_test.go
+++ b/etl/globals_test.go
@@ -322,3 +322,12 @@ func TestDirToTablename(t *testing.T) {
 		t.Errorf("DirToTablename() failed to translate PT dir name correctly.")
 	}
 }
+
+func TestParisFilename(t *testing.T) {
+
+	path, err := etl.ValidateTestPath(`gs://archive-mlab-oti/paris-traceroute/2019/06/11/20190611T000002Z-mlab2-bom01-paris-traceroute-0000.tgz`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Println(path)
+}

--- a/etl/globals_test.go
+++ b/etl/globals_test.go
@@ -84,6 +84,14 @@ func TestValidateTestPath(t *testing.T) {
 				"pusher-mlab-staging", "ndt", "tcpinfo", "2019/05/25", "20190525", "020001", "tcpinfo", "mlab4", "ord01", "ndt", "", "", ".tgz",
 			},
 		},
+		{
+			name:     "traceroute-tgz",
+			path:     `gs://archive-mlab-oti/paris-traceroute/2019/06/11/20190611T000002Z-mlab2-bom01-paris-traceroute-0000.tgz`,
+			wantType: etl.PT,
+			want: &etl.DataPath{
+				"archive-mlab-oti", "", "paris-traceroute", "2019/06/11", "20190611", "000002", "", "mlab2", "bom01", "paris-traceroute", "0000", "", ".tgz",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -321,13 +329,4 @@ func TestDirToTablename(t *testing.T) {
 	if etl.DirToTablename("paris-traceroute") != "traceroute" {
 		t.Errorf("DirToTablename() failed to translate PT dir name correctly.")
 	}
-}
-
-func TestParisFilename(t *testing.T) {
-
-	path, err := etl.ValidateTestPath(`gs://archive-mlab-oti/paris-traceroute/2019/06/11/20190611T000002Z-mlab2-bom01-paris-traceroute-0000.tgz`)
-	if err != nil {
-		t.Fatal(err)
-	}
-	log.Println(path)
 }


### PR DESCRIPTION
This fixes the etl/globals.go, and also fixes a logging bug in queue_pusher.go.
Also adds unit test so that we don't miss this next time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/683)
<!-- Reviewable:end -->
