### PR TITLE
Migrate ndt_result to use row.Base.

### DIFF
--- a/parser/ndt_result_test.go
+++ b/parser/ndt_result_test.go
@@ -30,8 +30,8 @@ func TestNDTResultParser_ParseAndInsert(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ins := newInMemoryInserter()
-			n := parser.NewNDTResultParser(ins)
+			ins := newInMemorySink()
+			n := parser.NewNDTResultParser(ins, "test", "_suffix", nil)
 
 			resultData, err := ioutil.ReadFile(`testdata/NDTResult/` + tt.testName)
 			if err != nil {
@@ -44,10 +44,11 @@ func TestNDTResultParser_ParseAndInsert(t *testing.T) {
 			if err := n.ParseAndInsert(meta, tt.testName, resultData); (err != nil) != tt.wantErr {
 				t.Errorf("NDTResultParser.ParseAndInsert() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if ins.Accepted() != 1 {
-				t.Fatalf("Failed to insert snaplog data.")
+			if n.Accepted() != 1 {
+				t.Fatal("Failed to insert snaplog data.", ins)
 			}
-			actualValues := ins.data[0].(schema.NDTResultRow)
+			n.Flush()
+			actualValues := ins.data[0].(*schema.NDTResultRow)
 			if actualValues.Result.Control == nil {
 				t.Fatal("Result.Control is nil, expected value")
 			}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -47,7 +47,14 @@ func NewParser(dt etl.DataType, ins etl.Inserter) etl.Parser {
 	case etl.NDT:
 		return NewNDTParser(ins)
 	case etl.NDT5:
-		return NewNDTResultParser(ins)
+		sink, ok := ins.(row.Sink)
+		if !ok {
+			log.Printf("%v is not a Sink\n", ins)
+			log.Println(reflect.TypeOf(ins))
+			return nil
+		}
+		return NewNDTResultParser(sink, ins.TableBase(), ins.TableSuffix(), nil)
+
 	case etl.SS:
 		return NewDefaultSSParser(ins) // TODO fix this hack.
 	case etl.PT:
@@ -61,7 +68,7 @@ func NewParser(dt etl.DataType, ins etl.Inserter) etl.Parser {
 			log.Println(reflect.TypeOf(ins))
 			return nil
 		}
-		return NewTCPInfoParser(sink, ins.TableBase(), nil)
+		return NewTCPInfoParser(sink, ins.TableBase(), ins.TableSuffix(), nil)
 	default:
 		return nil
 	}

--- a/parser/tcpinfo.go
+++ b/parser/tcpinfo.go
@@ -197,13 +197,15 @@ func (p *TCPInfoParser) ParseAndInsert(fileMetadata map[string]bigquery.Value, t
 
 // NewTCPInfoParser creates a new TCPInfoParser.  Duh.
 // Annotator may be optionally passed in, or will be created if nil.
-func NewTCPInfoParser(sink row.Sink, table string, ann v2as.Annotator) *TCPInfoParser {
+func NewTCPInfoParser(sink row.Sink, table, suffix string, ann v2as.Annotator) *TCPInfoParser {
 	bufSize := etl.TCPINFO.BQBufferSize()
 	if ann == nil {
 		ann = v2as.GetAnnotator(annotation.BatchURL)
 	}
 
 	return &TCPInfoParser{
-		Base:  row.NewBase("foobar", sink, bufSize, ann),
-		table: table}
+		Base:   row.NewBase("foobar", sink, bufSize, ann),
+		table:  table,
+		suffix: suffix,
+	}
 }

--- a/parser/tcpinfo_test.go
+++ b/parser/tcpinfo_test.go
@@ -115,7 +115,7 @@ func TestTCPParser(t *testing.T) {
 
 	// Inject fake inserter and annotator
 	ins := newInMemorySink()
-	p := parser.NewTCPInfoParser(ins, "test", &fakeAnnotator{})
+	p := parser.NewTCPInfoParser(ins, "test", "_suffix", &fakeAnnotator{})
 	task := task.NewTask(filename, src, p)
 
 	startDecode := time.Now()
@@ -218,7 +218,7 @@ func TestTCPTask(t *testing.T) {
 
 	// Inject fake inserter and annotator
 	ins := newInMemorySink()
-	p := parser.NewTCPInfoParser(ins, "test", &fakeAnnotator{})
+	p := parser.NewTCPInfoParser(ins, "test", "_suffix", &fakeAnnotator{})
 
 	filename := "testdata/20190516T013026.744845Z-tcpinfo-mlab4-arn02-ndt.tgz"
 	src, err := fileSource(filename)
@@ -243,7 +243,7 @@ func TestBQSaver(t *testing.T) {
 
 	// Inject fake inserter and annotator
 	ins := newInMemorySink()
-	p := parser.NewTCPInfoParser(ins, "test", &fakeAnnotator{})
+	p := parser.NewTCPInfoParser(ins, "test", "_suffix", &fakeAnnotator{})
 
 	filename := "testdata/20190516T013026.744845Z-tcpinfo-mlab4-arn02-ndt.tgz"
 	src, err := fileSource(filename)
@@ -276,7 +276,7 @@ func BenchmarkTCPParser(b *testing.B) {
 
 	// Inject fake inserter and annotator
 	ins := newInMemorySink()
-	p := parser.NewTCPInfoParser(ins, "test", &fakeAnnotator{})
+	p := parser.NewTCPInfoParser(ins, "test", "_suffix", &fakeAnnotator{})
 
 	filename := "testdata/20190516T013026.744845Z-tcpinfo-mlab4-arn02-ndt.tgz"
 	n := 0

--- a/row/row.go
+++ b/row/row.go
@@ -70,7 +70,6 @@ func (as *ActiveStats) MoveToPending(n int) {
 	as.Buffered -= n
 	if as.Buffered < 0 {
 		log.Println("BROKEN - negative buffered")
-		panic("negative Buffered")
 	}
 	as.Pending += n
 }
@@ -90,7 +89,6 @@ func (as *ActiveStats) Done(n int, err error) {
 	as.Pending -= n
 	if as.Pending < 0 {
 		log.Println("BROKEN: negative Pending")
-		panic("negative Pending")
 	}
 	if err != nil {
 		as.Failed += n

--- a/schema/ndt_result.go
+++ b/schema/ndt_result.go
@@ -1,7 +1,10 @@
 package schema
 
 import (
+	"time"
+
 	"cloud.google.com/go/bigquery"
+	"github.com/m-lab/annotation-service/api"
 	"github.com/m-lab/go/bqx"
 	"github.com/m-lab/ndt-server/data"
 )
@@ -27,4 +30,21 @@ func (row *NDTResultRow) Schema() (bigquery.Schema, error) {
 	}
 	rr := bqx.RemoveRequired(sch)
 	return rr, err
+}
+
+// Implement row.Annotatable
+func (row *NDTResultRow) GetLogTime() time.Time {
+	return time.Now()
+}
+func (row *NDTResultRow) GetClientIPs() []string {
+	return []string{}
+}
+func (row *NDTResultRow) GetServerIP() string {
+	return ""
+}
+func (row *NDTResultRow) AnnotateClients(map[string]*api.Annotations) error {
+	return nil
+}
+func (row *NDTResultRow) AnnotateServer(*api.Annotations) error {
+	return nil
 }

--- a/schema/ndt_result.go
+++ b/schema/ndt_result.go
@@ -33,6 +33,8 @@ func (row *NDTResultRow) Schema() (bigquery.Schema, error) {
 }
 
 // Implement row.Annotatable
+// This is a trivial implementation, as the schema does not yet include
+// annotations, and probably will not until we integrate UUID Annotator.
 func (row *NDTResultRow) GetLogTime() time.Time {
 	return time.Now()
 }


### PR DESCRIPTION
Previous PR refactored BQInserter to support row.Base stats.
This migrates NDTResultParser to use row.Base, allowing later substitution of GCS Sink.
This also seems to slightly reduce the memory footprint, which is unexpected.  May just be that it hasn't run long enough to reach the peak memory use.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/849)
<!-- Reviewable:end -->
