### PR TITLE
Handle request too big

### DIFF
--- a/appengine/queue.yaml
+++ b/appengine/queue.yaml
@@ -656,9 +656,9 @@ queue:
 # TCPINFO batch parsing queues.
 - name: etl-tcpinfo-batch-0
   target: etl-batch-parser
-  rate: 0.2/s
+  rate: 2/s
   bucket_size: 10
-  max_concurrent_requests: 5
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -666,9 +666,9 @@ queue:
 
 - name: etl-tcpinfo-batch-1
   target: etl-batch-parser
-  rate: 0.2/s
+  rate: 2/s
   bucket_size: 10
-  max_concurrent_requests: 5
+  max_concurrent_requests: 10
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20

--- a/bq/bq_test.go
+++ b/bq/bq_test.go
@@ -291,6 +291,10 @@ func TestHandleRequestTooLarge(t *testing.T) {
 
 	bqi.InsertRows(items)
 	bqi.Flush()
+	// Should see two fails, and three successes.
+	if fakeUploader.CallCount != 5 {
+		t.Errorf("Expected %d calls, got %d\n", 3, fakeUploader.CallCount)
+	}
 	if bqi.Committed() != 5 {
 		t.Error("Lost rows:", bqi.Committed())
 	}

--- a/bq/bq_test.go
+++ b/bq/bq_test.go
@@ -271,6 +271,34 @@ func TestHandleInsertErrors(t *testing.T) {
 	}
 }
 
+func TestHandleRequestTooLarge(t *testing.T) {
+	fakeUploader := fake.NewFakeUploader()
+	fakeUploader.RejectIfMoreThan = 2
+	bqi, e := bq.NewBQInserter(standardInsertParams(5), fakeUploader)
+	if e != nil {
+		log.Printf("%v\n", e)
+		t.Fatal()
+	}
+
+	// These don't have to implement saver as long as Err is being set,
+	// and flush is not autotriggering more than once.
+	var items []interface{}
+	items = append(items, Item{Name: "x1", Count: 17, Foobar: 44})
+	items = append(items, Item{Name: "x2", Count: 12, Foobar: 44})
+	items = append(items, Item{Name: "x3", Count: 12, Foobar: 44})
+	items = append(items, Item{Name: "x4", Count: 12, Foobar: 44})
+	items = append(items, Item{Name: "x5", Count: 12, Foobar: 44})
+
+	bqi.InsertRows(items)
+	bqi.Flush()
+	if bqi.Committed() != 5 {
+		t.Error("Lost rows:", bqi.Committed())
+	}
+	if bqi.Failed() > 0 {
+		t.Errorf("Lost rows: %+v", bqi)
+	}
+}
+
 func TestQuotaError(t *testing.T) {
 
 	// Set up an Inserter with a fake Uploader backend for testing.

--- a/bq/bq_test.go
+++ b/bq/bq_test.go
@@ -293,7 +293,7 @@ func TestHandleRequestTooLarge(t *testing.T) {
 	bqi.Flush()
 	// Should see two fails, and three successes.
 	if fakeUploader.CallCount != 5 {
-		t.Errorf("Expected %d calls, got %d\n", 3, fakeUploader.CallCount)
+		t.Errorf("Expected %d calls, got %d\n", 5, fakeUploader.CallCount)
 	}
 	if bqi.Committed() != 5 {
 		t.Error("Lost rows:", bqi.Committed())

--- a/bq/insert.go
+++ b/bq/insert.go
@@ -441,7 +441,9 @@ func (in *BQInserter) flushSlice(rows []interface{}) error {
 		in.pending = 0
 		err1 := in.flushSlice(rows[:size/2])
 		err2 := in.flushSlice(rows[size/2:])
-		// Recursive calls handled accounting for any errors not resolved by splitting,
+		// The recursive calls will have added various InsertionHistogram results, included successes
+		// and failures, so we don't need to add those here.
+		// Recursive calls also will have handled accounting for any errors not resolved by splitting,
 		// but we want to return any non-nil error up the stack WITHOUT repeating the accounting.
 		if err1 != nil {
 			err = err1

--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -252,6 +252,9 @@ func subworker(rawFileName string, executionCount, retryCount int, age time.Dura
 	if err != nil {
 		metrics.TaskCount.WithLabelValues(data.TableBase(), string(dataType), "TaskError").Inc()
 		log.Printf("Error Processing Tests:  %v", err)
+		// NOTE: This may cause indefinite retries, and stalled task queue.  Task will eventually
+		// expire, but it might be better to have a different mechanism for retries, particularly
+		// for gardener, which waits for empty task queue.
 		return http.StatusInternalServerError, `{"message": "Error in ProcessAllTests"}`
 		// TODO - anything better we could do here?
 	}

--- a/etl/globals.go
+++ b/etl/globals.go
@@ -245,7 +245,7 @@ var (
 	dataTypeToBQBufferSize = map[DataType]int{
 		NDT:             10,
 		NDT_OMIT_DELTAS: 50,
-		TCPINFO:         5,   // TODO We really should make this adaptive.
+		TCPINFO:         10,
 		SS:              500, // Average json size is 2.5K
 		PT:              5,
 		SW:              100,


### PR DESCRIPTION
When bigquery encounters "Request payload size exceeds ..." errors, it is often because a single row is too large.  This recursively splits the buffer in half and tries again.  Some rows may still fail, but they won't prevent other rows from successfully inserting.

This should (mostly) resolve #705.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/706)
<!-- Reviewable:end -->
