### PR TITLE
Factories for sink, source, and annotator

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,13 @@ The row.Sink interface, and row.Buffer define cleaner APIs for the back end
 and for buffering and annotating.  This will streamline migration to
 Gardener driven table selection, column partitioned tables, and possibly
 future migration to BigQuery loads instead of streaming inserts.
+
+## Factories
+
+The TaskFactory aggregates a number of other factories for the elements
+required for a Task
+
+* SinkFactory produces a Sink for output.
+* SourceFactory produces a Source for the input data.
+* AnnotatorFactory produces an Annotator to be used to annotate rows.
+* ParserFactory produces a Parser that can parse the Source data.

--- a/bq/bq_test.go
+++ b/bq/bq_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/m-lab/etl/bq"
 	"github.com/m-lab/etl/etl"
+	"github.com/m-lab/etl/factory"
 	"github.com/m-lab/etl/fake"
 )
 
@@ -22,6 +23,10 @@ func init() {
 
 func assertInserter(in etl.Inserter) {
 	func(in etl.Inserter) {}(&bq.BQInserter{})
+}
+
+func assertSinkFactory(f factory.SinkFactory) {
+	func(f factory.SinkFactory) {}(&bq.SinkFactory{})
 }
 
 func foobar(vs bigquery.ValueSaver) {

--- a/bq/bq_test.go
+++ b/bq/bq_test.go
@@ -26,7 +26,7 @@ func assertInserter(in etl.Inserter) {
 }
 
 func assertSinkFactory(f factory.SinkFactory) {
-	func(f factory.SinkFactory) {}(&bq.SinkFactory{})
+	func(f factory.SinkFactory) {}(bq.DefaultSinkFactory())
 }
 
 func foobar(vs bigquery.ValueSaver) {

--- a/bq/insert.go
+++ b/bq/insert.go
@@ -104,6 +104,21 @@ func NewColumnPartitionedInserterWithUploader(pdt bqx.PDT, uploader etl.Uploader
 	return sink, nil
 }
 
+// SinkFactory implements factory.SinkFactory.
+type SinkFactory struct {
+	uploader etl.Uploader
+}
+
+// Get mplements factory.SinkFactory
+func (sf *SinkFactory) Get(
+	ctx context.Context, path etl.DataPath) (row.Sink, error) {
+
+	dt := path.GetDataType()
+	pdt :=
+		bqx.PDT{Project: dt.BigqueryProject(), Dataset: dt.Dataset(), Table: dt.Table()}
+	return NewColumnPartitionedInserterWithUploader(pdt, sf.uploader)
+}
+
 // NewBQInserter initializes a new BQInserter
 // Pass in nil uploader for normal use, custom uploader for custom behavior
 // TODO - improve the naming between here and NewInserter.

--- a/etl/globals.go
+++ b/etl/globals.go
@@ -126,7 +126,7 @@ func ValidateTestPath(path string) (DataPath, error) {
 
 	dataType := dp.GetDataType()
 	if dataType == INVALID {
-		metrics.TaskCount.WithLabelValues(dp.TableBase(), "worker", "BadRequest").Inc()
+		metrics.TaskCount.WithLabelValues(string(dataType), "BadRequest").Inc()
 		log.Printf("Invalid filename: %s\n", path)
 		return DataPath{}, ErrBadDataType
 	}

--- a/etl/globals.go
+++ b/etl/globals.go
@@ -76,6 +76,8 @@ var (
 
 // DataPath breaks out the components of a task filename.
 type DataPath struct {
+	URI string // The full URI
+
 	// These fields are from the bucket and path
 	Bucket   string // the GCS bucket name.
 	ExpDir   string // the experiment directory.
@@ -109,6 +111,7 @@ func ValidateTestPath(path string) (DataPath, error) {
 		return DataPath{}, errors.New("Invalid postamble: " + basic[5])
 	}
 	dp := DataPath{
+		URI:        path,
 		Bucket:     preamble[1],
 		ExpDir:     preamble[2],
 		DataType:   preamble[3],

--- a/etl/globals_test.go
+++ b/etl/globals_test.go
@@ -53,6 +53,7 @@ func TestValidateTestPath(t *testing.T) {
 			path:     `gs://m-lab-sandbox/ndt/2016/01/26/20160126T000000Z-mlab1-prg01-ndt-0007.tgz`,
 			wantType: etl.NDT,
 			want: etl.DataPath{
+				`gs://m-lab-sandbox/ndt/2016/01/26/20160126T000000Z-mlab1-prg01-ndt-0007.tgz`,
 				"m-lab-sandbox", "", "ndt", "2016/01/26", "20160126", "000000", "", "mlab1", "prg01", "ndt", "0007", "", ".tgz",
 			},
 		},
@@ -61,6 +62,7 @@ func TestValidateTestPath(t *testing.T) {
 			path:     `gs://m-lab-sandbox/ndt/2016/07/14/20160714T123456Z-mlab1-lax04-ndt-0001.tar`,
 			wantType: etl.NDT,
 			want: etl.DataPath{
+				`gs://m-lab-sandbox/ndt/2016/07/14/20160714T123456Z-mlab1-lax04-ndt-0001.tar`,
 				"m-lab-sandbox", "", "ndt", "2016/07/14", "20160714", "123456", "", "mlab1", "lax04", "ndt", "0001", "", ".tar",
 			},
 		},
@@ -69,6 +71,7 @@ func TestValidateTestPath(t *testing.T) {
 			path:     `gs://m-lab-sandbox/ndt/2016/07/14/20160714T123456Z-mlab1-lax04-ndt-0001.tar.gz`,
 			wantType: etl.NDT,
 			want: etl.DataPath{
+				`gs://m-lab-sandbox/ndt/2016/07/14/20160714T123456Z-mlab1-lax04-ndt-0001.tar`,
 				"m-lab-sandbox", "", "ndt", "2016/07/14", "20160714", "123456", "", "mlab1", "lax04", "ndt", "0001", "", ".tar.gz",
 			},
 		},
@@ -77,6 +80,7 @@ func TestValidateTestPath(t *testing.T) {
 			path:     `gs://embargo-mlab-oti/sidestream/2018/02/27/20180227T000010Z-mlab1-dfw02-sidestream-0000-e.tgz`,
 			wantType: etl.SS,
 			want: etl.DataPath{
+				`gs://embargo-mlab-oti/sidestream/2018/02/27/20180227T000010Z-mlab1-dfw02-sidestream-0000-e.tgz`,
 				"embargo-mlab-oti", "", "sidestream", "2018/02/27", "20180227", "000010", "", "mlab1", "dfw02", "sidestream", "0000", "-e", ".tgz",
 			},
 		},
@@ -85,6 +89,7 @@ func TestValidateTestPath(t *testing.T) {
 			path:     `gs://pusher-mlab-staging/ndt/tcpinfo/2019/05/25/20190525T020001.697396Z-tcpinfo-mlab4-ord01-ndt.tgz`,
 			wantType: etl.TCPINFO,
 			want: etl.DataPath{
+				`gs://pusher-mlab-staging/ndt/tcpinfo/2019/05/25/20190525T020001.697396Z-tcpinfo-mlab4-ord01-ndt.tgz`,
 				"pusher-mlab-staging", "ndt", "tcpinfo", "2019/05/25", "20190525", "020001", "tcpinfo", "mlab4", "ord01", "ndt", "", "", ".tgz",
 			},
 		},
@@ -93,6 +98,7 @@ func TestValidateTestPath(t *testing.T) {
 			path:     `gs://archive-mlab-oti/paris-traceroute/2019/06/11/20190611T000002Z-mlab2-bom01-paris-traceroute-0000.tgz`,
 			wantType: etl.PT,
 			want: etl.DataPath{
+				`gs://archive-mlab-oti/paris-traceroute/2019/06/11/20190611T000002Z-mlab2-bom01-paris-traceroute-0000.tgz`,
 				"archive-mlab-oti", "", "paris-traceroute", "2019/06/11", "20190611", "000002", "", "mlab2", "bom01", "paris-traceroute", "0000", "", ".tgz",
 			},
 		},
@@ -101,6 +107,7 @@ func TestValidateTestPath(t *testing.T) {
 			path:     `gs://archive-mlab-oti/ndt/traceroute/2019/06/20/20190620T224809.435046Z-traceroute-mlab1-den06-ndt.tgz`,
 			wantType: etl.PT,
 			want: etl.DataPath{
+				`gs://archive-mlab-oti/ndt/traceroute/2019/06/20/20190620T224809.435046Z-traceroute-mlab1-den06-ndt.tgz`,
 				"archive-mlab-oti", "ndt", "traceroute", "2019/06/20", "20190620", "224809", "traceroute", "mlab1", "den06", "ndt", "", "", ".tgz",
 			},
 		},

--- a/etl/globals_test.go
+++ b/etl/globals_test.go
@@ -71,7 +71,7 @@ func TestValidateTestPath(t *testing.T) {
 			path:     `gs://m-lab-sandbox/ndt/2016/07/14/20160714T123456Z-mlab1-lax04-ndt-0001.tar.gz`,
 			wantType: etl.NDT,
 			want: etl.DataPath{
-				`gs://m-lab-sandbox/ndt/2016/07/14/20160714T123456Z-mlab1-lax04-ndt-0001.tar`,
+				`gs://m-lab-sandbox/ndt/2016/07/14/20160714T123456Z-mlab1-lax04-ndt-0001.tar.gz`,
 				"m-lab-sandbox", "", "ndt", "2016/07/14", "20160714", "123456", "", "mlab1", "lax04", "ndt", "0001", "", ".tar.gz",
 			},
 		},
@@ -127,7 +127,7 @@ func TestValidateTestPath(t *testing.T) {
 			if !tt.wantErr {
 				if diff := deep.Equal(got, tt.want); diff != nil {
 					log.Println(tt.path)
-					t.Errorf("ValidateTestPath() = %v\n", diff)
+					t.Errorf("%s: %v\n", tt.name, diff)
 				}
 			}
 		})

--- a/factory/factory.go
+++ b/factory/factory.go
@@ -1,0 +1,49 @@
+// Package factory provides factory definitions.
+// It may cause import cycles and have to be broken up.S
+package factory
+
+import (
+	"context"
+
+	"github.com/m-lab/annotation-service/api/v2"
+
+	"github.com/m-lab/etl/etl"
+	"github.com/m-lab/etl/row"
+	"github.com/m-lab/etl/task"
+)
+
+// ProcessingError extends error to provide  dataType and detail for metrics.
+type ProcessingError struct {
+	DataType string
+	Detail   string
+	Code     int
+	error
+}
+
+// NewError creates a new ProcessingError.
+func NewError(dt, detail string, code int, err error) *ProcessingError {
+	return &ProcessingError{dt, detail, code, err}
+}
+
+// TaskFactory provides Get() which always returns a new, complete Task.
+// TODO for the defs that stay in factory package, remove ...Factory.
+type TaskFactory interface {
+	Get(context.Context, etl.DataPath) (*task.Task, *ProcessingError)
+}
+
+// AnnotatorFactory provides Get() which always returns a new or existing Annotator.
+type AnnotatorFactory interface {
+	Get(context.Context, etl.DataPath) (api.Annotator, *ProcessingError)
+}
+
+// SinkFactory provides Get() which may return a new or existing Sink.
+// If existing Sink, the Commit method must support concurrent calls.
+// Existing Sink may or may not respect the context.
+type SinkFactory interface {
+	Get(context.Context, etl.DataPath) (row.Sink, *ProcessingError)
+}
+
+// SourceFactory provides Get() which always produces a new TestSource.
+type SourceFactory interface {
+	Get(context.Context, etl.DataPath) (etl.TestSource, *ProcessingError)
+}

--- a/factory/factory.go
+++ b/factory/factory.go
@@ -4,11 +4,15 @@ package factory
 
 import (
 	"context"
+	"log"
+	"net/http"
 
-	"github.com/m-lab/annotation-service/api/v2"
+	v2 "github.com/m-lab/annotation-service/api/v2"
 
+	"github.com/m-lab/etl/annotation"
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/row"
+	"github.com/m-lab/etl/storage"
 	"github.com/m-lab/etl/task"
 )
 
@@ -33,7 +37,7 @@ type TaskFactory interface {
 
 // AnnotatorFactory provides Get() which always returns a new or existing Annotator.
 type AnnotatorFactory interface {
-	Get(context.Context, etl.DataPath) (api.Annotator, *ProcessingError)
+	Get(context.Context, etl.DataPath) (v2.Annotator, *ProcessingError)
 }
 
 // SinkFactory provides Get() which may return a new or existing Sink.
@@ -46,4 +50,51 @@ type SinkFactory interface {
 // SourceFactory provides Get() which always produces a new TestSource.
 type SourceFactory interface {
 	Get(context.Context, etl.DataPath) (etl.TestSource, *ProcessingError)
+}
+
+type defaultAnnotatorFactory struct{}
+
+// Get implements AnnotatorFactory.Get
+func (ann *defaultAnnotatorFactory) Get(ctx context.Context, dp etl.DataPath) (v2.Annotator, *ProcessingError) {
+	return v2.GetAnnotator(annotation.BatchURL), nil
+}
+
+// DefaultAnnotatorFactory returns the annotation service annotator.
+func DefaultAnnotatorFactory() AnnotatorFactory {
+	return &defaultAnnotatorFactory{}
+}
+
+type defaultSourceFactory struct{}
+
+// Get implements SourceFactory.Get
+func (ann *defaultSourceFactory) Get(ctx context.Context, dp etl.DataPath) (etl.TestSource, *ProcessingError) {
+	label := dp.TableBase() // On error, this will be "invalid", so not all that useful.
+	client, err := storage.GetStorageClient(false)
+	if err != nil {
+		log.Printf("Error getting storage client: %v\n", err)
+		return nil, NewError(dp.DataType, "ServiceUnavailable",
+			http.StatusServiceUnavailable, err)
+	}
+
+	// TODO - is this already handled upstream?
+	dataType := dp.GetDataType()
+	if dataType == etl.INVALID {
+		return nil, NewError(dp.DataType, "InvalidDatatype",
+			http.StatusInternalServerError, err)
+	}
+
+	tr, err := storage.NewTestSource(client, dp.URI, label)
+	if err != nil {
+		log.Printf("Error opening gcs file: %v", err)
+		// TODO - anything better we could do here?
+		return nil, NewError(dp.DataType, "ETLSourceError",
+			http.StatusInternalServerError, err)
+	}
+
+	return tr, nil
+}
+
+// DefaultSourceFactory returns the default SourceFactory
+func DefaultSourceFactory() SourceFactory {
+	return &defaultSourceFactory{}
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -165,6 +165,7 @@ var (
 			Name: "etl_files_processed",
 			Help: "Number of files processed.",
 		},
+		// TODO maybe change to host and exp/type?  Maybe drop day_of_week?
 		[]string{"rsync_host_module", "day_of_week"},
 	)
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -179,8 +179,8 @@ var (
 			Name: "etl_task_count",
 			Help: "Number of tasks/archive files processed.",
 		},
-		// Go package or filename, and Status
-		[]string{"table", "package", "status"},
+		// table/datatype, and Status
+		[]string{"table", "status"},
 	)
 
 	// TestCount counts the number of tests successfully processed by the parsers.

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -99,7 +99,7 @@ func TestMetrics(t *testing.T) {
 	metrics.PTPollutedCount.WithLabelValues("x")
 	metrics.PTTestCount.WithLabelValues("x")
 	metrics.RowSizeHistogram.WithLabelValues("x")
-	metrics.TaskCount.WithLabelValues("x", "x", "x")
+	metrics.TaskCount.WithLabelValues("x", "x")
 	metrics.TestCount.WithLabelValues("x", "x", "x")
 	metrics.WarningCount.WithLabelValues("x", "x", "x")
 	metrics.WorkerCount.WithLabelValues("x")

--- a/parser/annotation.go
+++ b/parser/annotation.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"strings"
@@ -8,8 +9,8 @@ import (
 
 	"cloud.google.com/go/bigquery"
 
+	"github.com/m-lab/annotation-service/api"
 	v2as "github.com/m-lab/annotation-service/api/v2"
-	"github.com/m-lab/etl/annotation"
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/metrics"
 	"github.com/m-lab/etl/row"
@@ -27,11 +28,17 @@ type AnnotationParser struct {
 	suffix string
 }
 
+type nullAnnotator struct{}
+
+func (ann *nullAnnotator) GetAnnotations(ctx context.Context, date time.Time, ips []string, info ...string) (*v2as.Response, error) {
+	return &v2as.Response{AnnotatorDate: time.Now(), Annotations: make(map[string]*api.Annotations, 0)}, nil
+}
+
 // NewAnnotationParser creates a new parser for annotation data.
 func NewAnnotationParser(sink row.Sink, table, suffix string, ann v2as.Annotator) etl.Parser {
 	bufSize := etl.ANNOTATION.BQBufferSize()
 	if ann == nil {
-		ann = v2as.GetAnnotator(annotation.BatchURL)
+		ann = &nullAnnotator{}
 	}
 
 	return &AnnotationParser{

--- a/parser/annotation.go
+++ b/parser/annotation.go
@@ -42,7 +42,7 @@ func NewAnnotationParser(sink row.Sink, table, suffix string, ann v2as.Annotator
 	}
 
 	return &AnnotationParser{
-		Base:   row.NewBase("foobar", sink, bufSize, ann),
+		Base:   row.NewBase(table, sink, bufSize, ann),
 		table:  table,
 		suffix: suffix,
 	}

--- a/parser/ndt5_result.go
+++ b/parser/ndt5_result.go
@@ -38,7 +38,7 @@ func NewNDT5ResultParser(sink row.Sink, table, suffix string, ann v2as.Annotator
 	}
 
 	return &NDT5ResultParser{
-		Base:   row.NewBase("foobar", sink, bufSize, ann),
+		Base:   row.NewBase(table, sink, bufSize, ann),
 		table:  table,
 		suffix: suffix,
 	}

--- a/parser/ndt7_result.go
+++ b/parser/ndt7_result.go
@@ -39,7 +39,7 @@ func NewNDT7ResultParser(sink row.Sink, table, suffix string, ann v2as.Annotator
 	}
 
 	return &NDT7ResultParser{
-		Base:   row.NewBase("foobar", sink, bufSize, ann),
+		Base:   row.NewBase(table, sink, bufSize, ann),
 		table:  table,
 		suffix: suffix,
 	}

--- a/parser/tcpinfo.go
+++ b/parser/tcpinfo.go
@@ -204,7 +204,7 @@ func NewTCPInfoParser(sink row.Sink, table, suffix string, ann v2as.Annotator) *
 	}
 
 	return &TCPInfoParser{
-		Base:   row.NewBase("foobar", sink, bufSize, ann),
+		Base:   row.NewBase("tcpinfo", sink, bufSize, ann),
 		table:  table,
 		suffix: suffix,
 	}

--- a/storage/rowwriter.go
+++ b/storage/rowwriter.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"log"
 
 	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
+	"github.com/m-lab/etl/etl"
 )
 
 // ObjectWriter creates a writer to a named object.
@@ -40,6 +42,17 @@ func NewRowWriter(ctx context.Context, client stiface.Client, bucket string, pat
 	writing <- struct{}{}
 
 	return &RowWriter{w: w, encoding: encoding, writing: writing}, nil
+}
+
+// SinkFactory implements factory.SinkFactory.
+type SinkFactory struct {
+	client stiface.Client
+}
+
+// Get mplements factory.SinkFactory
+func (sf *SinkFactory) Get(
+	ctx context.Context, path etl.DataPath) (*RowWriter, error) {
+	return nil, errors.New("not implemented")
 }
 
 // Acquire the encoding token.

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -189,6 +189,7 @@ func ProcessGKETask(path etl.DataPath, tf factory.TaskFactory) *factory.Processi
 // DoGKETask creates task, processes all tests and handle metrics
 func DoGKETask(tsk *task.Task, path etl.DataPath) *factory.ProcessingError {
 	files, err := tsk.ProcessAllTests()
+	tsk.Close()
 
 	dateFormat := "20060102"
 	date, dateErr := time.Parse(dateFormat, path.PackedDate)

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -134,12 +134,13 @@ func ProcessTestSource(src etl.TestSource, path etl.DataPath) (int, error) {
 }
 
 // ProcessGKETask interprets a filename to create a Task, Parser, and Inserter,
-// and processes the file content.  The inserter is customized to write to column partitioned tables.
-// It is currently used in the GKE parser instances, but will eventually replace ProcessTask for
-// all parser/task types.
+// and processes the file content.
+// Used default BQ Sink, and GCS Source.
 // Returns an http status code and an error if the task did not complete successfully.
-// TODO pass in the configured Sink object, instead of creating based on datatype.
-func ProcessGKETask(fn string, pdt bqx.PDT, ann api.Annotator) (int, error) {
+func ProcessGKETask(fn string, path etl.DataPath, ann api.Annotator) (int, error) {
+	dataType := path.GetDataType()
+	pdt := bqx.PDT{Project: dataType.BigqueryProject(), Dataset: dataType.Dataset(), Table: dataType.Table()}
+
 	bqClient, err := bq.GetClient(pdt.Project)
 	if err != nil {
 		return http.StatusInternalServerError, err
@@ -211,7 +212,6 @@ func ProcessGKESourceSink(fn string, path etl.DataPath, src etl.TestSource, sink
 // DoGKETask creates task, processes all tests and handle metrics
 func DoGKETask(fn string, path etl.DataPath, src etl.TestSource, parser etl.Parser) (int, error) {
 	tsk := task.NewTask(fn, src, parser)
-
 	files, err := tsk.ProcessAllTests()
 
 	dateFormat := "20060102"

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -3,6 +3,7 @@ package worker_test
 import (
 	"archive/tar"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -21,9 +22,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 
+	"github.com/m-lab/etl/bq"
 	"github.com/m-lab/etl/etl"
+	"github.com/m-lab/etl/factory"
 	"github.com/m-lab/etl/fake"
 	"github.com/m-lab/etl/metrics"
+	"github.com/m-lab/etl/row"
 	"github.com/m-lab/etl/worker"
 
 	"github.com/fsouza/fake-gcs-server/fakestorage"
@@ -134,35 +138,98 @@ func TestProcessTask(t *testing.T) {
 	metrics.TestCount.Reset()
 }
 
+// This is also a factory
 type fakeAnnotator struct{}
 
 func (ann *fakeAnnotator) GetAnnotations(ctx context.Context, date time.Time, ips []string, info ...string) (*v2.Response, error) {
 	return &v2.Response{AnnotatorDate: time.Now(), Annotations: make(map[string]*api.Annotations, 0)}, nil
 }
 
-// Enable this test when we have fixed the prom counter resets.
+func (ann *fakeAnnotator) Get(ctx context.Context, dp etl.DataPath) (v2.Annotator, *factory.ProcessingError) {
+	return ann, nil
+}
+
+type fakeSinkFactory struct {
+	up etl.Uploader
+}
+
+func (fsf *fakeSinkFactory) Get(ctx context.Context, dp etl.DataPath) (row.Sink, *factory.ProcessingError) {
+	if fsf.up == nil {
+		return nil, factory.NewError(dp.DataType, "fakeSinkFactory",
+			http.StatusInternalServerError, errors.New("nil uploader"))
+	}
+	pdt := bqx.PDT{Project: "fake-project", Dataset: "fake-dataset", Table: "fake-table"}
+	in, err := bq.NewColumnPartitionedInserterWithUploader(pdt, fsf.up)
+	rtx.Must(err, "Bad SinkFactory")
+	return in, nil
+}
+
+type fakeSourceFactory struct {
+	client *storage.Client
+}
+
+func (sf *fakeSourceFactory) Get(ctx context.Context, dp etl.DataPath) (etl.TestSource, *factory.ProcessingError) {
+	// TODO simplify GetSource
+	tr, _, _, err := worker.GetSource(sf.client, dp.URI)
+	rtx.Must(err, "Bad TestSource")
+
+	// TODO
+	// defer tr.Close()
+
+	return tr, nil
+}
+
+func NewSourceFactory() factory.SourceFactory {
+	gcsClient := fromTar("test-bucket", "../testfiles/ndt.tar").Client()
+	return &fakeSourceFactory{client: gcsClient}
+}
+
+func TestNilUploader(t *testing.T) {
+	if testing.Short() {
+		t.Log("Skipping integration test")
+	}
+
+	fakeFactory := worker.StandardTaskFactory{
+		Ann:    &fakeAnnotator{},
+		Sink:   &fakeSinkFactory{up: nil},
+		Source: NewSourceFactory(),
+	}
+
+	filename := "gs://test-bucket/ndt/ndt5/2019/12/01/20191201T020011.395772Z-ndt5-mlab1-bcn01-ndt.tgz"
+	path, err := etl.ValidateTestPath(filename)
+	if err != nil {
+		t.Fatal(err, filename)
+	}
+	// TODO create a TaskFactory and use ProcessGKETask
+	status, err := worker.ProcessGKETask(path, &fakeFactory)
+	if status != http.StatusInternalServerError {
+		t.Fatal("Expected", http.StatusInternalServerError, "Got:", status)
+	}
+
+	metrics.FileCount.Reset()
+	metrics.TaskCount.Reset()
+	metrics.TestCount.Reset()
+}
+
 func TestProcessGKETask(t *testing.T) {
 	if testing.Short() {
 		t.Log("Skipping integration test")
 	}
 
-	gcsClient := fromTar("test-bucket", "../testfiles/ndt.tar").Client()
+	up := fake.NewFakeUploader()
+	fakeFactory := worker.StandardTaskFactory{
+		Ann:    &fakeAnnotator{},
+		Sink:   &fakeSinkFactory{up: up},
+		Source: NewSourceFactory(),
+	}
+
 	filename := "gs://test-bucket/ndt/ndt5/2019/12/01/20191201T020011.395772Z-ndt5-mlab1-bcn01-ndt.tgz"
-	data, err := etl.ValidateTestPath(filename)
+	path, err := etl.ValidateTestPath(filename)
 	if err != nil {
 		t.Fatal(err, filename)
 	}
-
-	// HACK - clean this up.
-	dataType := data.GetDataType()
-	pdt := bqx.PDT{Project: dataType.BigqueryProject(), Dataset: dataType.Dataset(), Table: dataType.Table()}
-
-	up := fake.NewFakeUploader()
-	status, err := worker.ProcessGKETaskWithClient(
-		filename, pdt, gcsClient, up, &fakeAnnotator{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	// TODO create a TaskFactory and use ProcessGKETask
+	status, err := worker.ProcessGKETask(path, &fakeFactory)
 	if status != http.StatusOK {
 		t.Fatal("Expected", http.StatusOK, "Got:", status)
 	}

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -201,9 +201,9 @@ func TestNilUploader(t *testing.T) {
 		t.Fatal(err, filename)
 	}
 	// TODO create a TaskFactory and use ProcessGKETask
-	status, err := worker.ProcessGKETask(path, &fakeFactory)
-	if status != http.StatusInternalServerError {
-		t.Fatal("Expected", http.StatusInternalServerError, "Got:", status)
+	pErr := worker.ProcessGKETask(path, &fakeFactory)
+	if pErr == nil || pErr.Code != http.StatusInternalServerError {
+		t.Fatal("Expected error with", http.StatusInternalServerError, "Got:", pErr)
 	}
 
 	metrics.FileCount.Reset()
@@ -229,9 +229,9 @@ func TestProcessGKETask(t *testing.T) {
 		t.Fatal(err, filename)
 	}
 	// TODO create a TaskFactory and use ProcessGKETask
-	status, err := worker.ProcessGKETask(path, &fakeFactory)
-	if status != http.StatusOK {
-		t.Fatal("Expected", http.StatusOK, "Got:", status)
+	pErr := worker.ProcessGKETask(path, &fakeFactory)
+	if pErr != nil {
+		t.Fatal("Expected", http.StatusOK, "Got:", pErr)
 	}
 
 	// This section checks that prom metrics are updated appropriately.


### PR DESCRIPTION
This introduces factories that can be provided as the context for Job/Task processing.  The factories are used to create the TestSource, row.Sink, and Annotator.

This allows configuration at a high level for testing, or for using storage vs bigquery backend.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/863)
<!-- Reviewable:end -->
