### PR TITLE
Update ETL parser to read ndt5 Result

### DIFF
--- a/cmd/update-schema/update.go
+++ b/cmd/update-schema/update.go
@@ -43,6 +43,13 @@ func CreateOrUpdatePT(project string, dataset string, table string) error {
 	return CreateOrUpdate(schema, project, dataset, table)
 }
 
+func CreateOrUpdateNDTResult(project string, dataset string, table string) error {
+	row := schema.NDTResult{}
+	schema, err := row.Schema()
+	rtx.Must(err, "NDTResult.Schema")
+	return CreateOrUpdate(schema, project, dataset, table)
+}
+
 // CreateOrUpdate will update or create a table from the given schema.
 func CreateOrUpdate(schema bigquery.Schema, project string, dataset string, table string) error {
 	name := project + "." + dataset + "." + table
@@ -112,6 +119,12 @@ func main() {
 		if err := CreateOrUpdatePT(project, "batch", "traceroute"); err != nil {
 			errCount++
 		}
+		if err := CreateOrUpdateNDTResult(project, "base_tables", "result"); err != nil {
+			errCount++
+		}
+		if err := CreateOrUpdateNDTResult(project, "batch", "result"); err != nil {
+			errCount++
+		}
 
 	case "tcpinfo":
 		if err := CreateOrUpdateTCPInfo(project, "base_tables", "tcpinfo"); err != nil {
@@ -120,12 +133,20 @@ func main() {
 		if err := CreateOrUpdateTCPInfo(project, "batch", "tcpinfo"); err != nil {
 			errCount++
 		}
-		
+
 	case "traceroute":
 		if err := CreateOrUpdatePT(project, "base_tables", "traceroute"); err != nil {
 			errCount++
 		}
 		if err := CreateOrUpdatePT(project, "batch", "traceroute"); err != nil {
+			errCount++
+		}
+
+	case "result":
+		if err := CreateOrUpdateNDTResult(project, "base_tables", "result"); err != nil {
+			errCount++
+		}
+		if err := CreateOrUpdateNDTResult(project, "batch", "result"); err != nil {
 			errCount++
 		}
 

--- a/etl/globals.go
+++ b/etl/globals.go
@@ -3,6 +3,7 @@ package etl
 import (
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"log"
 	"net"
 	"os"
@@ -36,13 +37,13 @@ const YYYYMMDD = `\d{4}[01]\d[0123]\d`
 const MlabDomain = `measurement-lab.org`
 
 const bucket = `gs://([^/]*)/`
-const expType = `(?:([a-z-]+)/)?([a-z-]+)/` // experiment OR experiment/type.
+const expType = `(?:([a-z-]+)/)?([a-z0-9-]+)/` // experiment OR experiment/type.
 
 const datePath = `(\d{4}/[01]\d/[0123]\d)/`
 
 const dateTime = `(\d{4}[01]\d[0123]\d)T(\d{6})(\.\d{0,6})?Z`
 
-const type2 = `(?:-([a-z-]+))?` // optional datatype string
+const type2 = `(?:-([a-z0-9-]+))?` // optional datatype string
 const mlabNSiteNN = `-(mlab\d)-([a-z]{3}\d[0-9t])-`
 
 // This parses the experiment name, optional -NNNN sequence number, and optional -e (for old embargoed files)
@@ -116,6 +117,7 @@ func ValidateTestPath(path string) (*DataPath, error) {
 		Embargo:    post[6],
 		Suffix:     post[7],
 	}
+	fmt.Printf("%#v\n", dp)
 	return dp, nil
 }
 
@@ -207,7 +209,7 @@ func (dt DataType) BQBufferSize() int {
 // TODO - use camelcase.
 const (
 	NDT             = DataType("ndt")
-	NDT_LEGACY      = DataType("ndt_legacy")
+	NDT_RESULT      = DataType("ndt_result")
 	NDT_OMIT_DELTAS = DataType("ndt_nodelta") // to support larger buffer size.
 	SS              = DataType("sidestream")
 	PT              = DataType("traceroute")
@@ -221,7 +223,8 @@ var (
 	// TODO - this should be loaded from a config.
 	dirToDataType = map[string]DataType{
 		"ndt":              NDT,
-		"legacy":           NDT_LEGACY,
+		"ndt5":             NDT_RESULT,
+		"ndt7":             NDT_RESULT,
 		"sidestream":       SS,
 		"paris-traceroute": PT,
 		"switch":           SW,
@@ -236,7 +239,7 @@ var (
 		PT:         "traceroute",
 		SW:         "switch",
 		TCPINFO:    "tcpinfo",
-		NDT_LEGACY: "legacy",
+		NDT_RESULT: "result",
 		INVALID:    "invalid",
 	}
 
@@ -249,7 +252,7 @@ var (
 		SS:              500, // Average json size is 2.5K
 		PT:              5,
 		SW:              100,
-		NDT_LEGACY:      50,
+		NDT_RESULT:      50,
 		INVALID:         0,
 	}
 	// There is also a mapping of data types to queue names in

--- a/etl/globals.go
+++ b/etl/globals.go
@@ -3,7 +3,6 @@ package etl
 import (
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"log"
 	"net"
 	"os"
@@ -117,7 +116,6 @@ func ValidateTestPath(path string) (*DataPath, error) {
 		Embargo:    post[6],
 		Suffix:     post[7],
 	}
-	fmt.Printf("%#v\n", dp)
 	return dp, nil
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -43,8 +43,8 @@ func NewParser(dt etl.DataType, ins etl.Inserter) etl.Parser {
 	switch dt {
 	case etl.NDT:
 		return NewNDTParser(ins)
-	case etl.NDT_LEGACY:
-		return NewNDTLegacyParser(ins)
+	case etl.NDT_RESULT:
+		return NewNDTResultParser(ins)
 	case etl.SS:
 		return NewDefaultSSParser(ins) // TODO fix this hack.
 	case etl.PT:

--- a/schema/ndt_legacy.go
+++ b/schema/ndt_legacy.go
@@ -1,48 +1,23 @@
 package schema
 
 import (
-	"time"
-
 	"cloud.google.com/go/bigquery"
 	"github.com/m-lab/go/bqx"
 
-	"github.com/m-lab/ndt-server/ndt5/c2s"
-	"github.com/m-lab/ndt-server/ndt5/ndt"
-	"github.com/m-lab/ndt-server/ndt5/s2c"
+	"github.com/m-lab/ndt-server/data"
 )
 
-// TODO: Remove this in favor of using the ndt-server legacy.NDTResult directly
-// once NDTResult.Meta support bigquery.Saver.
+// NDTResult defines the BQ schema for the NDT Result produced by the
+// ndt-server for the NDT5 and NDT7 clients.
 type NDTResult struct {
-	// GitShortCommit is the Git commit (short form) of the running server code.
-	GitShortCommit string
-
-	// These data members should all be self-describing. In the event of confusion,
-	// rename them to add clarity rather than adding a comment.
-	ControlChannelUUID string
-	Protocol           ndt.ConnectionType
-	MessageProtocol    string
-	ServerIP           string
-	ClientIP           string
-
-	StartTime time.Time
-	EndTime   time.Time
-	C2S       *c2s.ArchivalData `json:",omitempty"`
-	S2C       *s2c.ArchivalData `json:",omitempty"`
-	// NOTE: we omit NDTResult.Meta (map[]) until it supports the bigquery.Saver interface.
-}
-
-// NDTLegacySchema defines the BQ schema for the NDTLegacys produced by the
-// ndt-server for the NDT3 and NDT4 clients.
-type NDTLegacySchema struct {
 	ParseInfo *ParseInfo
-	TestID    string    `json:"test_id,string" bigquery:"test_id"`
-	LogTime   int64     `json:"log_time,int64" bigquery:"log_time"`
-	Result    NDTResult `json:"result" bigquery:"result"`
+	TestID    string         `json:"test_id,string" bigquery:"test_id"`
+	LogTime   int64          `json:"log_time,int64" bigquery:"log_time"`
+	Result    data.NDTResult `json:"result" bigquery:"result"`
 }
 
-// Schema returns the Bigquery schema for NDTLegacySchema
-func (row *NDTLegacySchema) Schema() (bigquery.Schema, error) {
+// Schema returns the BigQuery schema for NDTResult.
+func (row *NDTResult) Schema() (bigquery.Schema, error) {
 	sch, err := bigquery.InferSchema(row)
 	if err != nil {
 		return bigquery.Schema{}, err


### PR DESCRIPTION
This change removes support for the ndt "legacy" format for ndt5 results from the Go ndt-server. Instead, a new unified result schema records both ndt5 and ndt7 results. The current ETL worker will only recognize ndt5 results now due to the different directory hierarchy for ndt7 results. As well, this is the first time we've had two datatypes mapped to the same table, so gardener does not yet support ndt7 either. However, from 2019-07-19 forward, all results should use unified schemas.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/714)
<!-- Reviewable:end -->
