### PR TITLE
add metrics and increase tcpinfo speed

### DIFF
--- a/appengine/queue.yaml
+++ b/appengine/queue.yaml
@@ -658,7 +658,7 @@ queue:
   target: etl-batch-parser
   rate: 2/s
   bucket_size: 10
-  max_concurrent_requests: 10
+  max_concurrent_requests: 50
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20
@@ -668,7 +668,7 @@ queue:
   target: etl-batch-parser
   rate: 2/s
   bucket_size: 10
-  max_concurrent_requests: 10
+  max_concurrent_requests: 50
   retry_parameters:
     task_age_limit: 12h
     min_backoff_seconds: 20

--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -461,8 +461,8 @@ func (n *NDTParser) getDeltas(snaplog *web100.SnapLog, testType string) ([]schem
 
 func (n *NDTParser) getAndInsertValues(test *fileInfoAndData, testType string) {
 	// Extract the values from the last snapshot.
-	metrics.WorkerState.WithLabelValues(n.TableName(), "parse").Inc()
-	defer metrics.WorkerState.WithLabelValues(n.TableName(), "parse").Dec()
+	metrics.WorkerState.WithLabelValues(n.TableName(), "ndt-parse").Inc()
+	defer metrics.WorkerState.WithLabelValues(n.TableName(), "ndt-parse").Dec()
 
 	if !strings.HasSuffix(test.fn, ".gz") {
 		metrics.WarningCount.WithLabelValues(

--- a/parser/pt.go
+++ b/parser/pt.go
@@ -445,8 +445,8 @@ func ProcessOneTuple(parts []string, protocol string, currentLeaves []Node, allN
 // TODO(dev): dedup the hops that are identical.
 func Parse(meta map[string]bigquery.Value, testName string, testId string, rawContent []byte, tableName string) (cachedPTData, error) {
 	//log.Printf("%s", testName)
-	metrics.WorkerState.WithLabelValues(tableName, "parse").Inc()
-	defer metrics.WorkerState.WithLabelValues(tableName, "parse").Dec()
+	metrics.WorkerState.WithLabelValues(tableName, "pt-parse").Inc()
+	defer metrics.WorkerState.WithLabelValues(tableName, "pt-parse").Dec()
 
 	// Get the logtime
 	fn := PTFileName{Name: filepath.Base(testName)}

--- a/parser/tcpinfo.go
+++ b/parser/tcpinfo.go
@@ -27,6 +27,7 @@ import (
 	v2as "github.com/m-lab/annotation-service/api/v2"
 	"github.com/m-lab/etl/annotation"
 	"github.com/m-lab/etl/etl"
+	"github.com/m-lab/etl/metrics"
 	"github.com/m-lab/etl/schema"
 	"github.com/m-lab/tcp-info/netlink"
 	"github.com/m-lab/tcp-info/snapshot"
@@ -70,6 +71,10 @@ func (p *TCPInfoParser) IsParsable(testName string, data []byte) (string, bool) 
 // ParseAndInsert extracts all ArchivalRecords from the rawContent and inserts into a single row.
 // Approximately 15 usec/snapshot.
 func (p *TCPInfoParser) ParseAndInsert(fileMetadata map[string]bigquery.Value, testName string, rawContent []byte) error {
+	tableName := p.TableName()
+	metrics.WorkerState.WithLabelValues(tableName, "tcpinfo").Inc()
+	defer metrics.WorkerState.WithLabelValues(tableName, "tcpinfo").Dec()
+
 	if strings.HasSuffix(testName, "zst") {
 		var err error
 		rawContent, err = gozstd.Decompress(nil, rawContent)
@@ -82,6 +87,7 @@ func (p *TCPInfoParser) ParseAndInsert(fileMetadata map[string]bigquery.Value, t
 	rdr := bytes.NewReader(rawContent)
 	ar := netlink.NewArchiveReader(rdr)
 
+	metrics.WorkerState.WithLabelValues(tableName, "tcpinfo-parse").Inc()
 	var err error
 	var rec *netlink.ArchivalRecord
 	snaps := make([]*snapshot.Snapshot, 0, 2000)
@@ -135,6 +141,7 @@ func (p *TCPInfoParser) ParseAndInsert(fileMetadata map[string]bigquery.Value, t
 			// TODO - should populate other ServerInfo fields from siteinfo API.
 		}
 	}
+	metrics.WorkerState.WithLabelValues(tableName, "tcpinfo-parse").Dec()
 
 	err = p.AddRow(&row)
 	if err == etl.ErrBufferFull {

--- a/parser/tcpinfo.go
+++ b/parser/tcpinfo.go
@@ -88,6 +88,9 @@ func (p *TCPInfoParser) ParseAndInsert(fileMetadata map[string]bigquery.Value, t
 	ar := netlink.NewArchiveReader(rdr)
 
 	metrics.WorkerState.WithLabelValues(tableName, "tcpinfo-parse").Inc()
+	// This will include the annotation when the buffer flushes, which is unfortunate.
+	defer metrics.WorkerState.WithLabelValues(tableName, "tcpinfo-parse").Dec()
+
 	var err error
 	var rec *netlink.ArchivalRecord
 	snaps := make([]*snapshot.Snapshot, 0, 2000)
@@ -141,7 +144,6 @@ func (p *TCPInfoParser) ParseAndInsert(fileMetadata map[string]bigquery.Value, t
 			// TODO - should populate other ServerInfo fields from siteinfo API.
 		}
 	}
-	metrics.WorkerState.WithLabelValues(tableName, "tcpinfo-parse").Dec()
 
 	err = p.AddRow(&row)
 	if err == etl.ErrBufferFull {


### PR DESCRIPTION
tcpinfo processing speed in staging is quite slow, because of data volume.  This speeds it up 5x.
Also adds some missing metrics, and improves metric labels.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/707)
<!-- Reviewable:end -->
