### PR TITLE
Code to poll gardener for work to do.

### DIFF
--- a/active/active_test.go
+++ b/active/active_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/m-lab/go/logx"
+	"google.golang.org/api/iterator"
 
 	"cloud.google.com/go/storage"
 	"github.com/m-lab/etl/active"
@@ -97,7 +98,14 @@ func TestGCSSourceBasic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	active.RunAll(ctx, fs)
+	eg, err := active.RunAll(ctx, fs)
+	if err != iterator.Done {
+		t.Fatal(err)
+	}
+	err = eg.Wait()
+	if err != nil {
+		t.Error(err)
+	}
 
 	if p.success != 3 {
 		t.Error("All 3 tests should have succeeded.", p)
@@ -116,7 +124,14 @@ func TestWithRunFailures(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	active.RunAll(ctx, fs)
+	eg, err := active.RunAll(ctx, fs)
+	if err != iterator.Done {
+		t.Fatal(err)
+	}
+	err = eg.Wait()
+	if err != os.ErrInvalid {
+		t.Error(err, "should be invalid argument")
+	}
 
 	if p.success != 1 {
 		t.Error("1 test should have succeeded.", p.success)

--- a/active/poller.go
+++ b/active/poller.go
@@ -1,0 +1,86 @@
+package active
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
+	"google.golang.org/api/option"
+
+	"github.com/m-lab/etl-gardener/tracker"
+	"github.com/m-lab/etl/metrics"
+)
+
+func jobFileSource(ctx context.Context, job tracker.Job,
+	toRunnable func(*storage.ObjectAttrs) Runnable) (*GCSSource, error) {
+
+	client, err := storage.NewClient(ctx, option.WithScopes(storage.ScopeReadOnly))
+	if err != nil {
+		metrics.ErrorCount.WithLabelValues(
+			job.Experiment+"/"+job.Datatype, "active", "nil storage client").Inc()
+		return nil, err
+	}
+
+	lister := FileListerFunc(stiface.AdaptClient(client), job.Path())
+	gcsSource, err := NewGCSSource(ctx, job.Path(), lister, toRunnable)
+	if err != nil {
+		metrics.ErrorCount.WithLabelValues(
+			job.Experiment+"/"+job.Datatype, "active", "filesource error").Inc()
+		return nil, err
+	}
+	return gcsSource, nil
+}
+
+func pollAndRun(ctx context.Context, url string,
+	toRunnable func(o *storage.ObjectAttrs) Runnable, tokens TokenSource) error {
+	resp, err := http.Post(url, "application/x-www-form-urlencoded", nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	var job tracker.Job
+	err = json.Unmarshal(b, &job)
+	if err != nil {
+		return err
+	}
+
+	gcsSource, err := jobFileSource(ctx, job, toRunnable)
+	if err != nil {
+		return err
+	}
+	src := Throttle(gcsSource, tokens)
+
+	log.Println("Running", job.Path())
+
+	// We wait until the source is drained, but we ignore the errgroup.Group.
+	_, err = RunAll(ctx, src)
+	return err
+}
+
+// PollGardener requests work items from gardener, and processes them.
+func PollGardener(ctx context.Context, url string,
+	toRunnable func(o *storage.ObjectAttrs) Runnable, maxWorkers int) {
+	// Poll at most once every 10 seconds.
+	ticker := time.NewTicker(10 * time.Second)
+	throttle := NewWSTokenSource(maxWorkers)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			pollAndRun(ctx, url, toRunnable, throttle)
+		}
+
+		<-ticker.C // Wait for next tick, to avoid fast spinning on errors.
+	}
+}

--- a/active/poller.go
+++ b/active/poller.go
@@ -3,18 +3,66 @@ package active
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"log"
 	"net/http"
+	"net/url"
 	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/option"
 
 	"github.com/m-lab/etl-gardener/tracker"
 	"github.com/m-lab/etl/metrics"
 )
+
+func postNoResponse(url *url.URL) error {
+	resp, postErr := http.Post(url.String(), "", nil)
+	if postErr == nil {
+		resp.Body.Close()
+	}
+	return postErr
+}
+
+// RunAll will execute functions provided by Next() until there are no more,
+// or the context is canceled.
+// The tk URL is used for reporting status back to the tracker.
+func RunAll(ctx context.Context, rSrc RunnableSource, job tracker.Job, tk url.URL) (*errgroup.Group, error) {
+	eg := &errgroup.Group{}
+	for {
+		run, err := rSrc.Next(ctx)
+		if err != nil {
+			debug.Println(err)
+			return eg, err
+		}
+
+		heartbeat := tracker.HeartbeatURL(tk, job)
+		if postErr := postNoResponse(heartbeat); postErr != nil {
+			log.Println(postErr, "on heartbeat for", job.Path())
+		}
+
+		debug.Println("Starting func")
+
+		f := func() error {
+			metrics.ActiveTasks.WithLabelValues(rSrc.Label()).Inc()
+			defer metrics.ActiveTasks.WithLabelValues(rSrc.Label()).Dec()
+
+			err := run.Run()
+			if err == nil {
+				update := tracker.UpdateURL(tk, job, tracker.Parsing, run.Info())
+				if postErr := postNoResponse(update); postErr != nil {
+					log.Println(postErr, "on update for", job.Path())
+				}
+			}
+			return err
+		}
+
+		eg.Go(f)
+	}
+}
 
 func jobFileSource(ctx context.Context, job tracker.Job,
 	toRunnable func(*storage.ObjectAttrs) Runnable) (*GCSSource, error) {
@@ -36,13 +84,28 @@ func jobFileSource(ctx context.Context, job tracker.Job,
 	return gcsSource, nil
 }
 
-func pollAndRun(ctx context.Context, url string,
+func pollAndRun(ctx context.Context, base url.URL,
 	toRunnable func(o *storage.ObjectAttrs) Runnable, tokens TokenSource) error {
-	resp, err := http.Post(url, "application/x-www-form-urlencoded", nil)
+
+	jobURL := base
+	jobURL.Path = "job"
+
+	resp, err := http.Post(jobURL.String(), "application/x-www-form-urlencoded", nil)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		if len(b) > 0 {
+			return errors.New(string(b))
+		}
+
+		return errors.New(resp.Status)
+	}
 	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return err
@@ -62,13 +125,31 @@ func pollAndRun(ctx context.Context, url string,
 
 	log.Println("Running", job.Path())
 
-	// We wait until the source is drained, but we ignore the errgroup.Group.
-	_, err = RunAll(ctx, src)
+	update := tracker.UpdateURL(base, job, tracker.Parsing, "starting tasks")
+	if postErr := postNoResponse(update); postErr != nil {
+		log.Println(postErr)
+	}
+
+	eg, err := RunAll(ctx, src, job, base)
+
+	// Once all are dispatched, we want to wait until all have completed
+	// before posting the state change.
+	go func() {
+		log.Println("all tasks dispatched for", job.Path())
+		eg.Wait()
+		log.Println("finished", job.Path())
+		update := tracker.UpdateURL(base, job, tracker.ParseComplete, "")
+		// TODO - should this have a retry?
+		if postErr := postNoResponse(update); postErr != nil {
+			log.Println(postErr)
+		}
+	}()
+
 	return err
 }
 
 // PollGardener requests work items from gardener, and processes them.
-func PollGardener(ctx context.Context, url string,
+func PollGardener(ctx context.Context, base url.URL,
 	toRunnable func(o *storage.ObjectAttrs) Runnable, maxWorkers int) {
 	// Poll at most once every 10 seconds.
 	ticker := time.NewTicker(10 * time.Second)
@@ -78,7 +159,10 @@ func PollGardener(ctx context.Context, url string,
 		case <-ctx.Done():
 			return
 		default:
-			pollAndRun(ctx, url, toRunnable, throttle)
+			err := pollAndRun(ctx, base, toRunnable, throttle)
+			if err != nil {
+				log.Println(err)
+			}
 		}
 
 		<-ticker.C // Wait for next tick, to avoid fast spinning on errors.

--- a/active/runnable.go
+++ b/active/runnable.go
@@ -30,15 +30,16 @@ type RunnableSource interface {
 
 // RunAll will execute functions provided by Next() until there are no more,
 // or the context is canceled.
-func RunAll(ctx context.Context, rSrc RunnableSource) error {
-	eg := errgroup.Group{}
+func RunAll(ctx context.Context, rSrc RunnableSource) (*errgroup.Group, error) {
+	eg := &errgroup.Group{}
 	for {
 		run, err := rSrc.Next(ctx)
 		if err != nil {
 			debug.Println(err)
-			break
+			return eg, err
 		}
 		debug.Println("Starting func")
+
 		f := func() error {
 			metrics.ActiveTasks.WithLabelValues(rSrc.Label()).Inc()
 			// TestCount and other metrics should be handled within Run().
@@ -46,7 +47,7 @@ func RunAll(ctx context.Context, rSrc RunnableSource) error {
 			metrics.ActiveTasks.WithLabelValues(rSrc.Label()).Dec()
 			return err
 		}
+
 		eg.Go(f)
 	}
-	return eg.Wait()
 }

--- a/active/throttle.go
+++ b/active/throttle.go
@@ -28,8 +28,8 @@ func (ts *wsTokenSource) Release() {
 }
 
 // NewWSTokenSource returns a TokenSource based on semaphore.Weighted.
-func NewWSTokenSource(n int64) TokenSource {
-	return &wsTokenSource{semaphore.NewWeighted(n)}
+func NewWSTokenSource(n int) TokenSource {
+	return &wsTokenSource{semaphore.NewWeighted(int64(n))}
 }
 
 // throttedSource encapsulates a Source and a throttling mechanism.

--- a/active/throttle_test.go
+++ b/active/throttle_test.go
@@ -94,7 +94,7 @@ func TestThrottledSource(t *testing.T) {
 	// throttle to handle two at a time.
 	ts := active.Throttle(&src, active.NewWSTokenSource(2))
 
-	eg, err := active.RunAll(context.Background(), ts)
+	eg, err := runAll(context.Background(), ts)
 	if err != iterator.Done {
 		t.Fatal("Expected iterator.Done", err)
 	}

--- a/active/throttle_test.go
+++ b/active/throttle_test.go
@@ -94,7 +94,15 @@ func TestThrottledSource(t *testing.T) {
 	// throttle to handle two at a time.
 	ts := active.Throttle(&src, active.NewWSTokenSource(2))
 
-	active.RunAll(context.Background(), ts)
+	eg, err := active.RunAll(context.Background(), ts)
+	if err != iterator.Done {
+		t.Fatal("Expected iterator.Done", err)
+	}
+
+	err = eg.Wait()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if src.tracker.done() != 5 {
 		t.Error("Should have been 5 runnables", src.tracker.done())

--- a/cmd/etl_worker/Dockerfile.k8s
+++ b/cmd/etl_worker/Dockerfile.k8s
@@ -13,6 +13,7 @@ RUN go install \
 
 # Even with static linking, for some reason this doesn't work with just alpine.
 FROM ubuntu
+RUN apk add --no-cache ca-certificates
 
 COPY --from=builder /go/bin/etl_worker /bin/etl_worker
 

--- a/cmd/etl_worker/Dockerfile.k8s
+++ b/cmd/etl_worker/Dockerfile.k8s
@@ -3,16 +3,17 @@ FROM golang:1.13 as builder
 WORKDIR /go/src/github.com/m-lab/etl
 COPY . .
 
-# Get the requirements and put the produced binaries in /go/bin
 RUN go get -v ./...
 
+# This leave some dynamically linked lookups, but seems to work anyway.  But
+# it is unclear whether we might see random segfaults.
 RUN go install \
-      -v \
-      -ldflags "-linkmode external -extldflags -static -X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h)" \
-      ./...
+    -tags netgo -a \
+    -v \
+    -ldflags "-linkmode external -extldflags -static -X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h)" \
+    ./cmd/etl_worker/...
 
-# Even with static linking, for some reason this doesn't work with just alpine.
-FROM ubuntu
+FROM alpine
 RUN apk add --no-cache ca-certificates
 
 COPY --from=builder /go/bin/etl_worker /bin/etl_worker

--- a/etl/globals.go
+++ b/etl/globals.go
@@ -254,12 +254,12 @@ var (
 	dataTypeToBQBufferSize = map[DataType]int{
 		NDT:             10,
 		NDT_OMIT_DELTAS: 50,
-		TCPINFO:         10,
+		TCPINFO:         5,
 		SS:              500, // Average json size is 2.5K
 		PT:              20,
 		SW:              100,
-		NDT5:            50,
-		NDT7:            50,
+		NDT5:            200,
+		NDT7:            200,
 		INVALID:         0,
 	}
 	// There is also a mapping of data types to queue names in
@@ -271,7 +271,8 @@ var (
 *  In not to distant future we need a better solution.
 *  See https://github.com/m-lab/etl/issues/519
 ********************************************************************************/
-// Translate gs dir to BQ tablename.
+
+// DirToTablename translates gs dir to BQ tablename.
 func DirToTablename(dir string) string {
 	return dataTypeToTable[dirToDataType[dir]]
 }

--- a/k8s/data-processing/deployments/parser.yml
+++ b/k8s/data-processing/deployments/parser.yml
@@ -42,7 +42,7 @@ spec:
           value: {{RELEASE_TAG}}
         - name: GIT_COMMIT
           value: "{{GIT_COMMIT}}"
-        - name: PROJECT
+        - name: GCLOUD_PROJECT
           value: "{{GCLOUD_PROJECT}}"
 
         - name: GARDENER_HOST

--- a/k8s/data-processing/deployments/parser.yml
+++ b/k8s/data-processing/deployments/parser.yml
@@ -77,11 +77,11 @@ spec:
 
         resources:
           requests:
-            memory: "24Gi"
+            memory: "40Gi"
             cpu: "14"
           limits:
-            memory: "24Gi"
-            cpu: "14"
+            memory: "55Gi"
+            cpu: "15"
 
       nodeSelector:
         parser-node: "true"


### PR DESCRIPTION
This adds a polling loop that gets jobs from gardener, and processes all the corresponding files.  It is basically working in sandbox, but may need a little more refinement.

Won't currently work in staging (and isn't deployed to prod), for two reasons:
  1. archive-mlab-sandbox is hardcoded (because archive-measurement-lab is apparently not accessible from sandbox instances)
  2. gardener is currently in the wrong region, so private network is failing.

These will be fixed in upcoming PRs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/780)
<!-- Reviewable:end -->
