### PR TITLE
Fix `go vet` field visibility error

### DIFF
--- a/parser/pt.go
+++ b/parser/pt.go
@@ -116,7 +116,7 @@ type TracelbLine struct {
 type CyclestartLine struct {
 	Type       string  `json:"type"`
 	List_name  string  `json:"list_name"`
-	id         float64 `json:"id"`
+	ID         float64 `json:"id"`
 	Hostname   string  `json:"hostname"`
 	Start_time float64 `json:"start_time"`
 }
@@ -124,7 +124,7 @@ type CyclestartLine struct {
 type CyclestopLine struct {
 	Type      string  `json:"type"`
 	List_name string  `json:"list_name"`
-	id        float64 `json:"id"`
+	ID        float64 `json:"id"`
 	Hostname  string  `json:"hostname"`
 	Stop_time float64 `json:"stop_time"`
 }


### PR DESCRIPTION
This will also fix the NDT build

Please submit this immediately if it looks good to you. The ndt-server build is currently broken due to `go vet` complaints.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/735)
<!-- Reviewable:end -->
