### PR TITLE
Batch sandbox noisy metric

### DIFF
--- a/parser/pt.go
+++ b/parser/pt.go
@@ -548,7 +548,8 @@ func (pt *PTParser) ParseAndInsert(meta map[string]bigquery.Value, testName stri
 	// Process the legacy Paris Traceroute txt output
 	cachedTest, err := Parse(meta, testName, testId, rawContent, pt.TableName())
 	if err != nil {
-		metrics.ErrorCount.WithLabelValues(
+		// These are happening at a high rate, so demote them to warnings until we can fix them.
+		metrics.WarningCount.WithLabelValues(
 			pt.TableName(), "pt", "corrupted content").Inc()
 		metrics.TestCount.WithLabelValues(
 			pt.TableName(), "pt", "corrupted content").Inc()


### PR DESCRIPTION
Improve noisy metrics:
  - break out Quota Exceeded
  - change pt corrupted content to Warning

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/833)
<!-- Reviewable:end -->
