### PR TITLE
Revert "Update unit tests to use changed Geo field names"

### DIFF
--- a/annotation/geo_test.go
+++ b/annotation/geo_test.go
@@ -57,8 +57,8 @@ func TestAddGeoAnnotations(t *testing.T) {
 		},
 	}
 	responseJSON := `{"AnnotatorDate":"2018-12-05T00:00:00Z",
-	                  "Annotations":{"127.0.0.1":{"Geo":{"PostalCode":"10583"}},
-	                                 "127.0.0.2":{"Geo":{"PostalCode":"10584"}}}}`
+	                  "Annotations":{"127.0.0.1":{"Geo":{"postal_code":"10583"}},
+	                                 "127.0.0.2":{"Geo":{"postal_code":"10584"}}}}`
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, responseJSON)
 	}))
@@ -147,7 +147,7 @@ func TestGetAndInsertGeolocationIPStruct(t *testing.T) {
 		},
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, `{"Geo":{"PostalCode":"10583"},"ASN":{}}`)
+		fmt.Fprint(w, `{"Geo":{"postal_code":"10583"},"ASN":{}}`)
 	}))
 	for _, test := range tests {
 		annotation.BaseURL = ts.URL + test.url

--- a/parser/base_test.go
+++ b/parser/base_test.go
@@ -60,9 +60,9 @@ func TestBase(t *testing.T) {
 
 	// Set up fake annotation service
 	r1 := `{"AnnotatorDate":"2018-12-05T00:00:00Z",
-	                  "Annotations":{"1.2.3.4":{"Geo":{"PostalCode":"10583"}}}}`
+	                  "Annotations":{"1.2.3.4":{"Geo":{"postal_code":"10583"}}}}`
 	r2 := `{"AnnotatorDate":"2018-12-05T00:00:00Z",
-					  "Annotations":{"4.3.2.1":{"Geo":{"PostalCode":"10584"}}}}`
+					  "Annotations":{"4.3.2.1":{"Geo":{"postal_code":"10584"}}}}`
 
 	callCount := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -128,9 +128,9 @@ func TestAsyncPut(t *testing.T) {
 
 	// Set up fake annotation service
 	r1 := `{"AnnotatorDate":"2018-12-05T00:00:00Z",
-	                  "Annotations":{"1.2.3.4":{"Geo":{"PostalCode":"10583"}}}}`
+	                  "Annotations":{"1.2.3.4":{"Geo":{"postal_code":"10583"}}}}`
 	r2 := `{"AnnotatorDate":"2018-12-05T00:00:00Z",
-					  "Annotations":{"4.3.2.1":{"Geo":{"PostalCode":"10584"}}}}`
+					  "Annotations":{"4.3.2.1":{"Geo":{"postal_code":"10584"}}}}`
 
 	callCount := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/parser/ndt_test.go
+++ b/parser/ndt_test.go
@@ -114,8 +114,8 @@ func TestNDTParser(t *testing.T) {
 	// Completely fake annotation data.
 	responseJSON := `{"AnnotatorDate":"2018-12-05T00:00:00Z",
 		"Annotations":{
-				   "45.56.98.222":{"Geo":{"PostalCode":"45569"}, "Network":{"Systems":[{"ASNs":[123]}]}},
-				   "213.208.152.37":{"Geo":{"PostalCode":"21320"}, "Network":{"Systems":[{"ASNs":[456]}]}}
+				   "45.56.98.222":{"Geo":{"postal_code":"45569"}, "Network":{"Systems":[{"ASNs":[123]}]}},
+				   "213.208.152.37":{"Geo":{"postal_code":"21320"}, "Network":{"Systems":[{"ASNs":[456]}]}}
 				   }}`
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, responseJSON)

--- a/parser/ss_test.go
+++ b/parser/ss_test.go
@@ -73,12 +73,12 @@ func TestSSInserter(t *testing.T) {
 	ins := &inMemoryInserter{}
 	// Completely fake annotation data.
 	responseJSON := `{"AnnotatorDate":"2018-12-05T00:00:00Z",
-		"Annotations":{"5.228.253.100":{"Geo":{"PostalCode":"52282"}, "Network":{"Systems":[{"ASNs":[456]}]}},
-				   "178.141.112.12":{"Geo":{"PostalCode":"17814"}, "Network":{"Systems":[{"ASNs":[456]}]}},
-				   "193.169.96.33":{"Geo":{"PostalCode":"19316"}, "Network":{"Systems":[{"ASNs":[456]}]}},
-				   "178.141.112.12":{"Geo":{"PostalCode":"17814"}, "Network":{"Systems":[{"ASNs":[456]}]}},
-				   "45.56.98.222":{"Geo":{"PostalCode":"45569"}, "Network":{"Systems":[{"ASNs":[456]}]}},
-				   "213.248.112.75":{"Geo":{"PostalCode":"213248"}, "Network":{"Systems":[{"ASNs":[456]}]}}
+		"Annotations":{"5.228.253.100":{"Geo":{"postal_code":"52282"}, "Network":{"Systems":[{"ASNs":[456]}]}},
+				   "178.141.112.12":{"Geo":{"postal_code":"17814"}, "Network":{"Systems":[{"ASNs":[456]}]}},
+				   "193.169.96.33":{"Geo":{"postal_code":"19316"}, "Network":{"Systems":[{"ASNs":[456]}]}},
+				   "178.141.112.12":{"Geo":{"postal_code":"17814"}, "Network":{"Systems":[{"ASNs":[456]}]}},
+				   "45.56.98.222":{"Geo":{"postal_code":"45569"}, "Network":{"Systems":[{"ASNs":[456]}]}},
+				   "213.248.112.75":{"Geo":{"postal_code":"213248"}, "Network":{"Systems":[{"ASNs":[456]}]}}
 				   }}`
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, responseJSON)


### PR DESCRIPTION
Reverts m-lab/etl#825

Evidently some individual etl parsers have dependencies on the json representation of the geo data. I will revert these changes to preserve existing functionality and create mirror structs for use by uuid-annotator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/826)
<!-- Reviewable:end -->
