### PR TITLE
Allow json.gz files for ndt7

### DIFF
--- a/parser/ndt7_result.go
+++ b/parser/ndt7_result.go
@@ -57,7 +57,8 @@ func (dp *NDT7ResultParser) TaskError() error {
 // IsParsable returns the canonical test type and whether to parse data.
 func (dp *NDT7ResultParser) IsParsable(testName string, data []byte) (string, bool) {
 	// Files look like: "<UUID>.json"
-	if strings.HasPrefix(testName, "ndt7") && strings.HasSuffix(testName, "json") {
+	// ndt7-{upload,download}-YYYYMMDDTHHMMSS.066461502Z.<UUID>.json.gz
+	if strings.HasPrefix(testName, "ndt7") && (strings.HasSuffix(testName, "json.gz") || strings.HasSuffix(testName, "json")) {
 		return "ndt7_result", true
 	}
 	return "unknown", false

--- a/parser/ndt7_result.go
+++ b/parser/ndt7_result.go
@@ -56,7 +56,7 @@ func (dp *NDT7ResultParser) TaskError() error {
 
 // IsParsable returns the canonical test type and whether to parse data.
 func (dp *NDT7ResultParser) IsParsable(testName string, data []byte) (string, bool) {
-	// Files look like: "<UUID>.json"
+	// Files look like:
 	// ndt7-{upload,download}-YYYYMMDDTHHMMSS.066461502Z.<UUID>.json.gz
 	if strings.HasPrefix(testName, "ndt7") && (strings.HasSuffix(testName, "json.gz") || strings.HasSuffix(testName, "json")) {
 		return "ndt7_result", true


### PR DESCRIPTION
This fixes a bug in the ndt7 parser `IsParsable` to recognize `.json.gz` files which is the typical output format for ndt7 datatype.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/861)
<!-- Reviewable:end -->
