### PR TITLE
fix pt empty hop handling and unit test

### DIFF
--- a/parser/pt.go
+++ b/parser/pt.go
@@ -287,6 +287,11 @@ func (pt *PTParser) ParseAndInsert(meta map[string]bigquery.Value, testName stri
 		return err
 	}
 
+	if len(cachedTest.Hops) == 0 {
+		// Empty test, no further action.
+		return nil
+	}
+
 	// Check all buffered PT tests whether Client_ip in connSpec appear in
 	// the last hop of the buffered test.
 	// If it does appear, then the buffered test was polluted, and it will
@@ -542,8 +547,8 @@ func Parse(meta map[string]bigquery.Value, testName string, testId string, rawCo
 	// reach destIP at the last hop.
 	lastHop := destIP
 	if len(allNodes) == 0 {
-		// Empty test, stop here.
-		return cachedPTData{}, errors.New("Empty Test.")
+		// Empty test, stop here.  Not an error.
+		return cachedPTData{}, nil
 	}
 	if allNodes[len(allNodes)-1].ip != destIP && !strings.Contains(lastValidHopLine, destIP) {
 		// This is the case that we consider the test did not reach destIP at the last hop.

--- a/parser/pt_test.go
+++ b/parser/pt_test.go
@@ -221,7 +221,7 @@ func TestPTEmptyTest(t *testing.T) {
 		return
 	}
 	_, parseErr := parser.Parse(nil, "testdata/20180201T07:57:37Z-125.212.217.215-56622-208.177.76.115-9100.paris", "", rawData, "pt-daily")
-	if parseErr.Error() != "Empty Test." {
-		t.Fatalf("Do not handle empty test correctly.")
+	if parseErr != nil {
+		t.Fatal(parseErr)
 	}
 }


### PR DESCRIPTION
This fixes handling of PT test with no hops.  Previously it was returning an error, but it is not an error to have no hops.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/726)
<!-- Reviewable:end -->
