### PR TITLE
Fix IsParsable again

### DIFF
--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"log"
 	"net/http"
@@ -255,6 +256,7 @@ var mainCtx, mainCancel = context.WithCancel(context.Background())
 
 func main() {
 	defer mainCancel()
+	flag.Parse()
 
 	// Expose prometheus and pprof metrics on a separate port.
 	prometheusx.MustStartPrometheus(":9090")
@@ -285,5 +287,5 @@ func main() {
 	} else {
 		log.Println("GARDENER_HOST not specified or empty")
 	}
-	http.ListenAndServe(":8080", nil)
+	rtx.Must(http.ListenAndServe(":8080", nil), "failed to listen")
 }


### PR DESCRIPTION
This change really fixes the is parsable bug for ndt7. This also adds flag parsing to the etl_worker to begin using logx.Debug logs in some places.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/862)
<!-- Reviewable:end -->
