### PR TITLE
Integrate factories into processing flow.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,13 @@ The row.Sink interface, and row.Buffer define cleaner APIs for the back end
 and for buffering and annotating.  This will streamline migration to
 Gardener driven table selection, column partitioned tables, and possibly
 future migration to BigQuery loads instead of streaming inserts.
+
+## Factories
+
+The TaskFactory aggregates a number of other factories for the elements
+required for a Task.  Factory injection is used to generalize
+ProcessGKETask, and simplify testing.
+
+* SinkFactory produces a Sink for output.
+* SourceFactory produces a Source for the input data.
+* AnnotatorFactory produces an Annotator to be used to annotate rows.

--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -14,17 +14,18 @@ import (
 	"sync/atomic"
 	"time"
 
-	"cloud.google.com/go/storage"
+	gcs "cloud.google.com/go/storage"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	"github.com/m-lab/go/bqx"
 	"github.com/m-lab/go/prometheusx"
 	"github.com/m-lab/go/rtx"
 
 	"github.com/m-lab/etl/active"
 	"github.com/m-lab/etl/bq"
 	"github.com/m-lab/etl/etl"
+	"github.com/m-lab/etl/factory"
 	"github.com/m-lab/etl/metrics"
+	"github.com/m-lab/etl/storage"
 	"github.com/m-lab/etl/worker"
 
 	// Enable profiling. For more background and usage information, see:
@@ -121,7 +122,7 @@ func handleRequest(rwr http.ResponseWriter, rq *http.Request) {
 
 	// Throttle by grabbing a semaphore from channel.
 	if shouldThrottle() {
-		metrics.TaskCount.WithLabelValues("unknown", "worker", "TooManyRequests").Inc()
+		metrics.TaskCount.WithLabelValues("unknown", "TooManyRequests").Inc()
 		rwr.WriteHeader(http.StatusTooManyRequests)
 		fmt.Fprintf(rwr, `{"message": "Too many tasks."}`)
 		return
@@ -177,7 +178,7 @@ func subworker(rawFileName string, executionCount, retryCount int, age time.Dura
 	// This handles base64 encoding, and requires a gs:// prefix.
 	fn, err := etl.GetFilename(rawFileName)
 	if err != nil {
-		metrics.TaskCount.WithLabelValues("unknown", "worker", "BadRequest").Inc()
+		metrics.TaskCount.WithLabelValues("unknown", "BadRequest").Inc()
 		log.Printf("Invalid filename: %s\n", fn)
 		return http.StatusBadRequest, `{"message": "Invalid filename."}`
 	}
@@ -217,36 +218,28 @@ func setMaxInFlight() {
 }
 
 type runnable struct {
-	storage.ObjectAttrs
+	tf factory.TaskFactory
+	gcs.ObjectAttrs
 }
 
 func (r *runnable) Run() error {
 	path := fmt.Sprintf("gs://%s/%s", r.Bucket, r.Name)
-	data, err := etl.ValidateTestPath(path)
+	dp, err := etl.ValidateTestPath(path)
 	if err != nil {
 		log.Printf("Invalid filename: %v\n", err)
 		return err
 	}
 
-	// TODO This is short term hack to fix the injection bug.
-	// It will be removed in the third PR that introduces Factories
-	dataType := data.GetDataType()
-	pdt := bqx.PDT{Project: dataType.BigqueryProject(), Dataset: dataType.Dataset(), Table: dataType.Table()}
-	client, err := bq.GetClient(pdt.Project)
-	if err != nil {
-		return err
-	}
-	up := client.Dataset(pdt.Dataset).Table(pdt.Table).Uploader()
-	// This avoids problems when a single row of the insert has invalid
-	// data.  We then have to carefully parse the returned error object.
-	up.SkipInvalidRows = true
-
 	start := time.Now()
 	log.Println("Processing", path)
-	// TODO pass in storage client, or pass in TestSource.
-	statusCode, err := worker.ProcessGKETask(path, up, nil) // Use default uploader and annotator
+
+	statusCode := http.StatusOK
+	pErr := worker.ProcessGKETask(dp, r.tf)
+	if pErr != nil {
+		statusCode = pErr.Code()
+	}
 	metrics.DurationHistogram.WithLabelValues(
-		data.DataType, http.StatusText(statusCode)).Observe(
+		dp.DataType, http.StatusText(statusCode)).Observe(
 		time.Since(start).Seconds())
 	return err
 }
@@ -256,8 +249,17 @@ func (r *runnable) Info() string {
 	return r.Name
 }
 
-func toRunnable(obj *storage.ObjectAttrs) active.Runnable {
-	return &runnable{*obj}
+func toRunnable(obj *gcs.ObjectAttrs) active.Runnable {
+	c, err := storage.GetStorageClient(false)
+	if err != nil {
+		return nil // TODO add an error?
+	}
+	taskFactory := worker.StandardTaskFactory{
+		Ann:    factory.DefaultAnnotatorFactory(),
+		Sink:   bq.NewSinkFactory(),
+		Source: factory.GCSSourceFactory(c),
+	}
+	return &runnable{&taskFactory, *obj}
 }
 
 func mustGardenerAPI(ctx context.Context, jobServer string) *active.GardenerAPI {

--- a/etl/globals.go
+++ b/etl/globals.go
@@ -129,7 +129,7 @@ func ValidateTestPath(path string) (DataPath, error) {
 
 	dataType := dp.GetDataType()
 	if dataType == INVALID {
-		metrics.TaskCount.WithLabelValues(dp.TableBase(), "worker", "BadRequest").Inc()
+		metrics.TaskCount.WithLabelValues(string(dataType), "BadRequest").Inc()
 		log.Printf("Invalid filename: %s\n", path)
 		return DataPath{}, ErrBadDataType
 	}

--- a/factory/factory.go
+++ b/factory/factory.go
@@ -14,6 +14,7 @@ import (
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/row"
 	"github.com/m-lab/etl/storage"
+	"github.com/m-lab/etl/task"
 )
 
 // ProcessingError extends error to provide dataType and detail for metrics,
@@ -47,6 +48,12 @@ func (pe processingError) Code() int {
 // NewError creates a new ProcessingError.
 func NewError(dt, detail string, code int, err error) ProcessingError {
 	return processingError{dt, detail, code, err}
+}
+
+// TaskFactory provides Get() which always returns a new, complete Task.
+// TODO for the defs that stay in factory package, remove ...Factory.
+type TaskFactory interface {
+	Get(context.Context, etl.DataPath) (*task.Task, ProcessingError)
 }
 
 // AnnotatorFactory provides Get() which always returns a new or existing Annotator.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -165,6 +165,7 @@ var (
 			Name: "etl_files_processed",
 			Help: "Number of files processed.",
 		},
+		// TODO maybe change to host and exp/type?  Maybe drop day_of_week?
 		[]string{"rsync_host_module", "day_of_week"},
 	)
 
@@ -179,8 +180,8 @@ var (
 			Name: "etl_task_count",
 			Help: "Number of tasks/archive files processed.",
 		},
-		// Go package or filename, and Status
-		[]string{"table", "package", "status"},
+		// table/datatype, and Status
+		[]string{"table", "status"},
 	)
 
 	// TestCount counts the number of tests successfully processed by the parsers.

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -99,7 +99,7 @@ func TestMetrics(t *testing.T) {
 	metrics.PTPollutedCount.WithLabelValues("x")
 	metrics.PTTestCount.WithLabelValues("x")
 	metrics.RowSizeHistogram.WithLabelValues("x")
-	metrics.TaskCount.WithLabelValues("x", "x", "x")
+	metrics.TaskCount.WithLabelValues("x", "x")
 	metrics.TestCount.WithLabelValues("x", "x", "x")
 	metrics.WarningCount.WithLabelValues("x", "x", "x")
 	metrics.WorkerCount.WithLabelValues("x")

--- a/storage/rowwriter.go
+++ b/storage/rowwriter.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"log"
 
 	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
+	"github.com/m-lab/etl/etl"
 )
 
 // ObjectWriter creates a writer to a named object.
@@ -40,6 +42,17 @@ func NewRowWriter(ctx context.Context, client stiface.Client, bucket string, pat
 	writing <- struct{}{}
 
 	return &RowWriter{w: w, encoding: encoding, writing: writing}, nil
+}
+
+// SinkFactory implements factory.SinkFactory.
+type SinkFactory struct {
+	client stiface.Client
+}
+
+// Get mplements factory.SinkFactory
+func (sf *SinkFactory) Get(
+	ctx context.Context, path etl.DataPath) (*RowWriter, error) {
+	return nil, errors.New("not implemented")
 }
 
 // Acquire the encoding token.

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -8,11 +9,9 @@ import (
 
 	gcs "cloud.google.com/go/storage"
 
-	"github.com/m-lab/annotation-service/api/v2"
-	"github.com/m-lab/go/bqx"
-
 	"github.com/m-lab/etl/bq"
 	"github.com/m-lab/etl/etl"
+	"github.com/m-lab/etl/factory"
 	"github.com/m-lab/etl/metrics"
 	"github.com/m-lab/etl/parser"
 	"github.com/m-lab/etl/storage"
@@ -25,7 +24,7 @@ func GetSource(client *gcs.Client, uri string) (etl.TestSource, etl.DataPath, in
 	path, err := etl.ValidateTestPath(uri)
 	label := path.TableBase() // On error, this will be "invalid", so not all that useful.
 	if err != nil {
-		metrics.TaskCount.WithLabelValues(label, "worker", "InvalidFilename").Inc()
+		metrics.TaskCount.WithLabelValues(label, "InvalidFilename").Inc()
 		log.Printf("Invalid filename: %v\n", err)
 		return nil, etl.DataPath{}, http.StatusBadRequest, err
 	}
@@ -33,13 +32,13 @@ func GetSource(client *gcs.Client, uri string) (etl.TestSource, etl.DataPath, in
 	dataType := path.GetDataType()
 	// Can this be merged with error case above?
 	if dataType == etl.INVALID {
-		metrics.TaskCount.WithLabelValues(label, "invalid", "SourcePathError").Inc()
+		metrics.TaskCount.WithLabelValues(string(dataType), "SourcePathError").Inc()
 		log.Printf("Invalid datatype: %s", path)
 		return nil, etl.DataPath{}, http.StatusInternalServerError, err
 	}
 	tr, err := storage.NewTestSource(client, uri, label)
 	if err != nil {
-		metrics.TaskCount.WithLabelValues(label, string(dataType), "ETLSourceError").Inc()
+		metrics.TaskCount.WithLabelValues(string(dataType), "ETLSourceError").Inc()
 		log.Printf("Error opening gcs file: %v", err)
 		return nil, etl.DataPath{}, http.StatusInternalServerError, err
 		// TODO - anything better we could do here?
@@ -56,7 +55,7 @@ func ProcessTask(fn string) (int, error) {
 	client, err := storage.GetStorageClient(false)
 	if err != nil {
 		path, _ := etl.ValidateTestPath(fn)
-		metrics.TaskCount.WithLabelValues(path.TableBase(), "worker", "ServiceUnavailable").Inc()
+		metrics.TaskCount.WithLabelValues(path.DataType, "ServiceUnavailable").Inc()
 		log.Printf("Error getting storage client: %v\n", err)
 		return http.StatusServiceUnavailable, err
 	}
@@ -102,7 +101,7 @@ func ProcessTestSource(src etl.TestSource, path etl.DataPath) (int, error) {
 	// Create parser, injecting Inserter
 	p := parser.NewParser(dataType, ins)
 	if p == nil {
-		metrics.TaskCount.WithLabelValues(label, string(dataType), "NewInserterError").Inc()
+		metrics.TaskCount.WithLabelValues(string(dataType), "NewInserterError").Inc()
 		log.Printf("Error creating parser for %s", dataType)
 		return http.StatusInternalServerError, fmt.Errorf("problem creating parser for %s", dataType)
 	}
@@ -119,7 +118,7 @@ func ProcessTestSource(src etl.TestSource, path etl.DataPath) (int, error) {
 	metrics.WorkerState.WithLabelValues(label, "finish").Inc()
 	defer metrics.WorkerState.WithLabelValues(label, "finish").Dec()
 	if err != nil {
-		metrics.TaskCount.WithLabelValues(label, string(dataType), "TaskError").Inc()
+		metrics.TaskCount.WithLabelValues(string(dataType), "TaskError").Inc()
 		log.Printf("Error Processing Tests:  %v", err)
 		// NOTE: This may cause indefinite retries, and stalled task queue.  Task will eventually
 		// expire, but it might be better to have a different mechanism for retries, particularly
@@ -128,73 +127,77 @@ func ProcessTestSource(src etl.TestSource, path etl.DataPath) (int, error) {
 		// TODO - anything better we could do here?
 	}
 
-	metrics.TaskCount.WithLabelValues(label, string(dataType), "OK").Inc()
+	metrics.TaskCount.WithLabelValues(string(dataType), "OK").Inc()
 	return http.StatusOK, nil
 }
 
-// ProcessGKETask interprets a filename to create a Task, Parser, and Inserter,
-// and processes the file content.  The inserter is customized to write to column partitioned tables.
-// It is currently used in the GKE parser instances, but will eventually replace ProcessTask for
-// all parser/task types.
-// Returns an http status code and an error if the task did not complete successfully.
-// TODO pass in the configured Sink object, instead of creating based on datatype.
-func ProcessGKETask(fn string, uploader etl.Uploader, ann api.Annotator) (int, error) {
-	client, err := storage.GetStorageClient(false)
-	if err != nil {
-		path, _ := etl.ValidateTestPath(fn)
-		metrics.TaskCount.WithLabelValues(path.TableBase(), "worker", "ServiceUnavailable").Inc()
-		log.Printf("Error getting storage client: %v\n", err)
-		return http.StatusServiceUnavailable, err
-	}
-	return ProcessGKETaskWithClient(fn, client, uploader, ann)
+// StandardTaskFactory implements factory.Task
+type StandardTaskFactory struct {
+	Sink   factory.SinkFactory
+	Source factory.SourceFactory
+	Ann    factory.AnnotatorFactory
 }
 
-// ProcessGKETaskWithClient uses the provided GCS client to source the file.
-func ProcessGKETaskWithClient(fn string, client *gcs.Client, uploader etl.Uploader, ann api.Annotator) (int, error) {
-	tr, path, status, err := GetSource(client, fn)
+// Get implements factory.TaskFactory.Get
+func (tf *StandardTaskFactory) Get(ctx context.Context, dp etl.DataPath) (*task.Task, factory.ProcessingError) {
+	sink, err := tf.Sink.Get(ctx, dp)
 	if err != nil {
-		return status, err
-	}
-	defer tr.Close()
-
-	label := path.TableBase()
-
-	// Count number of workers operating on each table.
-	metrics.WorkerCount.WithLabelValues(label).Inc()
-	defer metrics.WorkerCount.WithLabelValues(label).Dec()
-
-	// These keep track of the (nested) state of the worker.
-	metrics.WorkerState.WithLabelValues(label, "worker").Inc()
-	defer metrics.WorkerState.WithLabelValues(label, "worker").Dec()
-
-	dataType := path.GetDataType()
-	pdt := bqx.PDT{Project: dataType.BigqueryProject(), Dataset: dataType.Dataset(), Table: dataType.Table()}
-
-	ins, err := bq.NewColumnPartitionedInserterWithUploader(pdt, uploader)
-	if err != nil {
-		metrics.TaskCount.WithLabelValues(label, string(dataType), "NewInserterError").Inc()
-		log.Printf("Error creating BQ Inserter:  %v", err)
-		return http.StatusInternalServerError, err
-		// TODO - anything better we could do here?
+		e := fmt.Errorf("%v creating sink for %s", err, dp.GetDataType())
+		log.Println(e, dp.URI)
+		return nil, err
 	}
 
-	// Create parser, injecting Inserter
-	p := parser.NewSinkParser(dataType, ins, label, ann)
+	ann, err := tf.Ann.Get(ctx, dp)
+	if err != nil {
+		e := fmt.Errorf("%v creating annotator for %s", err, dp.GetDataType())
+		log.Println(e, dp.URI)
+		return nil, err
+	}
+	src, err := tf.Source.Get(ctx, dp)
+	if err != nil {
+		e := fmt.Errorf("%v creating source for %s", err, dp.GetDataType())
+		log.Println(e, dp.URI)
+		return nil, err
+	}
+
+	p := parser.NewSinkParser(dp.GetDataType(), sink, src.Type(), ann)
 	if p == nil {
-		metrics.TaskCount.WithLabelValues(label, string(dataType), "NewInserterError").Inc()
-		log.Printf("Error creating parser for %s", dataType)
-		return http.StatusInternalServerError, fmt.Errorf("problem creating parser for %s", dataType)
+		e := fmt.Errorf("%v creating parser for %s", err, dp.GetDataType())
+		log.Println(e, dp.URI)
+		return nil, err
 	}
-	tsk := task.NewTask(fn, tr, p)
 
+	tsk := task.NewTask(dp.URI, src, p)
+	return tsk, nil
+}
+
+// ProcessGKETask interprets a filename to create a Task, Parser, and Inserter,
+// and processes the file content.
+// Used default BQ Sink, and GCS Source.
+// Returns an http status code and an error if the task did not complete successfully.
+func ProcessGKETask(path etl.DataPath, tf factory.TaskFactory) factory.ProcessingError {
+	t, err := tf.Get(nil, path)
+	if err != nil {
+		metrics.TaskCount.WithLabelValues(err.DataType(), err.Detail()).Inc()
+		log.Printf("TaskFactory error: %v", err)
+		return err // http.StatusBadRequest, err
+	}
+
+	return DoGKETask(t, path)
+}
+
+// DoGKETask creates task, processes all tests and handle metrics
+func DoGKETask(tsk *task.Task, path etl.DataPath) factory.ProcessingError {
 	files, err := tsk.ProcessAllTests()
+	tsk.Close()
 
 	dateFormat := "20060102"
-	date, err := time.Parse(dateFormat, path.PackedDate)
-	if err != nil {
-		metrics.TaskCount.WithLabelValues(label, string(dataType), "Bad Date").Inc()
+	date, dateErr := time.Parse(dateFormat, path.PackedDate)
+	if dateErr != nil {
+		metrics.TaskCount.WithLabelValues(path.DataType, "Bad Date").Inc()
 		log.Printf("Error parsing path.PackedDate: %v", err)
-		return http.StatusBadRequest, err
+		return factory.NewError(
+			path.DataType, "PackedDate", http.StatusBadRequest, dateErr)
 	}
 
 	// Count the files processed per-host-module per-weekday.
@@ -203,15 +206,11 @@ func ProcessGKETaskWithClient(fn string, client *gcs.Client, uploader etl.Upload
 		path.Host+"-"+path.Site+"-"+path.Experiment,
 		date.Weekday().String()).Add(float64(files))
 
-	metrics.WorkerState.WithLabelValues(label, "finish").Inc()
-	defer metrics.WorkerState.WithLabelValues(label, "finish").Dec()
 	if err != nil {
-		metrics.TaskCount.WithLabelValues(label, string(dataType), "TaskError").Inc()
+		metrics.TaskCount.WithLabelValues(path.DataType, "TaskError").Inc()
 		log.Printf("Error Processing Tests:  %v", err)
-		// NOTE: This may cause indefinite retries, and stalled task queue.  Task will eventually
-		// expire, but it might be better to have a different mechanism for retries, particularly
-		// for gardener, which waits for empty task queue.
-		return http.StatusInternalServerError, err
+		return factory.NewError(
+			path.DataType, "TaskError", http.StatusInternalServerError, err)
 		// TODO - anything better we could do here?
 	}
 
@@ -225,6 +224,6 @@ func ProcessGKETaskWithClient(fn string, client *gcs.Client, uploader etl.Upload
 	// the partition corresponding to the time of the traffic, rather than the time of the original
 	// connection.  We are unclear about how to handle short connections that span midnight UTC, but
 	// suspect they should be placed in the date of the original connection time.
-	metrics.TaskCount.WithLabelValues(label, string(dataType), "OK").Inc()
-	return http.StatusOK, nil
+	metrics.TaskCount.WithLabelValues(path.DataType, "OK").Inc()
+	return nil
 }

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -3,6 +3,7 @@ package worker_test
 import (
 	"archive/tar"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -16,12 +17,17 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/m-lab/annotation-service/api"
 	v2 "github.com/m-lab/annotation-service/api/v2"
+	"github.com/m-lab/go/bqx"
 	"github.com/m-lab/go/rtx"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 
+	"github.com/m-lab/etl/bq"
+	"github.com/m-lab/etl/etl"
+	"github.com/m-lab/etl/factory"
 	"github.com/m-lab/etl/fake"
 	"github.com/m-lab/etl/metrics"
+	"github.com/m-lab/etl/row"
 	"github.com/m-lab/etl/worker"
 
 	"github.com/fsouza/fake-gcs-server/fakestorage"
@@ -132,27 +138,100 @@ func TestProcessTask(t *testing.T) {
 	metrics.TestCount.Reset()
 }
 
+// This is also a factory
 type fakeAnnotator struct{}
 
 func (ann *fakeAnnotator) GetAnnotations(ctx context.Context, date time.Time, ips []string, info ...string) (*v2.Response, error) {
 	return &v2.Response{AnnotatorDate: time.Now(), Annotations: make(map[string]*api.Annotations, 0)}, nil
 }
 
-// Enable this test when we have fixed the prom counter resets.
+func (ann *fakeAnnotator) Get(ctx context.Context, dp etl.DataPath) (v2.Annotator, factory.ProcessingError) {
+	return ann, nil
+}
+
+type fakeSinkFactory struct {
+	up etl.Uploader
+}
+
+func (fsf *fakeSinkFactory) Get(ctx context.Context, dp etl.DataPath) (row.Sink, factory.ProcessingError) {
+	if fsf.up == nil {
+		return nil, factory.NewError(dp.DataType, "fakeSinkFactory",
+			http.StatusInternalServerError, errors.New("nil uploader"))
+	}
+	pdt := bqx.PDT{Project: "fake-project", Dataset: "fake-dataset", Table: "fake-table"}
+	in, err := bq.NewColumnPartitionedInserterWithUploader(pdt, fsf.up)
+	rtx.Must(err, "Bad SinkFactory")
+	return in, nil
+}
+
+type fakeSourceFactory struct {
+	client *storage.Client
+}
+
+func (sf *fakeSourceFactory) Get(ctx context.Context, dp etl.DataPath) (etl.TestSource, factory.ProcessingError) {
+	// TODO simplify GetSource
+	tr, _, _, err := worker.GetSource(sf.client, dp.URI)
+	rtx.Must(err, "Bad TestSource")
+
+	// TODO
+	// defer tr.Close()
+
+	return tr, nil
+}
+
+func NewSourceFactory() factory.SourceFactory {
+	gcsClient := fromTar("test-bucket", "../testfiles/ndt.tar").Client()
+	return &fakeSourceFactory{client: gcsClient}
+}
+
+func TestNilUploader(t *testing.T) {
+	if testing.Short() {
+		t.Log("Skipping integration test")
+	}
+
+	fakeFactory := worker.StandardTaskFactory{
+		Ann:    &fakeAnnotator{},
+		Sink:   &fakeSinkFactory{up: nil},
+		Source: NewSourceFactory(),
+	}
+
+	filename := "gs://test-bucket/ndt/ndt5/2019/12/01/20191201T020011.395772Z-ndt5-mlab1-bcn01-ndt.tgz"
+	path, err := etl.ValidateTestPath(filename)
+	if err != nil {
+		t.Fatal(err, filename)
+	}
+	// TODO create a TaskFactory and use ProcessGKETask
+	pErr := worker.ProcessGKETask(path, &fakeFactory)
+	if pErr == nil || pErr.Code() != http.StatusInternalServerError {
+		t.Fatal("Expected error with", http.StatusInternalServerError, "Got:", pErr)
+	}
+
+	metrics.FileCount.Reset()
+	metrics.TaskCount.Reset()
+	metrics.TestCount.Reset()
+}
+
 func TestProcessGKETask(t *testing.T) {
 	if testing.Short() {
 		t.Log("Skipping integration test")
 	}
 
-	gcsClient := fromTar("test-bucket", "../testfiles/ndt.tar").Client()
-	filename := "gs://test-bucket/ndt/ndt5/2019/12/01/20191201T020011.395772Z-ndt5-mlab1-bcn01-ndt.tgz"
 	up := fake.NewFakeUploader()
-	status, err := worker.ProcessGKETaskWithClient(filename, gcsClient, up, &fakeAnnotator{})
-	if err != nil {
-		t.Fatal(err)
+	fakeFactory := worker.StandardTaskFactory{
+		Ann:    &fakeAnnotator{},
+		Sink:   &fakeSinkFactory{up: up},
+		Source: NewSourceFactory(),
 	}
-	if status != http.StatusOK {
-		t.Fatal("Expected", http.StatusOK, "Got:", status)
+
+	filename := "gs://test-bucket/ndt/ndt5/2019/12/01/20191201T020011.395772Z-ndt5-mlab1-bcn01-ndt.tgz"
+	path, err := etl.ValidateTestPath(filename)
+	if err != nil {
+		t.Fatal(err, filename)
+	}
+	// TODO create a TaskFactory and use ProcessGKETask
+	pErr := worker.ProcessGKETask(path, &fakeFactory)
+	if pErr != nil {
+		t.Fatal("Expected", http.StatusOK, "Got:", pErr)
 	}
 
 	// This section checks that prom metrics are updated appropriately.


### PR DESCRIPTION
Adds implementations for factories, and integrates them into ProcessGKETask and related code.
Uses ProcessingError to simplify error handling.

Also simplifies and unifies TaskCount labels.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/867)
<!-- Reviewable:end -->
