### PR TITLE
Implement tcpinfo parser using row.Base

### DIFF
--- a/bq/insert.go
+++ b/bq/insert.go
@@ -354,7 +354,7 @@ func (in *BQInserter) Flush() error {
 	return in.Put(rows)
 }
 
-// Commit implements row.Commit.
+// Commit implements row.Sink.
 // NOTE: the label is ignored, and the TableBase is used instead.
 func (in *BQInserter) Commit(rows []interface{}, label string) {
 	in.flushSlice(rows)

--- a/bq/insert.go
+++ b/bq/insert.go
@@ -501,3 +501,7 @@ func (in *BQInserter) Failed() int {
 	defer in.release()
 	return in.badRows
 }
+
+func (in *BQInserter) Params() etl.InserterParams {
+	return in.params
+}

--- a/bq/insert.go
+++ b/bq/insert.go
@@ -356,10 +356,10 @@ func (in *BQInserter) Flush() error {
 
 // Commit implements row.Sink.
 // NOTE: the label is ignored, and the TableBase is used instead.
-func (in *BQInserter) Commit(rows []interface{}, label string) {
+func (in *BQInserter) Commit(rows []interface{}, label string) error {
 	in.acquire()
-	in.flushSlice(rows)
-	in.release()
+	defer in.release()
+	return in.flushSlice(rows)
 }
 
 // flushSlice flushes a slice of rows to BigQuery.

--- a/bq/insert.go
+++ b/bq/insert.go
@@ -357,7 +357,9 @@ func (in *BQInserter) Flush() error {
 // Commit implements row.Sink.
 // NOTE: the label is ignored, and the TableBase is used instead.
 func (in *BQInserter) Commit(rows []interface{}, label string) {
+	in.acquire()
 	in.flushSlice(rows)
+	in.release()
 }
 
 // flushSlice flushes a slice of rows to BigQuery.

--- a/bq/insert.go
+++ b/bq/insert.go
@@ -501,7 +501,3 @@ func (in *BQInserter) Failed() int {
 	defer in.release()
 	return in.badRows
 }
-
-func (in *BQInserter) Params() etl.InserterParams {
-	return in.params
-}

--- a/etl/etl.go
+++ b/etl/etl.go
@@ -50,6 +50,8 @@ type Inserter interface {
 	// Deprecated:  Please use external buffer, Put, and PutAsync instead.
 	Flush() error
 
+	// TODO Replace this with Params()
+
 	// Base Table name of the BQ table that the uploader pushes to.
 	TableBase() string
 	// Table name suffix of the BQ table that the uploader pushes to.

--- a/parser/ndt_test.go
+++ b/parser/ndt_test.go
@@ -297,11 +297,23 @@ type inMemoryInserter struct {
 	data      []interface{}
 	committed int
 	failed    int
+	token     chan struct{}
 }
 
 func newInMemoryInserter() *inMemoryInserter {
 	data := make([]interface{}, 0)
-	return &inMemoryInserter{data, 0, 0}
+	token := make(chan struct{}, 1)
+	token <- struct{}{}
+	return &inMemoryInserter{data, 0, 0, token}
+}
+
+// acquire and release handle the single token that protects the FlushSlice and
+// access to the metrics.
+func (in *inMemoryInserter) acquire() {
+	<-in.token
+}
+func (in *inMemoryInserter) release() {
+	in.token <- struct{}{} // return the token.
 }
 
 func (in *inMemoryInserter) Commit(data []interface{}, label string) error {

--- a/parser/ndt_test.go
+++ b/parser/ndt_test.go
@@ -304,6 +304,14 @@ func newInMemoryInserter() *inMemoryInserter {
 	return &inMemoryInserter{data, 0, 0}
 }
 
+func (in *inMemoryInserter) Commit(data []interface{}, label string) error {
+	return in.Put(data)
+}
+
+func (in *inMemoryInserter) Params() etl.InserterParams {
+	return etl.InserterParams{}
+}
+
 func (in *inMemoryInserter) Put(data []interface{}) error {
 	in.data = append(in.data, data...)
 	in.committed = len(in.data)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -3,12 +3,15 @@
 package parser
 
 import (
+	"log"
 	"os"
+	"reflect"
 
 	"cloud.google.com/go/bigquery"
 
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/metrics"
+	"github.com/m-lab/etl/row"
 )
 
 func init() {
@@ -52,7 +55,13 @@ func NewParser(dt etl.DataType, ins etl.Inserter) etl.Parser {
 	case etl.SW:
 		return NewDiscoParser(ins)
 	case etl.TCPINFO:
-		return NewTCPInfoParser(ins)
+		sink, ok := ins.(row.Sink)
+		if !ok {
+			log.Printf("%v is not a Sink\n", ins)
+			log.Println(reflect.TypeOf(ins))
+			return nil
+		}
+		return NewTCPInfoParser2(sink, ins.TableBase(), nil)
 	default:
 		return nil
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -61,7 +61,7 @@ func NewParser(dt etl.DataType, ins etl.Inserter) etl.Parser {
 			log.Println(reflect.TypeOf(ins))
 			return nil
 		}
-		return NewTCPInfoParser2(sink, ins.TableBase(), nil)
+		return NewTCPInfoParser(sink, ins.TableBase(), nil)
 	default:
 		return nil
 	}

--- a/parser/tcpinfo.go
+++ b/parser/tcpinfo.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"io"
 	"log"
-	"reflect"
 	"strings"
 	"time"
 
@@ -207,39 +206,9 @@ func (p *TCPInfoParser) ParseAndInsert(fileMetadata map[string]bigquery.Value, t
 >>>>>>> b6b5fce... Add tcpinfo test stats
 }
 
-// HasParams defines interface with Params()
-type HasParams interface {
-	Params() etl.InserterParams
-}
-
 // NewTCPInfoParser creates a new TCPInfoParser.  Duh.
-// Single annotator may be optionally passed in.
-// TODO change to required parameter.
-func NewTCPInfoParser(ins etl.Inserter, ann ...v2as.Annotator) *TCPInfoParser {
-	bufSize := etl.TCPINFO.BQBufferSize()
-	var annotator v2as.Annotator
-	if len(ann) > 0 && ann[0] != nil {
-		annotator = ann[0]
-	} else {
-		annotator = v2as.GetAnnotator(annotation.BatchURL)
-	}
-	sink, ok := ins.(row.Sink)
-	if !ok {
-		log.Printf("%v is not a Sink\n", ins)
-		log.Println(reflect.TypeOf(ins))
-		return nil
-	}
-
-	return &TCPInfoParser{
-		Base:   row.NewBase("foobar", sink, bufSize, annotator),
-		table:  ins.TableBase(),
-		suffix: ins.TableSuffix()}
-}
-
-// NewTCPInfoParser2 creates a new TCPInfoParser.  Duh.
-// Single annotator may be optionally passed in.
-// TODO change to required parameter.
-func NewTCPInfoParser2(sink row.Sink, table string, ann v2as.Annotator) *TCPInfoParser {
+// Annotator may be optionally passed in, or will be created if nil.
+func NewTCPInfoParser(sink row.Sink, table string, ann v2as.Annotator) *TCPInfoParser {
 	bufSize := etl.TCPINFO.BQBufferSize()
 	if ann == nil {
 		ann = v2as.GetAnnotator(annotation.BatchURL)

--- a/parser/tcpinfo.go
+++ b/parser/tcpinfo.go
@@ -38,7 +38,8 @@ import (
 // TCPInfoParser handles parsing for TCPINFO datatype.
 type TCPInfoParser struct {
 	*row.Base
-	params etl.InserterParams // TODO - eliminate this.
+	table  string
+	suffix string
 }
 
 // RowsInBuffer returns the count of rows currently in the buffer.
@@ -61,35 +62,14 @@ func (p *TCPInfoParser) Failed() int {
 	return p.GetStats().Failed
 }
 
-// FullTableName implements etl.Inserter.FullTableName
+// FullTableName implements etl.Parser.FullTableName
 func (p *TCPInfoParser) FullTableName() string {
-	return p.params.Table + p.params.Suffix
+	return p.table + p.suffix
 }
 
-// TableBase implements etl.Inserter.TableBase
-func (p *TCPInfoParser) TableBase() string {
-	return p.params.Table
-}
-
-// TableSuffix implements etl.Inserter.TableSuffix
-// The $ or _ suffix.
-func (p *TCPInfoParser) TableSuffix() string {
-	return p.params.Suffix
-}
-
-// Project implements etl.Inserter.Project
-func (p *TCPInfoParser) Project() string {
-	return p.params.Project
-}
-
-// Dataset implements etl.Inserter.Dataset
-func (p *TCPInfoParser) Dataset() string {
-	return p.params.Dataset
-}
-
-// TableName implements etl.Inserter.TableName
+// TableName implements etl.Parser.TableName
 func (p *TCPInfoParser) TableName() string {
-	return p.params.Table
+	return p.table
 }
 
 // TaskError return the task level error, based on failed rows, or any other criteria.
@@ -236,10 +216,9 @@ func NewTCPInfoParser(ins etl.Inserter, ann ...v2as.Annotator) *TCPInfoParser {
 		log.Printf("%v is not a Sink\n", ins)
 		panic("")
 	}
-	bqi, ok := ins.(HasParams)
-	if !ok {
-		log.Fatalf("%v is not a HasParams\n", ins)
-	}
 
-	return &TCPInfoParser{row.NewBase("foobar", sink, bufSize, annotator), bqi.Params()}
+	return &TCPInfoParser{
+		Base:   row.NewBase("foobar", sink, bufSize, annotator),
+		table:  ins.TableBase(),
+		suffix: ins.TableSuffix()}
 }

--- a/parser/tcpinfo.go
+++ b/parser/tcpinfo.go
@@ -191,9 +191,20 @@ func (p *TCPInfoParser) ParseAndInsert(fileMetadata map[string]bigquery.Value, t
 		}
 	}
 
+<<<<<<< HEAD
 	// TODO - handle metrics differently for error?
 	metrics.TestCount.WithLabelValues(p.TableName(), "", "ok").Inc()
 	return p.Put(&row)
+=======
+	err = p.AddRow(&row)
+
+	if err != nil {
+		metrics.TestCount.WithLabelValues(p.TableName(), "", "ErrNotAnnotatable?").Inc()
+	} else {
+		metrics.TestCount.WithLabelValues(p.TableName(), "", "ok").Inc()
+	}
+	return err
+>>>>>>> b6b5fce... Add tcpinfo test stats
 }
 
 // HasParams defines interface with Params()

--- a/parser/tcpinfo.go
+++ b/parser/tcpinfo.go
@@ -190,20 +190,9 @@ func (p *TCPInfoParser) ParseAndInsert(fileMetadata map[string]bigquery.Value, t
 		}
 	}
 
-<<<<<<< HEAD
-	// TODO - handle metrics differently for error?
+	p.Put(&row)
 	metrics.TestCount.WithLabelValues(p.TableName(), "", "ok").Inc()
-	return p.Put(&row)
-=======
-	err = p.AddRow(&row)
-
-	if err != nil {
-		metrics.TestCount.WithLabelValues(p.TableName(), "", "ErrNotAnnotatable?").Inc()
-	} else {
-		metrics.TestCount.WithLabelValues(p.TableName(), "", "ok").Inc()
-	}
-	return err
->>>>>>> b6b5fce... Add tcpinfo test stats
+	return nil
 }
 
 // NewTCPInfoParser creates a new TCPInfoParser.  Duh.

--- a/parser/tcpinfo.go
+++ b/parser/tcpinfo.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"io"
 	"log"
+	"reflect"
 	"strings"
 	"time"
 
@@ -214,6 +215,7 @@ func NewTCPInfoParser(ins etl.Inserter, ann ...v2as.Annotator) *TCPInfoParser {
 	sink, ok := ins.(row.Sink)
 	if !ok {
 		log.Printf("%v is not a Sink\n", ins)
+		log.Println(reflect.TypeOf(ins))
 		return nil
 	}
 

--- a/parser/tcpinfo.go
+++ b/parser/tcpinfo.go
@@ -214,7 +214,7 @@ func NewTCPInfoParser(ins etl.Inserter, ann ...v2as.Annotator) *TCPInfoParser {
 	sink, ok := ins.(row.Sink)
 	if !ok {
 		log.Printf("%v is not a Sink\n", ins)
-		panic("")
+		return nil
 	}
 
 	return &TCPInfoParser{

--- a/parser/tcpinfo.go
+++ b/parser/tcpinfo.go
@@ -235,3 +235,17 @@ func NewTCPInfoParser(ins etl.Inserter, ann ...v2as.Annotator) *TCPInfoParser {
 		table:  ins.TableBase(),
 		suffix: ins.TableSuffix()}
 }
+
+// NewTCPInfoParser2 creates a new TCPInfoParser.  Duh.
+// Single annotator may be optionally passed in.
+// TODO change to required parameter.
+func NewTCPInfoParser2(sink row.Sink, table string, ann v2as.Annotator) *TCPInfoParser {
+	bufSize := etl.TCPINFO.BQBufferSize()
+	if ann == nil {
+		ann = v2as.GetAnnotator(annotation.BatchURL)
+	}
+
+	return &TCPInfoParser{
+		Base:  row.NewBase("foobar", sink, bufSize, ann),
+		table: table}
+}

--- a/parser/tcpinfo_test.go
+++ b/parser/tcpinfo_test.go
@@ -62,6 +62,7 @@ func (ann *fakeAnnotator) GetAnnotations(ctx context.Context, date time.Time, ip
 }
 
 // NOTE: This uses a fake annotator which returns no annotations.
+// TODO: This test seems to be flakey in travis - sometimes only 357 tests instead of 362
 func TestTCPParser(t *testing.T) {
 	os.Setenv("RELEASE_TAG", "foobar")
 	parserVersion := parser.InitParserVersionForTest()

--- a/parser/tcpinfo_test.go
+++ b/parser/tcpinfo_test.go
@@ -73,6 +73,7 @@ func TestTCPParser(t *testing.T) {
 		t.Fatal("Failed reading testdata from", filename)
 	}
 
+	// Inject fake inserter and annotator
 	ins := &inMemoryInserter{}
 	p := parser.NewTCPInfoParser(ins, &fakeAnnotator{})
 	task := task.NewTask(filename, src, p)
@@ -175,8 +176,9 @@ func TestTCPTask(t *testing.T) {
 	os.Setenv("RELEASE_TAG", "foobar")
 	parser.InitParserVersionForTest()
 
+	// Inject fake inserter and annotator
 	ins := &inMemoryInserter{}
-	p := parser.NewTCPInfoParser(ins)
+	p := parser.NewTCPInfoParser(ins, &fakeAnnotator{})
 
 	filename := "testdata/20190516T013026.744845Z-tcpinfo-mlab4-arn02-ndt.tgz"
 	src, err := localETLSource(filename)
@@ -199,8 +201,9 @@ func TestBQSaver(t *testing.T) {
 	os.Setenv("RELEASE_TAG", "foobar")
 	parser.InitParserVersionForTest()
 
+	// Inject fake inserter and annotator
 	ins := &inMemoryInserter{}
-	p := parser.NewTCPInfoParser(ins)
+	p := parser.NewTCPInfoParser(ins, &fakeAnnotator{})
 
 	filename := "testdata/20190516T013026.744845Z-tcpinfo-mlab4-arn02-ndt.tgz"
 	src, err := localETLSource(filename)
@@ -231,8 +234,9 @@ func BenchmarkTCPParser(b *testing.B) {
 	os.Setenv("RELEASE_TAG", "foobar")
 	parser.InitParserVersionForTest()
 
+	// Inject fake inserter and annotator
 	ins := &inMemoryInserter{}
-	p := parser.NewTCPInfoParser(ins)
+	p := parser.NewTCPInfoParser(ins, &fakeAnnotator{})
 
 	filename := "testdata/20190516T013026.744845Z-tcpinfo-mlab4-arn02-ndt.tgz"
 	n := 0

--- a/row/row_test.go
+++ b/row/row_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/m-lab/etl/bq"
 	"github.com/m-lab/etl/row"
 
 	"github.com/m-lab/annotation-service/api"
@@ -177,4 +178,8 @@ func TestAsyncPut(t *testing.T) {
 	if inserted.serverAnn == nil || inserted.serverAnn.Geo.PostalCode != "10584" {
 		t.Error("Failed server annotation")
 	}
+}
+
+func assertBQInserterIsSink(in row.Sink) {
+	func(in row.Sink) {}(&bq.BQInserter{})
 }

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -4,9 +4,10 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/m-lab/go/bqx"
+
 	"github.com/m-lab/etl/row"
 	"github.com/m-lab/etl/schema"
-	"github.com/m-lab/go/bqx"
 )
 
 func assertAnnotatable(r *schema.SS) {

--- a/task/task.go
+++ b/task/task.go
@@ -55,6 +55,9 @@ func (tt *Task) SetMaxFileSize(max int64) {
 // injected parser to parse them, and inserts them into bigquery. Returns the
 // number of files processed.
 func (tt *Task) ProcessAllTests() (int, error) {
+	if tt.Parser == nil {
+		panic("Parser is nil")
+	}
 	metrics.WorkerState.WithLabelValues(tt.TableName(), "task").Inc()
 	defer metrics.WorkerState.WithLabelValues(tt.TableName(), "task").Dec()
 	files := 0


### PR DESCRIPTION
This migrates the tcpinfo parser to use row.Base.
It requires a fair amount of cruft because the rest of the system still expects TCPInfoParser to implement etl.Parser.

This will eventually allow migration to a back end that uses GCS json files, to enable BQ Loads instead of streaming inserts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/835)
<!-- Reviewable:end -->
