### PR TITLE
Add BIGQUERY_DATASET for GKE deploymment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -359,6 +359,9 @@ deploy:
     $TRAVIS_BUILD_DIR/travis/run_with_application_credentials.sh mlab-staging
     SERVICE_ACCOUNT_mlab_staging $TRAVIS_BUILD_DIR/cmd/update-schema update-schema
     &&
+    BIGQUERY_DATASET="ndt_raw"
+    $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-staging data-processing ./apply-cluster.sh
+    &&
     $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
     SERVICE_ACCOUNT_mlab_staging $TRAVIS_BUILD_DIR/cmd/etl_worker app-ndt.yaml
     && $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
@@ -384,18 +387,6 @@ deploy:
   on:
     repo: m-lab/etl
     branch: master
-
-## Service: etl-fast-ss-parser -- AppEngine Flexible Environment.
-## Hack for demo
-- provider: script
-  script:
-    $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
-    SERVICE_ACCOUNT_mlab_staging $TRAVIS_BUILD_DIR/cmd/etl_worker fast-sidestream.yaml
-  skip_cleanup: true
-  on:
-    repo: m-lab/etl
-    all_branches: true
-    condition: $TRAVIS_BRANCH == fast-staging-*
 
 ######################################################################
 #  Prod deployments

--- a/.travis.yml
+++ b/.travis.yml
@@ -319,6 +319,7 @@ deploy:
   script:
     $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_sandbox
     &&
+    BIGQUERY_DATASET="ndt_raw"
     $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-sandbox data-processing ./apply-cluster.sh
   skip_cleanup: true
   on:

--- a/apply-cluster.sh
+++ b/apply-cluster.sh
@@ -16,6 +16,7 @@ USAGE="PROJECT=<projectid> CLUSTER=<cluster> TRAVIS_TAG=<tag> TRAVIS_COMMIT=<com
 PROJECT=${PROJECT:?Please provide project id: $USAGE}
 CLUSTER=${CLUSTER:?Please provide cluster name: $USAGE}
 TRAVIS_TAG=${TRAVIS_TAG:-empty_tag}
+BIGQUERY_DATASET=${BIGQUERY_DATASET:-empty_tag}
 TRAVIS_COMMIT=${TRAVIS_COMMIT:?Please provide travis commit: $USAGE}
 
 # Apply templates
@@ -26,6 +27,7 @@ kexpand expand --ignore-missing-keys k8s/${CLUSTER}/*/*.yml \
     --value GCLOUD_PROJECT=${PROJECT} \
     --value RELEASE_TAG=${TRAVIS_TAG} \
     --value GIT_COMMIT=${TRAVIS_COMMIT} \
+    --value BIGQUERY_DATASET=${BIGQUERY_DATASET} \
     > ${CFG}
 cat ${CFG}
 

--- a/k8s/data-processing/deployments/parser.yml
+++ b/k8s/data-processing/deployments/parser.yml
@@ -44,6 +44,8 @@ spec:
           value: "{{GIT_COMMIT}}"
         - name: GCLOUD_PROJECT
           value: "{{GCLOUD_PROJECT}}"
+        - name: BIGQUERY_DATASET
+          value: "{{BIGQUERY_DATASET}}"
 
         - name: GARDENER_HOST
           value: "etl-gardener-service.default.svc.cluster.local"


### PR DESCRIPTION
This configures the GKE parsers to write to templated tables in ndt_raw.  Next step is to make them write to normal partitioned tables.
Manually created the tables in sandbox.  The creation query is in the Description fields.

I had to change the ndt5 log_time field to be a timestamp to allow column partitioning.  

This change has NO impact on V1 parser - only V2 GKE instances.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/852)
<!-- Reviewable:end -->
