### PR TITLE
fix ndt5 dependency

### DIFF
--- a/schema/ndt_legacy.go
+++ b/schema/ndt_legacy.go
@@ -6,9 +6,9 @@ import (
 	"cloud.google.com/go/bigquery"
 	"github.com/m-lab/go/bqx"
 
-	"github.com/m-lab/ndt-server/legacy/c2s"
-	"github.com/m-lab/ndt-server/legacy/ndt"
-	"github.com/m-lab/ndt-server/legacy/s2c"
+	"github.com/m-lab/ndt-server/ndt5/c2s"
+	"github.com/m-lab/ndt-server/ndt5/ndt"
+	"github.com/m-lab/ndt-server/ndt5/s2c"
 )
 
 // TODO: Remove this in favor of using the ndt-server legacy.NDTResult directly


### PR DESCRIPTION
change from legacy to ndt5 broke etl.
This fixes etl, so that it can build at head.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/711)
<!-- Reviewable:end -->
