### PR TITLE
Add parser for NDT legacy format from ndt-server

### DIFF
--- a/appengine/queue.yaml
+++ b/appengine/queue.yaml
@@ -673,6 +673,27 @@ queue:
     min_backoff_seconds: 20
     max_backoff_seconds: 20
 
+- name: etl-legacy-batch-0
+  target: etl-batch-parser
+  rate: 0.2/s
+  bucket_size: 10
+  max_concurrent_requests: 5
+  retry_parameters:
+    task_age_limit: 12h
+    min_backoff_seconds: 20
+    max_backoff_seconds: 20
+    max_doublings: 0
+- name: etl-legacy-batch-1
+  target: etl-batch-parser
+  rate: 0.2/s
+  bucket_size: 10
+  max_concurrent_requests: 5
+  retry_parameters:
+    task_age_limit: 12h
+    min_backoff_seconds: 20
+    max_backoff_seconds: 20
+    max_doublings: 0
+
 - name: etl-traceroute-queue
   target: etl-traceroute-parser
   # Average rate at which to release tasks to the service.  Default is 5/sec

--- a/etl/globals.go
+++ b/etl/globals.go
@@ -207,6 +207,7 @@ func (dt DataType) BQBufferSize() int {
 // TODO - use camelcase.
 const (
 	NDT             = DataType("ndt")
+	NDT_LEGACY      = DataType("ndt_legacy")
 	NDT_OMIT_DELTAS = DataType("ndt_nodelta") // to support larger buffer size.
 	SS              = DataType("sidestream")
 	PT              = DataType("traceroute")
@@ -220,6 +221,7 @@ var (
 	// TODO - this should be loaded from a config.
 	dirToDataType = map[string]DataType{
 		"ndt":              NDT,
+		"legacy":           NDT_LEGACY,
 		"sidestream":       SS,
 		"paris-traceroute": PT,
 		"switch":           SW,
@@ -229,12 +231,13 @@ var (
 	// DataTypeToTable maps from data type to BigQuery table name.
 	// TODO - this should be loaded from a config.
 	dataTypeToTable = map[DataType]string{
-		NDT:     "ndt",
-		SS:      "sidestream",
-		PT:      "scamper",
-		SW:      "switch",
-		TCPINFO: "tcpinfo",
-		INVALID: "invalid",
+		NDT:        "ndt",
+		SS:         "sidestream",
+		PT:         "scamper",
+		SW:         "switch",
+		TCPINFO:    "tcpinfo",
+		NDT_LEGACY: "legacy",
+		INVALID:    "invalid",
 	}
 
 	// Map from data type to number of buffer size for BQ insertion.
@@ -246,6 +249,7 @@ var (
 		SS:              500, // Average json size is 2.5K
 		PT:              5,
 		SW:              100,
+		NDT_LEGACY:      50,
 		INVALID:         0,
 	}
 	// There is also a mapping of data types to queue names in

--- a/parser/ndt_legacy.go
+++ b/parser/ndt_legacy.go
@@ -1,0 +1,126 @@
+// Package parser defines the Parser interface and implementations for the different
+// test types, NDT, Paris Traceroute, and SideStream.
+package parser
+
+// This file defines the Parser subtype that handles NDTLegacy data.
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+
+	"github.com/m-lab/etl/etl"
+	"github.com/m-lab/etl/metrics"
+	"github.com/m-lab/etl/schema"
+)
+
+//=====================================================================================
+//                       NDTLegacy Parser
+//=====================================================================================
+type NDTLegacyParser struct {
+	inserter     etl.Inserter
+	etl.RowStats // RowStats implemented for NDTLegacyParser with an embedded struct.
+}
+
+func NewNDTLegacyParser(ins etl.Inserter) etl.Parser {
+	return &NDTLegacyParser{
+		inserter: ins,
+		RowStats: ins} // Delegate RowStats functions to the Inserter.
+}
+
+func (dp *NDTLegacyParser) TaskError() error {
+	return nil
+}
+
+// IsParsable returns the canonical test type and whether to parse data.
+func (dp *NDTLegacyParser) IsParsable(testName string, data []byte) (string, bool) {
+	// Files look like: "<UUID>.json"
+	if strings.HasSuffix(testName, "json") {
+		return "ndt_legacy", true
+	}
+	return "unknown", false
+}
+
+// NOTE: NDTLegacy data is a JSON object that should be pushed directly into BigQuery.
+// We read the value into a struct, for compatibility with current inserter
+// backend and to eventually rely on the schema inference in m-lab/go/bqx.CreateTable().
+
+// ParseAndInsert decodes the NDT Result JSON data and inserts it into BQ.
+func (dp *NDTLegacyParser) ParseAndInsert(meta map[string]bigquery.Value, testName string, test []byte) error {
+	metrics.WorkerState.WithLabelValues(dp.TableName(), "ndt_legacy").Inc()
+	defer metrics.WorkerState.WithLabelValues(dp.TableName(), "ndt_legacy").Dec()
+
+	rdr := bytes.NewReader(test)
+	dec := json.NewDecoder(rdr)
+	rowCount := 0
+
+	for dec.More() {
+		stats := schema.NDTLegacySchema{
+			TaskFilename:  meta["filename"].(string),
+			TestID:        testName,
+			ParseTime:     time.Now(),
+			ParserVersion: Version(),
+		}
+		err := dec.Decode(&stats.Result)
+		if err != nil {
+			metrics.TestCount.WithLabelValues(
+				dp.TableName(), "ndt_legacy", "Decode").Inc()
+			return err
+		}
+		rowCount++
+
+		// Set the LogTime to the Result.StartTime
+		stats.LogTime = stats.Result.StartTime.Unix()
+
+		// Count the number of samples per record.
+		metrics.DeltaNumFieldsHistogram.WithLabelValues(
+			dp.TableName()).Observe(1.0)
+
+		// Estimate the row size based on the input JSON size.
+		metrics.RowSizeHistogram.WithLabelValues(
+			dp.TableName()).Observe(float64(len(test)))
+
+		log.Println("Inserting:", stats)
+		err = dp.inserter.InsertRow(stats)
+		if err != nil {
+			switch t := err.(type) {
+			case bigquery.PutMultiError:
+				// TODO improve error handling??
+				metrics.TestCount.WithLabelValues(
+					dp.TableName(), "ndt_legacy", "insert-multi").Inc()
+				log.Printf("%v\n", t[0].Error())
+			default:
+				metrics.TestCount.WithLabelValues(
+					dp.TableName(), "ndt_legacy", "insert-other").Inc()
+			}
+			return err
+		}
+		// Count successful inserts.
+		metrics.TestCount.WithLabelValues(dp.TableName(), "ndt_legacy", "ok").Inc()
+	}
+
+	// There should always be one row per file.
+	metrics.EntryFieldCountHistogram.WithLabelValues(
+		dp.TableName()).Observe(float64(rowCount))
+
+	return nil
+}
+
+// NB: These functions are also required to complete the etl.Parser interface.
+// For NDTLegacy, we just forward the calls to the Inserter.
+
+func (dp *NDTLegacyParser) Flush() error {
+	return dp.inserter.Flush()
+}
+
+func (dp *NDTLegacyParser) TableName() string {
+	return dp.inserter.TableBase()
+}
+
+func (dp *NDTLegacyParser) FullTableName() string {
+	return dp.inserter.FullTableName()
+}

--- a/parser/ndt_legacy.go
+++ b/parser/ndt_legacy.go
@@ -84,7 +84,6 @@ func (dp *NDTLegacyParser) ParseAndInsert(meta map[string]bigquery.Value, testNa
 		metrics.RowSizeHistogram.WithLabelValues(
 			dp.TableName()).Observe(float64(len(test)))
 
-		log.Println("Inserting:", stats)
 		err = dp.inserter.InsertRow(stats)
 		if err != nil {
 			switch t := err.(type) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -43,6 +43,8 @@ func NewParser(dt etl.DataType, ins etl.Inserter) etl.Parser {
 	switch dt {
 	case etl.NDT:
 		return NewNDTParser(ins)
+	case etl.NDT_LEGACY:
+		return NewNDTLegacyParser(ins)
 	case etl.SS:
 		return NewDefaultSSParser(ins) // TODO fix this hack.
 	case etl.PT:

--- a/schema/ndt_legacy.go
+++ b/schema/ndt_legacy.go
@@ -35,12 +35,10 @@ type NDTResult struct {
 // NDTLegacySchema defines the BQ schema for the NDTLegacys produced by the
 // ndt-server for the NDT3 and NDT4 clients.
 type NDTLegacySchema struct {
-	TaskFilename  string    `json:"task_filename,string" bigquery:"task_filename"`
-	TestID        string    `json:"test_id,string" bigquery:"test_id"`
-	ParseTime     time.Time `json:"parse_time" bigquery:"parse_time"`
-	ParserVersion string    `json:"parser_version,string" bigquery:"parser_version"`
-	LogTime       int64     `json:"log_time,int64" bigquery:"log_time"`
-	Result        NDTResult `json:"result" bigquery:"result"`
+	ParseInfo *ParseInfo
+	TestID    string    `json:"test_id,string" bigquery:"test_id"`
+	LogTime   int64     `json:"log_time,int64" bigquery:"log_time"`
+	Result    NDTResult `json:"result" bigquery:"result"`
 }
 
 // Schema returns the Bigquery schema for NDTLegacySchema

--- a/schema/ndt_legacy.go
+++ b/schema/ndt_legacy.go
@@ -1,0 +1,54 @@
+package schema
+
+import (
+	"time"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/m-lab/go/bqx"
+
+	"github.com/m-lab/ndt-server/legacy/c2s"
+	"github.com/m-lab/ndt-server/legacy/ndt"
+	"github.com/m-lab/ndt-server/legacy/s2c"
+)
+
+// TODO: Remove this in favor of using the ndt-server legacy.NDTResult directly
+// once NDTResult.Meta support bigquery.Saver.
+type NDTResult struct {
+	// GitShortCommit is the Git commit (short form) of the running server code.
+	GitShortCommit string
+
+	// These data members should all be self-describing. In the event of confusion,
+	// rename them to add clarity rather than adding a comment.
+	ControlChannelUUID string
+	Protocol           ndt.ConnectionType
+	MessageProtocol    string
+	ServerIP           string
+	ClientIP           string
+
+	StartTime time.Time
+	EndTime   time.Time
+	C2S       *c2s.ArchivalData `json:",omitempty"`
+	S2C       *s2c.ArchivalData `json:",omitempty"`
+	// NOTE: we omit NDTResult.Meta (map[]) until it supports the bigquery.Saver interface.
+}
+
+// NDTLegacySchema defines the BQ schema for the NDTLegacys produced by the
+// ndt-server for the NDT3 and NDT4 clients.
+type NDTLegacySchema struct {
+	TaskFilename  string    `json:"task_filename,string" bigquery:"task_filename"`
+	TestID        string    `json:"test_id,string" bigquery:"test_id"`
+	ParseTime     time.Time `json:"parse_time" bigquery:"parse_time"`
+	ParserVersion string    `json:"parser_version,string" bigquery:"parser_version"`
+	LogTime       int64     `json:"log_time,int64" bigquery:"log_time"`
+	Result        NDTResult `json:"result" bigquery:"result"`
+}
+
+// Schema returns the Bigquery schema for NDTLegacySchema
+func (row *NDTLegacySchema) Schema() (bigquery.Schema, error) {
+	sch, err := bigquery.InferSchema(row)
+	if err != nil {
+		return bigquery.Schema{}, err
+	}
+	rr := bqx.RemoveRequired(sch)
+	return rr, nil
+}


### PR DESCRIPTION
This change adds basic ndt_legacy parser support for the legacy JSON output format from the ndt-server.

Ultimately this functionality should be retired once the ndt-server Result type unifies the legacy & ndt7 schemas. For now, this parser will help with analysis of the data from the new ndt-server pilot.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/696)
<!-- Reviewable:end -->
