### PR TITLE
Add Dockerfile for generate-schema-docs container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /go/src/github.com/m-lab/etl
 RUN go get -v github.com/m-lab/etl/cmd/generate_schema_docs
 
 # Build the image.
-FROM alpine:3.7
+FROM alpine
 COPY --from=build /go/bin/generate_schema_docs /
 WORKDIR /
 ENTRYPOINT ["/generate_schema_docs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Dockerfile to contain the generate_schema_docs CLI.
+
+# Build the command.
+FROM golang:1.12 as build
+ENV CGO_ENABLED 0
+COPY . /go/src/github.com/m-lab/etl
+WORKDIR /go/src/github.com/m-lab/etl
+RUN go get -v github.com/m-lab/etl/cmd/generate_schema_docs
+
+# Build the image.
+FROM alpine:3.7
+COPY --from=build /go/bin/generate_schema_docs /
+WORKDIR /
+ENTRYPOINT ["/generate_schema_docs"]
+

--- a/README.md
+++ b/README.md
@@ -13,3 +13,16 @@ bq mk --time_partitioning_type=DAY --schema=schema/repeated.json mlab-sandbox:ml
 
 Also see schema/README.md.
 
+## Generating Schema Docs
+
+To build a new docker image with the `generate_schema_docs` command, run:
+
+```sh
+$ docker build -t measurementlab/generate-schema-docs .
+$ docker run -v $PWD:/workspace -w /workspace \
+  -it measurementlab/generate-schema-docs
+
+Writing schema_ndtresultrow.md
+...
+
+```


### PR DESCRIPTION
This change will adds a new Dockerfile to the m-lab/etl repo. This Dockerfile builds the `generate_schema_docs` container.

Build rules in dockerhub will produce a new version on every `/v.*/` tag of the ETL repo.

Part of https://github.com/m-lab/dev-tracker/issues/472

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/761)
<!-- Reviewable:end -->
