### PR TITLE
Refactor ETLSource

### DIFF
--- a/active/poller.go
+++ b/active/poller.go
@@ -159,12 +159,12 @@ func (g *GardenerAPI) pollAndRun(ctx context.Context,
 
 	log.Println("Running", job.Path())
 
-	update := tracker.UpdateURL(g.trackerBase, job, tracker.Parsing, "starting tasks")
+	update := tracker.UpdateURL(g.trackerBase, job.Job, tracker.Parsing, "starting tasks")
 	if postErr := postAndIgnoreResponse(ctx, *update); postErr != nil {
 		log.Println(postErr)
 	}
 
-	eg, err := g.RunAll(ctx, src, job)
+	eg, err := g.RunAll(ctx, src, job.Job)
 
 	// Once all are dispatched, we want to wait until all have completed
 	// before posting the state change.
@@ -172,7 +172,7 @@ func (g *GardenerAPI) pollAndRun(ctx context.Context,
 		log.Println("all tasks dispatched for", job.Path())
 		eg.Wait()
 		log.Println("finished", job.Path())
-		update := tracker.UpdateURL(g.trackerBase, job, tracker.ParseComplete, "")
+		update := tracker.UpdateURL(g.trackerBase, job.Job, tracker.ParseComplete, "")
 		// TODO - should this have a retry?
 		if postErr := postAndIgnoreResponse(ctx, *update); postErr != nil {
 			log.Println(postErr)

--- a/active/poller.go
+++ b/active/poller.go
@@ -2,7 +2,6 @@ package active
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"io/ioutil"
 	"log"
@@ -17,9 +16,11 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/option"
 
+	job "github.com/m-lab/etl-gardener/job-service"
 	"github.com/m-lab/etl-gardener/tracker"
-	"github.com/m-lab/etl/metrics"
 	"github.com/m-lab/go/rtx"
+
+	"github.com/m-lab/etl/metrics"
 )
 
 // JobFailures counts the all errors that result in test loss.
@@ -137,31 +138,9 @@ func (g *GardenerAPI) JobFileSource(ctx context.Context, job tracker.Job,
 	return gcsSource, nil
 }
 
-// nextJob is used by clients to fetch the next job from the service.
-// DEPRECATED - for transition only.  Should use job.NextJob once gardener is
-// has been updated with JobWithTarget
-func nextJob(ctx context.Context, base url.URL) (tracker.Job, error) {
-	jobURL := base
-	jobURL.Path = "job"
-
-	job := tracker.Job{}
-
-	b, status, err := post(ctx, jobURL)
-	if err != nil {
-		return job, err
-	}
-	if status != http.StatusOK {
-		return job, errors.New(http.StatusText(status))
-	}
-
-	err = json.Unmarshal(b, &job)
-	return job, err
-}
-
 // NextJob requests a new job from Gardener service.
-func (g *GardenerAPI) NextJob(ctx context.Context) (tracker.Job, error) {
-	// TODO use job.NextJob from gardener.
-	return nextJob(ctx, g.trackerBase)
+func (g *GardenerAPI) NextJob(ctx context.Context) (tracker.JobWithTarget, error) {
+	return job.NextJob(ctx, g.trackerBase)
 }
 
 func (g *GardenerAPI) pollAndRun(ctx context.Context,
@@ -171,7 +150,8 @@ func (g *GardenerAPI) pollAndRun(ctx context.Context,
 		return err
 	}
 
-	gcsSource, err := g.JobFileSource(ctx, job, toRunnable)
+	log.Println(job)
+	gcsSource, err := g.JobFileSource(ctx, job.Job, toRunnable)
 	if err != nil {
 		return err
 	}

--- a/active/poller_test.go
+++ b/active/poller_test.go
@@ -82,7 +82,7 @@ func TestGardenerAPI_JobFileSource(t *testing.T) {
 
 	// The test counter creates runnables for the jobs.
 	p := newCounter(t)
-	src, err := g.JobFileSource(ctx, job, p.toRunnable)
+	src, err := g.JobFileSource(ctx, job.Job, p.toRunnable)
 	rtx.Must(err, "file source")
 	log.Println(src)
 
@@ -126,9 +126,9 @@ func TestGardenerAPI_RunAll(t *testing.T) {
 
 	// The test counter creates runnables for the jobs.
 	p := newCounter(t)
-	src, err := g.JobFileSource(ctx, job, p.toRunnable)
+	src, err := g.JobFileSource(ctx, job.Job, p.toRunnable)
 	rtx.Must(err, "file source")
-	eg, err := g.RunAll(ctx, src, job)
+	eg, err := g.RunAll(ctx, src, job.Job)
 	if err != iterator.Done {
 		t.Fatal(err)
 	}

--- a/etl/etl.go
+++ b/etl/etl.go
@@ -122,6 +122,18 @@ type Parser interface {
 	RowStats // Parser must implement RowStats
 }
 
+// TestSource provides a source of test data.
+type TestSource interface {
+	// NextTest reads the next test object from the tar file.
+	// Skips reading contents of any file larger than maxSize, returning empty data
+	// and storage.ErrOversizeFile.
+	// Returns io.EOF when there are no more tests.
+	NextTest(maxSize int64) (string, []byte, error)
+	Close() error
+
+	Label() string // Label for logs and metrics
+}
+
 //========================================================================
 // Interface to allow fakes.
 //========================================================================

--- a/parser/tcpinfo_test.go
+++ b/parser/tcpinfo_test.go
@@ -27,7 +27,7 @@ func assertTCPInfoParser(in *parser.TCPInfoParser) {
 	func(p etl.Parser) {}(in)
 }
 
-func localETLSource(fn string) (storage.ETLSource, error) {
+func fileSource(fn string) (etl.TestSource, error) {
 	if !(strings.HasSuffix(fn, ".tgz") || strings.HasSuffix(fn, ".tar") ||
 		strings.HasSuffix(fn, ".tar.gz")) {
 		return nil, errors.New("not tar or tgz: " + fn)
@@ -52,7 +52,7 @@ func localETLSource(fn string) (storage.ETLSource, error) {
 	tarReader := tar.NewReader(rdr)
 
 	timeout := 16 * time.Millisecond
-	return &storage.ETLSourceImpl{TarReader: tarReader, Closer: raw, RetryBaseTime: timeout, TableBase: "test"}, nil
+	return &storage.GCSSource{TarReader: tarReader, Closer: raw, RetryBaseTime: timeout, TableBase: "test"}, nil
 }
 
 type fakeAnnotator struct{}
@@ -108,7 +108,7 @@ func TestTCPParser(t *testing.T) {
 
 	filename := "testdata/20190516T013026.744845Z-tcpinfo-mlab4-arn02-ndt.tgz"
 
-	src, err := localETLSource(filename)
+	src, err := fileSource(filename)
 	if err != nil {
 		t.Fatal("Failed reading testdata from", filename)
 	}
@@ -221,7 +221,7 @@ func TestTCPTask(t *testing.T) {
 	p := parser.NewTCPInfoParser(ins, "test", &fakeAnnotator{})
 
 	filename := "testdata/20190516T013026.744845Z-tcpinfo-mlab4-arn02-ndt.tgz"
-	src, err := localETLSource(filename)
+	src, err := fileSource(filename)
 	if err != nil {
 		t.Fatal("Failed reading testdata from", filename)
 	}
@@ -246,7 +246,7 @@ func TestBQSaver(t *testing.T) {
 	p := parser.NewTCPInfoParser(ins, "test", &fakeAnnotator{})
 
 	filename := "testdata/20190516T013026.744845Z-tcpinfo-mlab4-arn02-ndt.tgz"
-	src, err := localETLSource(filename)
+	src, err := fileSource(filename)
 	if err != nil {
 		t.Fatal("Failed reading testdata from", filename)
 	}
@@ -281,7 +281,7 @@ func BenchmarkTCPParser(b *testing.B) {
 	filename := "testdata/20190516T013026.744845Z-tcpinfo-mlab4-arn02-ndt.tgz"
 	n := 0
 	for i := 0; i < b.N; i += n {
-		src, err := localETLSource(filename)
+		src, err := fileSource(filename)
 		if err != nil {
 			b.Fatalf("cannot read testdata.")
 		}

--- a/parser/tcpinfo_test.go
+++ b/parser/tcpinfo_test.go
@@ -27,7 +27,7 @@ func assertTCPInfoParser(in *parser.TCPInfoParser) {
 	func(p etl.Parser) {}(in)
 }
 
-func localETLSource(fn string) (*storage.ETLSource, error) {
+func localETLSource(fn string) (storage.ETLSource, error) {
 	if !(strings.HasSuffix(fn, ".tgz") || strings.HasSuffix(fn, ".tar") ||
 		strings.HasSuffix(fn, ".tar.gz")) {
 		return nil, errors.New("not tar or tgz: " + fn)
@@ -52,7 +52,7 @@ func localETLSource(fn string) (*storage.ETLSource, error) {
 	tarReader := tar.NewReader(rdr)
 
 	timeout := 16 * time.Millisecond
-	return &storage.ETLSource{TarReader: tarReader, Closer: raw, RetryBaseTime: timeout, TableBase: "test"}, nil
+	return &storage.ETLSourceImpl{TarReader: tarReader, Closer: raw, RetryBaseTime: timeout, TableBase: "test"}, nil
 }
 
 type fakeAnnotator struct{}

--- a/schema/tcpinfo_test.go
+++ b/schema/tcpinfo_test.go
@@ -21,7 +21,8 @@ import (
 	"github.com/m-lab/tcp-info/snapshot"
 )
 
-func localETLSource(fn string) (*storage.ETLSource, error) {
+// TODO - move this to storage for general use.
+func localETLSource(fn string) (storage.ETLSource, error) {
 	if !(strings.HasSuffix(fn, ".tgz") || strings.HasSuffix(fn, ".tar") ||
 		strings.HasSuffix(fn, ".tar.gz")) {
 		return nil, errors.New("not tar or tgz: " + fn)
@@ -46,7 +47,7 @@ func localETLSource(fn string) (*storage.ETLSource, error) {
 	tarReader := tar.NewReader(rdr)
 
 	timeout := 16 * time.Millisecond
-	return &storage.ETLSource{TarReader: tarReader, Closer: raw, RetryBaseTime: timeout, TableBase: "test"}, nil
+	return &storage.ETLSourceImpl{TarReader: tarReader, Closer: raw, RetryBaseTime: timeout, TableBase: "test"}, nil
 }
 
 func TestBQSaver(t *testing.T) {

--- a/schema/tcpinfo_test.go
+++ b/schema/tcpinfo_test.go
@@ -16,13 +16,14 @@ import (
 	"github.com/m-lab/tcp-info/inetdiag"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/schema"
 	"github.com/m-lab/etl/storage"
 	"github.com/m-lab/tcp-info/snapshot"
 )
 
 // TODO - move this to storage for general use.
-func localETLSource(fn string) (storage.ETLSource, error) {
+func fileSource(fn string) (etl.TestSource, error) {
 	if !(strings.HasSuffix(fn, ".tgz") || strings.HasSuffix(fn, ".tar") ||
 		strings.HasSuffix(fn, ".tar.gz")) {
 		return nil, errors.New("not tar or tgz: " + fn)
@@ -47,7 +48,7 @@ func localETLSource(fn string) (storage.ETLSource, error) {
 	tarReader := tar.NewReader(rdr)
 
 	timeout := 16 * time.Millisecond
-	return &storage.ETLSourceImpl{TarReader: tarReader, Closer: raw, RetryBaseTime: timeout, TableBase: "test"}, nil
+	return &storage.GCSSource{TarReader: tarReader, Closer: raw, RetryBaseTime: timeout, TableBase: "test"}, nil
 }
 
 func TestBQSaver(t *testing.T) {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -33,8 +33,21 @@ type TarReader interface {
 	Read(b []byte) (int, error)
 }
 
-// ETLSource wraps a gsutil tar file containing tests.
-type ETLSource struct {
+// ETLSource provides a source of testdata.
+type ETLSource interface {
+	// NextTest reads the next test object from the tar file.
+	// Skips reading contents of any file larger than maxSize, returning empty data
+	// and storage.ErrOversizeFile.
+	// Returns io.EOF when there are no more tests.
+	NextTest(maxSize int64) (string, []byte, error)
+	Close() error
+
+	Label() string // Label for logs and metrics
+}
+
+// ETLSourceImpl wraps a gsutil tar file containing tests.
+// TODO make this local, and create NewFileETLSource, NewGCSETLSource, etc.
+type ETLSourceImpl struct {
 	TarReader                   // TarReader interface provided by an embedded struct.
 	io.Closer                   // Closer interface to be provided by an embedded struct.
 	RetryBaseTime time.Duration // The base time for backoff and retry.
@@ -43,7 +56,7 @@ type ETLSource struct {
 
 // Retrieve next file header.
 // Lots of error handling because of common faults in underlying GCS.
-func (rr *ETLSource) nextHeader(trial int) (*tar.Header, bool, error) {
+func (rr *ETLSourceImpl) nextHeader(trial int) (*tar.Header, bool, error) {
 	h, err := rr.Next()
 	if err != nil {
 		if err == io.EOF {
@@ -67,7 +80,7 @@ func (rr *ETLSource) nextHeader(trial int) (*tar.Header, bool, error) {
 // Retrieve the data for a single file.
 // Lots of error handling because of common faults in underlying GCS.
 // Returns data in byte array, error and boolean regarding whether to retry.
-func (rr *ETLSource) nextData(h *tar.Header, trial int) ([]byte, bool, error) {
+func (rr *ETLSourceImpl) nextData(h *tar.Header, trial int) ([]byte, bool, error) {
 	var data []byte
 	var err error
 	var phase string
@@ -110,11 +123,16 @@ func (rr *ETLSource) nextData(h *tar.Header, trial int) ([]byte, bool, error) {
 	return data, false, nil
 }
 
+// Label returns a string for use in metrics and logs.
+func (rr *ETLSourceImpl) Label() string {
+	return rr.TableBase
+}
+
 // NextTest reads the next test object from the tar file.
 // Skips reading contents of any file larger than maxSize, returning empty data
 // and storage.ErrOversizeFile.
 // Returns io.EOF when there are no more tests.
-func (rr *ETLSource) NextTest(maxSize int64) (string, []byte, error) {
+func (rr *ETLSourceImpl) NextTest(maxSize int64) (string, []byte, error) {
 	metrics.WorkerState.WithLabelValues(rr.TableBase, "read").Inc()
 	defer metrics.WorkerState.WithLabelValues(rr.TableBase, "read").Dec()
 
@@ -203,7 +221,7 @@ var errNoClient = errors.New("client should be non-null")
 //
 // uri should be of form gs://bucket/filename.tar or gs://bucket/filename.tgz
 // FYI Using a persistent client saves about 80 msec, and 220 allocs, totalling 70kB.
-func NewETLSource(client *storage.Client, uri string) (*ETLSource, error) {
+func NewETLSource(client *storage.Client, uri string, label string) (ETLSource, error) {
 	if client == nil {
 		return nil, errNoClient
 	}
@@ -253,7 +271,7 @@ func NewETLSource(client *storage.Client, uri string) (*ETLSource, error) {
 	tarReader := tar.NewReader(rdr)
 
 	baseTimeout := 16 * time.Millisecond
-	return &ETLSource{tarReader, closer, baseTimeout, "invalid"}, nil
+	return &ETLSourceImpl{tarReader, closer, baseTimeout, label}, nil
 }
 
 // GetStorageClient provides a storage reader client.

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -33,7 +33,7 @@ func TestNewTarReader(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping tests that access GCS")
 	}
-	src, err := NewETLSource(client, tarFile, "label")
+	src, err := NewTestSource(client, tarFile, "label")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func TestNewTarReaderGzip(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping tests that access GCS")
 	}
-	src, err := NewETLSource(client, tgzFile, "label")
+	src, err := NewTestSource(client, tgzFile, "label")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,7 +86,7 @@ func init() {
 
 func BenchmarkNewTarReader(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		src, err := NewETLSource(client, tarFile, "label")
+		src, err := NewTestSource(client, tarFile, "label")
 		if err == nil {
 			src.Close()
 		}
@@ -95,7 +95,7 @@ func BenchmarkNewTarReader(b *testing.B) {
 
 func BenchmarkNewTarReaderGzip(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		src, err := NewETLSource(client, tgzFile, "label")
+		src, err := NewTestSource(client, tgzFile, "label")
 		if err == nil {
 			src.Close()
 		}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -33,7 +33,7 @@ func TestNewTarReader(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping tests that access GCS")
 	}
-	src, err := NewETLSource(client, tarFile)
+	src, err := NewETLSource(client, tarFile, "label")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func TestNewTarReaderGzip(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping tests that access GCS")
 	}
-	src, err := NewETLSource(client, tgzFile)
+	src, err := NewETLSource(client, tgzFile, "label")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,7 +86,7 @@ func init() {
 
 func BenchmarkNewTarReader(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		src, err := NewETLSource(client, tarFile)
+		src, err := NewETLSource(client, tarFile, "label")
 		if err == nil {
 			src.Close()
 		}
@@ -95,7 +95,7 @@ func BenchmarkNewTarReader(b *testing.B) {
 
 func BenchmarkNewTarReaderGzip(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		src, err := NewETLSource(client, tgzFile)
+		src, err := NewETLSource(client, tgzFile, "label")
 		if err == nil {
 			src.Close()
 		}

--- a/task/task.go
+++ b/task/task.go
@@ -28,15 +28,15 @@ const DefaultMaxFileSize = 200 * 1024 * 1024
 type Task struct {
 	// ETLSource and Parser are both embedded, so their interfaces are delegated
 	// to the component structs.
-	*storage.ETLSource // Source from which to read tests.
-	etl.Parser         // Parser to parse the tests.
+	storage.ETLSource // Source from which to read tests.
+	etl.Parser        // Parser to parse the tests.
 
 	meta        map[string]bigquery.Value // Metadata about this task.
 	maxFileSize int64                     // Max file size to avoid OOM.
 }
 
 // NewTask constructs a task, injecting the source and the parser.
-func NewTask(filename string, src *storage.ETLSource, prsr etl.Parser) *Task {
+func NewTask(filename string, src storage.ETLSource, prsr etl.Parser) *Task {
 	// TODO - should the meta data be a nested type?
 	meta := make(map[string]bigquery.Value, 3)
 	meta["filename"] = filename

--- a/task/task.go
+++ b/task/task.go
@@ -26,17 +26,17 @@ const DefaultMaxFileSize = 200 * 1024 * 1024
 // Task contains the state required to process a single task tar file.
 // TODO(dev) Add unit tests for meta data.
 type Task struct {
-	// ETLSource and Parser are both embedded, so their interfaces are delegated
+	// TestSource and Parser are both embedded, so their interfaces are delegated
 	// to the component structs.
-	storage.ETLSource // Source from which to read tests.
-	etl.Parser        // Parser to parse the tests.
+	etl.TestSource // Source from which to read tests.
+	etl.Parser     // Parser to parse the tests.
 
 	meta        map[string]bigquery.Value // Metadata about this task.
 	maxFileSize int64                     // Max file size to avoid OOM.
 }
 
 // NewTask constructs a task, injecting the source and the parser.
-func NewTask(filename string, src storage.ETLSource, prsr etl.Parser) *Task {
+func NewTask(filename string, src etl.TestSource, prsr etl.Parser) *Task {
 	// TODO - should the meta data be a nested type?
 	meta := make(map[string]bigquery.Value, 3)
 	meta["filename"] = filename

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -14,6 +14,7 @@ import (
 
 	"time"
 
+	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/parser"
 	"github.com/m-lab/etl/storage" // TODO - would be better not to have this.
 	"github.com/m-lab/etl/task"
@@ -37,7 +38,7 @@ func (nc NullCloser) Close() error {
 
 // Create a TarReader with simple test contents.
 // TODO - could we break the dependency on storage here?
-func MakeTestSource(t *testing.T) storage.ETLSource {
+func MakeTestSource(t *testing.T) etl.TestSource {
 	b := new(bytes.Buffer)
 	tw := tar.NewWriter(b)
 	hdr := tar.Header{Name: "foo", Mode: 0666, Typeflag: tar.TypeReg, Size: int64(8)}
@@ -62,7 +63,7 @@ func MakeTestSource(t *testing.T) storage.ETLSource {
 		t.Fatal(err)
 	}
 
-	return &storage.ETLSourceImpl{TarReader: tar.NewReader(b), Closer: NullCloser{}, RetryBaseTime: time.Millisecond}
+	return &storage.GCSSource{TarReader: tar.NewReader(b), Closer: NullCloser{}, RetryBaseTime: time.Millisecond}
 }
 
 type TestParser struct {
@@ -104,7 +105,7 @@ func (bs *badSource) Read(b []byte) (int, error) {
 
 // TODO - this test is very slow, because it triggers the backoff and retry mechanism.
 func TestBadTarFileInput(t *testing.T) {
-	rdr := &storage.ETLSourceImpl{TarReader: &badSource{}, Closer: NullCloser{}, RetryBaseTime: time.Millisecond}
+	rdr := &storage.GCSSource{TarReader: &badSource{}, Closer: NullCloser{}, RetryBaseTime: time.Millisecond}
 
 	tp := &TestParser{}
 

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -37,7 +37,7 @@ func (nc NullCloser) Close() error {
 
 // Create a TarReader with simple test contents.
 // TODO - could we break the dependency on storage here?
-func MakeTestSource(t *testing.T) *storage.ETLSource {
+func MakeTestSource(t *testing.T) storage.ETLSource {
 	b := new(bytes.Buffer)
 	tw := tar.NewWriter(b)
 	hdr := tar.Header{Name: "foo", Mode: 0666, Typeflag: tar.TypeReg, Size: int64(8)}
@@ -62,7 +62,7 @@ func MakeTestSource(t *testing.T) *storage.ETLSource {
 		t.Fatal(err)
 	}
 
-	return &storage.ETLSource{TarReader: tar.NewReader(b), Closer: NullCloser{}, RetryBaseTime: time.Millisecond}
+	return &storage.ETLSourceImpl{TarReader: tar.NewReader(b), Closer: NullCloser{}, RetryBaseTime: time.Millisecond}
 }
 
 type TestParser struct {
@@ -104,7 +104,7 @@ func (bs *badSource) Read(b []byte) (int, error) {
 
 // TODO - this test is very slow, because it triggers the backoff and retry mechanism.
 func TestBadTarFileInput(t *testing.T) {
-	rdr := &storage.ETLSource{TarReader: &badSource{}, Closer: NullCloser{}, RetryBaseTime: time.Millisecond}
+	rdr := &storage.ETLSourceImpl{TarReader: &badSource{}, Closer: NullCloser{}, RetryBaseTime: time.Millisecond}
 
 	tp := &TestParser{}
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -56,7 +56,7 @@ func ProcessTask(fn string) (int, error) {
 	}
 
 	// TODO - add a timer for reading the file.
-	tr, err := storage.NewETLSource(client, fn)
+	tr, err := storage.NewETLSource(client, fn, data.TableBase())
 	if err != nil {
 		metrics.TaskCount.WithLabelValues(data.TableBase(), string(dataType), "ETLSourceError").Inc()
 		log.Printf("Error opening gcs file: %v", err)
@@ -64,8 +64,6 @@ func ProcessTask(fn string) (int, error) {
 		// TODO - anything better we could do here?
 	}
 	defer tr.Close()
-	// Label storage metrics with the expected table name.
-	tr.TableBase = data.TableBase()
 
 	dateFormat := "20060102"
 	date, err := time.Parse(dateFormat, data.PackedDate)

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -56,7 +56,7 @@ func ProcessTask(fn string) (int, error) {
 	}
 
 	// TODO - add a timer for reading the file.
-	tr, err := storage.NewETLSource(client, fn, data.TableBase())
+	tr, err := storage.NewTestSource(client, fn, data.TableBase())
 	if err != nil {
 		metrics.TaskCount.WithLabelValues(data.TableBase(), string(dataType), "ETLSourceError").Inc()
 		log.Printf("Error opening gcs file: %v", err)


### PR DESCRIPTION
This moves struct storage.ETLSource to interface etl.TestSource.   storage.GCSSource implements the interface backed by a GCS object.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/845)
<!-- Reviewable:end -->
