### PR TITLE
Add public status page

### DIFF
--- a/bq/insert.go
+++ b/bq/insert.go
@@ -233,6 +233,7 @@ func (in *BQInserter) updateMetrics(err error) error {
 		}
 		// If ALL rows failed...
 		if len(typedErr) == in.pending {
+			log.Printf("%v %v\n", err, typedErr.Error()) // Log the first RowInsertionError detail
 			metrics.BackendFailureCount.WithLabelValues(
 				in.TableBase(), "failed insert").Inc()
 			in.failures++

--- a/k8s/data-processing/deployments/parser.yml
+++ b/k8s/data-processing/deployments/parser.yml
@@ -47,6 +47,8 @@ spec:
 
         - name: GARDENER_HOST
           value: "etl-gardener-service.default.svc.cluster.local"
+        - name: STATUS_PORT
+          value: ":8081"
         - name: BATCH_SERVICE
           value: 'true'   # Allow instances to discover they are BATCH instances.
         - name: MAX_WORKERS

--- a/k8s/data-processing/services/parser-status.yml
+++ b/k8s/data-processing/services/parser-status.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: etl-parser-status
+  namespace: default
+spec:
+  ports:
+  - port: 8081
+    protocol: TCP
+    targetPort: 8081
+  selector:
+    run: etl-parser
+  sessionAffinity: None
+  type: LoadBalancer


### PR DESCRIPTION
This adds a public status/debug page to the k8s parser deployment.  Similar to etl-gardener.
Very useful for profiling and debugging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/842)
<!-- Reviewable:end -->
