### PR TITLE
adjust ndt and ndt-legacy rates

### DIFF
--- a/appengine/queue.yaml
+++ b/appengine/queue.yaml
@@ -93,7 +93,8 @@ queue:
 #
 - name: etl-ndt-batch-0
   target: etl-batch-parser
-  rate: 10/s
+  # At 10/s, the ndt requests cause a lot of 429s, and crowd out the other queues.
+  rate: 5/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -104,7 +105,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-1
   target: etl-batch-parser
-  rate: 10/s
+  rate: 5/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -114,7 +115,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-2
   target: etl-batch-parser
-  rate: 10/s
+  rate: 5/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -124,7 +125,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-3
   target: etl-batch-parser
-  rate: 10/s
+  rate: 5/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -134,7 +135,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-4
   target: etl-batch-parser
-  rate: 10/s
+  rate: 5/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -144,7 +145,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-5
   target: etl-batch-parser
-  rate: 10/s
+  rate: 5/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -154,7 +155,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-6
   target: etl-batch-parser
-  rate: 10/s
+  rate: 5/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -164,7 +165,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-7
   target: etl-batch-parser
-  rate: 10/s
+  rate: 5/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -174,7 +175,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-8
   target: etl-batch-parser
-  rate: 10/s
+  rate: 5/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -184,7 +185,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-9
   target: etl-batch-parser
-  rate: 10/s
+  rate: 5/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -194,7 +195,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-10
   target: etl-batch-parser
-  rate: 10/s
+  rate: 5/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -204,7 +205,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-11
   target: etl-batch-parser
-  rate: 10/s
+  rate: 5/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -214,7 +215,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-12
   target: etl-batch-parser
-  rate: 10/s
+  rate: 5/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -224,7 +225,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-13
   target: etl-batch-parser
-  rate: 10/s
+  rate: 5/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -234,7 +235,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-14
   target: etl-batch-parser
-  rate: 10/s
+  rate: 5/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -244,7 +245,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-15
   target: etl-batch-parser
-  rate: 10/s
+  rate: 5/s
   bucket_size: 10
   max_concurrent_requests: 150
   retry_parameters:
@@ -675,7 +676,8 @@ queue:
 
 - name: etl-legacy-batch-0
   target: etl-batch-parser
-  rate: 0.2/s
+  # At 0.2/sec, this was getting crowded out by ndt.
+  rate: 1/s
   bucket_size: 10
   max_concurrent_requests: 5
   retry_parameters:
@@ -685,7 +687,7 @@ queue:
     max_doublings: 0
 - name: etl-legacy-batch-1
   target: etl-batch-parser
-  rate: 0.2/s
+  rate: 1/s
   bucket_size: 10
   max_concurrent_requests: 5
   retry_parameters:


### PR DESCRIPTION
This adjusts the NDT task queue request rate from 10 to 5, to reduce the degree to which NDT is crowding out other tasks.

It also increases ndt-legacy request rate from 0.2 to 1.0.  This may require addition adjustment, but it is difficult to know without trial and error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/698)
<!-- Reviewable:end -->
