### PR TITLE
ndt7: Use BytesAcked to calculate MeanThroughputMbps

### DIFF
--- a/parser/ndt7_result.go
+++ b/parser/ndt7_result.go
@@ -140,7 +140,7 @@ func downRate(m []model.Measurement) float64 {
 	var mbps float64
 	if len(m) > 0 {
 		// Convert to Mbps.
-		mbps = 8 * float64(m[len(m)-1].TCPInfo.BytesSent) / float64(m[len(m)-1].TCPInfo.ElapsedTime)
+		mbps = 8 * float64(m[len(m)-1].TCPInfo.BytesAcked) / float64(m[len(m)-1].TCPInfo.ElapsedTime)
 	}
 	return mbps
 }

--- a/parser/ndt7_result_test.go
+++ b/parser/ndt7_result_test.go
@@ -54,7 +54,7 @@ func TestNDT7ResultParser_ParseAndInsert(t *testing.T) {
 					UUID:               "ndt-knwp4_1583603744_000000000000590E",
 					TestTime:           row.A.TestTime,
 					CongestionControl:  "bbr",
-					MeanThroughputMbps: 46.26645885913907,
+					MeanThroughputMbps: 38.714033637501984,
 					MinRTT:             0.285804,
 					LossRate:           0.12029169202467564,
 				}


### PR DESCRIPTION
This change fixes the calculation for rate used by the etl ndt7 parser. BytesSent includes retransmissions, while BytesAcked includes only the bytes received by the client, more closely reflecting user experience.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/856)
<!-- Reviewable:end -->
