### PR TITLE
Plumb destination table to ProcessSource

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_install:
 
 # Install gcloud, for integration tests.
 # TODO: maybe just use travis apt: packages: ?
-- $TRAVIS_BUILD_DIR/travis/install_gcloud.sh
+- $TRAVIS_BUILD_DIR/travis/install_gcloud.sh app-engine-python app-engine-go cloud-datastore-emulator
 - source "${HOME}/google-cloud-sdk/path.bash.inc"
 
 # Install test credentials.

--- a/.travis.yml
+++ b/.travis.yml
@@ -323,7 +323,7 @@ deploy:
   on:
     repo: m-lab/etl
     all_branches: true
-    condition: $TRAVIS_BRANCH == u-sanddbox-* || universal-sandbox-* || $TRAVIS_BRANCH == sandbox-*
+    condition: $TRAVIS_BRANCH == u-sandbox-* || universal-sandbox-* || $TRAVIS_BRANCH == sandbox-*
 
 ######################################################################
 #  Staging deployments

--- a/active/active_test.go
+++ b/active/active_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
+	"github.com/m-lab/go/bqx"
 	"github.com/m-lab/go/logx"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/iterator"
@@ -63,7 +64,7 @@ func (r *runnable) Info() string {
 	return "test"
 }
 
-func (c *counter) toRunnable(obj *storage.ObjectAttrs) active.Runnable {
+func (c *counter) toRunnable(obj *storage.ObjectAttrs, pdt bqx.PDT) active.Runnable {
 	log.Println("Creating runnable for", obj.Name)
 	return &runnable{c, obj}
 }
@@ -118,7 +119,7 @@ func runAll(ctx context.Context, rSrc active.RunnableSource) (*errgroup.Group, e
 func TestGCSSourceBasic(t *testing.T) {
 	p := newCounter(t)
 	ctx := context.Background()
-	fs, err := active.NewGCSSource(ctx, "test", standardLister(), p.toRunnable)
+	fs, err := active.NewGCSSource(ctx, "test", bqx.PDT{}, standardLister(), p.toRunnable)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,7 +145,7 @@ func TestWithRunFailures(t *testing.T) {
 	p.addOutcome(os.ErrInvalid)
 
 	ctx := context.Background()
-	fs, err := active.NewGCSSource(ctx, "test", standardLister(), p.toRunnable)
+	fs, err := active.NewGCSSource(ctx, "test", bqx.PDT{}, standardLister(), p.toRunnable)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +170,7 @@ func TestWithRunFailures(t *testing.T) {
 func TestExpiredContext(t *testing.T) {
 	p := newCounter(t)
 	ctx := context.Background()
-	fs, err := active.NewGCSSource(ctx, "test", standardLister(), p.toRunnable)
+	fs, err := active.NewGCSSource(ctx, "test", bqx.PDT{}, standardLister(), p.toRunnable)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -194,7 +195,7 @@ func TestWithStorageError(t *testing.T) {
 	p := newCounter(t)
 
 	ctx := context.Background()
-	fs, err := active.NewGCSSource(ctx, "test", ErroringLister, p.toRunnable)
+	fs, err := active.NewGCSSource(ctx, "test", bqx.PDT{}, ErroringLister, p.toRunnable)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -209,7 +210,7 @@ func TestExpiredFileListerContext(t *testing.T) {
 	p := newCounter(t)
 
 	ctx := context.Background()
-	fs, err := active.NewGCSSource(ctx, "test", standardLister(), p.toRunnable)
+	fs, err := active.NewGCSSource(ctx, "test", bqx.PDT{}, standardLister(), p.toRunnable)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/active/runnable.go
+++ b/active/runnable.go
@@ -8,7 +8,7 @@ import (
 
 // Runnable is just a function that does something and returns an error.
 // A Runnable may return ErrShouldRetry if there was a non-persistent error.
-// TODO - should this instead be and interface, with Run() and ShouldRetry()?
+// TODO - should this provide ShouldRetry()?
 type Runnable interface {
 	Run() error
 	Info() string

--- a/bq/insert.go
+++ b/bq/insert.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/metrics"
+	"github.com/m-lab/go/bqx"
 )
 
 // insertsBeforeRowJSONCount controls how often we perform a wasted JSON marshal
@@ -53,6 +54,15 @@ const (
 	// typically complete in one or two seconds.
 	putContextTimeout = 60 * time.Second
 )
+
+// NewPDTInserter creates a new BQInserter to a specific column partitioned table.
+func NewPDTInserter(destTable bqx.PDT) (etl.Inserter, error) {
+	return NewBQInserter(
+		etl.InserterParams{Project: bqProject, Dataset: dataset, Table: table, Suffix: suffix,
+			PutTimeout: putContextTimeout, MaxRetryDelay: maxPutRetryDelay,
+			BufferSize: dt.BQBufferSize()},
+		nil)
+}
 
 // NewInserter creates a new BQInserter with appropriate characteristics.
 func NewInserter(dt etl.DataType, partition time.Time) (etl.Inserter, error) {

--- a/bq/insert.go
+++ b/bq/insert.go
@@ -229,7 +229,7 @@ func (in *BQInserter) updateMetrics(err error) error {
 			log.Println("Inconsistent state error!!")
 		}
 		if len(typedErr) == in.pending {
-			log.Printf("%v\n", err)
+			log.Printf("%v %v\n", err, typedErr[0]) // Log the first RowInsertionError detail
 			metrics.BackendFailureCount.WithLabelValues(
 				in.TableBase(), "failed insert").Inc()
 			in.failures++

--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -20,6 +20,7 @@ import (
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/metrics"
 	"github.com/m-lab/etl/worker"
+	"github.com/m-lab/go/bqx"
 	"github.com/m-lab/go/prometheusx"
 	"github.com/m-lab/go/rtx"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -239,7 +240,7 @@ func (r *runnable) Info() string {
 	return r.Name
 }
 
-func toRunnable(obj *storage.ObjectAttrs) active.Runnable {
+func toRunnable(obj *storage.ObjectAttrs, pdt bqx.PDT) active.Runnable {
 	return &runnable{*obj}
 }
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -26,31 +26,51 @@ var (
 // TODO - add comprehensive unit test??
 // TODO - refactor into a Worker struct containing a StorageClient and other similar things, to allow use of fake implementations for testing.
 func ProcessTask(fn string) (int, error) {
-	data, err := etl.ValidateTestPath(fn)
+	path, err := etl.ValidateTestPath(fn)
 	if err != nil {
 		log.Printf("Invalid filename: %v\n", err)
 		return http.StatusBadRequest, err
 	}
+	tableBase := path.TableBase()
 
 	// Count number of workers operating on each table.
-	metrics.WorkerCount.WithLabelValues(data.TableBase()).Inc()
-	defer metrics.WorkerCount.WithLabelValues(data.TableBase()).Dec()
+	metrics.WorkerCount.WithLabelValues(tableBase).Inc()
+	defer metrics.WorkerCount.WithLabelValues(tableBase).Dec()
 
 	// These keep track of the (nested) state of the worker.
-	metrics.WorkerState.WithLabelValues(data.TableBase(), "worker").Inc()
-	defer metrics.WorkerState.WithLabelValues(data.TableBase(), "worker").Dec()
+	metrics.WorkerState.WithLabelValues(tableBase, "worker").Inc()
+	defer metrics.WorkerState.WithLabelValues(tableBase, "worker").Dec()
 
 	// Move this into Validate function
-	dataType := data.GetDataType()
+	dataType := path.GetDataType()
 	if dataType == etl.INVALID {
-		metrics.TaskCount.WithLabelValues(data.TableBase(), "worker", "BadRequest").Inc()
+		metrics.TaskCount.WithLabelValues(tableBase, "worker", "BadRequest").Inc()
 		log.Printf("Invalid filename: %s\n", fn)
 		return http.StatusBadRequest, ErrBadDataType
 	}
 
+	dateFormat := "20060102"
+	date, _ := time.Parse(dateFormat, path.PackedDate)
+	ins, err := bq.NewInserter(dataType, date)
+	if err != nil {
+		metrics.TaskCount.WithLabelValues(tableBase, string(dataType), "NewInserterError").Inc()
+		log.Printf("Error creating BQ Inserter:  %v", err)
+		return http.StatusInternalServerError, err
+		// TODO - anything better we could do here?
+	}
+
+	return process(*path, dataType, ins, fn)
+}
+
+// process allows injection of arbitrary inserter.
+func process(path etl.DataPath, dt etl.DataType, ins etl.Inserter, fn string) (int, error) {
+	tableBase := path.TableBase()
+	dateFormat := "20060102"
+	date, _ := time.Parse(dateFormat, path.PackedDate)
+
 	client, err := storage.GetStorageClient(false)
 	if err != nil {
-		metrics.TaskCount.WithLabelValues(data.TableBase(), "worker", "ServiceUnavailable").Inc()
+		metrics.TaskCount.WithLabelValues(tableBase, "worker", "ServiceUnavailable").Inc()
 		log.Printf("Error getting storage client: %v\n", err)
 		return http.StatusServiceUnavailable, err
 	}
@@ -58,32 +78,21 @@ func ProcessTask(fn string) (int, error) {
 	// TODO - add a timer for reading the file.
 	tr, err := storage.NewETLSource(client, fn)
 	if err != nil {
-		metrics.TaskCount.WithLabelValues(data.TableBase(), string(dataType), "ETLSourceError").Inc()
+		metrics.TaskCount.WithLabelValues(tableBase, string(dt), "ETLSourceError").Inc()
 		log.Printf("Error opening gcs file: %v", err)
 		return http.StatusInternalServerError, err
 		// TODO - anything better we could do here?
 	}
 	defer tr.Close()
 	// Label storage metrics with the expected table name.
-	tr.TableBase = data.TableBase()
-
-	dateFormat := "20060102"
-	date, err := time.Parse(dateFormat, data.PackedDate)
-
-	ins, err := bq.NewInserter(dataType, date)
-	if err != nil {
-		metrics.TaskCount.WithLabelValues(data.TableBase(), string(dataType), "NewInserterError").Inc()
-		log.Printf("Error creating BQ Inserter:  %v", err)
-		return http.StatusInternalServerError, err
-		// TODO - anything better we could do here?
-	}
+	tr.TableBase = tableBase
 
 	// Create parser, injecting Inserter
-	p := parser.NewParser(dataType, ins)
+	p := parser.NewParser(dt, ins)
 	if p == nil {
-		metrics.TaskCount.WithLabelValues(data.TableBase(), string(dataType), "NewInserterError").Inc()
-		log.Printf("Error creating parser for %s", dataType)
-		return http.StatusInternalServerError, fmt.Errorf("problem creating parser for %s", dataType)
+		metrics.TaskCount.WithLabelValues(tableBase, string(dt), "NewInserterError").Inc()
+		log.Printf("Error creating parser for %s", dt)
+		return http.StatusInternalServerError, fmt.Errorf("problem creating parser for %s", dt)
 	}
 	tsk := task.NewTask(fn, tr, p)
 
@@ -92,13 +101,13 @@ func ProcessTask(fn string) (int, error) {
 	// Count the files processed per-host-module per-weekday.
 	// TODO(soltesz): evaluate separating hosts and pods as separate metrics.
 	metrics.FileCount.WithLabelValues(
-		data.Host+"-"+data.Site+"-"+data.Experiment,
+		path.Host+"-"+path.Site+"-"+path.Experiment,
 		date.Weekday().String()).Add(float64(files))
 
-	metrics.WorkerState.WithLabelValues(data.TableBase(), "finish").Inc()
-	defer metrics.WorkerState.WithLabelValues(data.TableBase(), "finish").Dec()
+	metrics.WorkerState.WithLabelValues(path.TableBase(), "finish").Inc()
+	defer metrics.WorkerState.WithLabelValues(path.TableBase(), "finish").Dec()
 	if err != nil {
-		metrics.TaskCount.WithLabelValues(data.TableBase(), string(dataType), "TaskError").Inc()
+		metrics.TaskCount.WithLabelValues(path.TableBase(), string(dt), "TaskError").Inc()
 		log.Printf("Error Processing Tests:  %v", err)
 		// NOTE: This may cause indefinite retries, and stalled task queue.  Task will eventually
 		// expire, but it might be better to have a different mechanism for retries, particularly
@@ -107,6 +116,6 @@ func ProcessTask(fn string) (int, error) {
 		// TODO - anything better we could do here?
 	}
 
-	metrics.TaskCount.WithLabelValues(data.TableBase(), string(dataType), "OK").Inc()
+	metrics.TaskCount.WithLabelValues(tableBase, string(dt), "OK").Inc()
 	return http.StatusOK, nil
 }

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -1,11 +1,19 @@
 package worker_test
 
 import (
+	"archive/tar"
 	"log"
 	"math"
 	"net/http"
 	"testing"
+	"time"
 
+	"github.com/m-lab/etl/storage"
+	"github.com/m-lab/go/rtx"
+
+	"github.com/m-lab/etl/bq"
+	"github.com/m-lab/etl/etl"
+	"github.com/m-lab/etl/fake"
 	"github.com/m-lab/etl/metrics"
 	"github.com/m-lab/etl/worker"
 	"github.com/prometheus/client_golang/prometheus"
@@ -24,6 +32,13 @@ func counterValue(m prometheus.Metric) float64 {
 	return *ctr.Value
 }
 
+func counterVecValue(m *prometheus.CounterVec) float64 {
+	c := make(chan prometheus.Metric, 1) // buffer to allow Collect to complete before reading.
+	// This may block if the metric hasn't been measured yet?
+	m.Collect(c)
+	return counterValue(<-c)
+}
+
 func checkCounter(t *testing.T, c chan prometheus.Metric, expected float64) {
 	m := <-c
 	v := counterValue(m)
@@ -36,6 +51,15 @@ func TestProcessTask(t *testing.T) {
 	if testing.Short() {
 		t.Log("Skipping integration test")
 	}
+	/*
+		files := counterVecValue(metrics.FileCount)
+		tasks := counterVecValue(metrics.TaskCount)
+		tests := counterVecValue(metrics.TestCount)
+	*/
+	metrics.FileCount.Reset()
+	metrics.TaskCount.Reset()
+	metrics.TestCount.Reset()
+
 	filename := "gs://archive-mlab-testing/ndt/2018/05/09/20180509T101913Z-mlab1-mad03-ndt-0000.tgz"
 	status, err := worker.ProcessTask(filename)
 	if err != nil {
@@ -46,6 +70,7 @@ func TestProcessTask(t *testing.T) {
 	}
 
 	// This section checks that prom metrics are updated appropriately.
+	// Unfortunately, these are cumulative over all tests!!
 	c := make(chan prometheus.Metric, 10)
 
 	metrics.FileCount.Collect(c)
@@ -56,4 +81,87 @@ func TestProcessTask(t *testing.T) {
 
 	metrics.TestCount.Collect(c)
 	checkCounter(t, c, 1)
+}
+
+// Item represents a row item.
+type Item struct {
+	Name   string
+	Count  int
+	Foobar int `json:"foobar"`
+}
+
+func standardInsertParams(bufferSize int) etl.InserterParams {
+	return etl.InserterParams{
+		Project: "mlab-testing", Dataset: "dataset", Table: "table",
+		Suffix:        "",
+		BufferSize:    bufferSize,
+		PutTimeout:    10 * time.Second,
+		MaxRetryDelay: 1 * time.Second,
+	}
+}
+
+func fakeETLSource(rdr *tar.Reader) (*storage.ETLSource, error) {
+
+	baseTimeout := 16 * time.Millisecond
+	return &storage.ETLSource{rdr, nil, baseTimeout, "invalid"}, nil
+}
+
+func TestProcessSource(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping tests that access GCS")
+	}
+	metrics.FileCount.Reset()
+	metrics.TaskCount.Reset()
+	metrics.TestCount.Reset()
+
+	fn := "gs://archive-mlab-testing/ndt/2018/05/01/20180501T142423Z-mlab1-iad05-ndt-0000.tgz"
+	path, err := etl.ValidateTestPath(fn)
+	rtx.Must(err, "path")
+
+	// Move this into Validate function
+	dt := path.GetDataType()
+	if dt == etl.INVALID {
+		t.Fatal("Invalid datatype")
+	}
+
+	client, err := storage.GetStorageClient(false)
+	rtx.Must(err, "client")
+
+	src, err := storage.NewETLSource(client, fn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer src.Close()
+
+	// Set up an Inserter with a fake Uploader backend for testing.
+	// Buffer 3 rows, so that we can test the buffering.
+	uploader := fake.NewFakeUploader()
+	ins, err := bq.NewBQInserter(standardInsertParams(3), uploader)
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
+
+	got, err := worker.ProcessSource(fn, *path, dt, src, ins)
+	if err != nil {
+		t.Fatalf("process() error = %v", err)
+	}
+	if got != http.StatusOK {
+		t.Error(http.StatusText(got))
+	}
+
+	// This section checks that prom metrics are updated appropriately.
+	c := make(chan prometheus.Metric, 10)
+
+	metrics.FileCount.Collect(c)
+	checkCounter(t, c, 4)
+
+	metrics.TaskCount.Collect(c)
+	checkCounter(t, c, 1)
+
+	metrics.TestCount.Collect(c)
+	checkCounter(t, c, 1)
+
+	if len(uploader.Rows) != 1 {
+		t.Error(len(uploader.Rows))
+	}
 }

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -103,7 +103,7 @@ func standardInsertParams(bufferSize int) etl.InserterParams {
 func fakeETLSource(rdr *tar.Reader) (*storage.ETLSource, error) {
 
 	baseTimeout := 16 * time.Millisecond
-	return &storage.ETLSource{rdr, nil, baseTimeout, "invalid"}, nil
+	return &storage.ETLSource{TarReader: rdr, Closer: nil, RetryBaseTime: baseTimeout, TableBase: "invalid"}, nil
 }
 
 func TestProcessSource(t *testing.T) {


### PR DESCRIPTION
This plumbs the pdt from Job through to where it is needed, but does not yet change behavior.

Still need to use it to create the inserter, in the next PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/823)
<!-- Reviewable:end -->
