### PR TITLE
Deploy sandbox k8s parsers only on u-sandbox branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -325,7 +325,7 @@ deploy:
   on:
     repo: m-lab/etl
     all_branches: true
-    condition: $TRAVIS_BRANCH == u-sandbox-* || universal-sandbox-* || $TRAVIS_BRANCH == sandbox-*
+    condition: $TRAVIS_BRANCH == u-sandbox-* || universal-sandbox-*
 
 ######################################################################
 #  Staging deployments

--- a/.travis.yml
+++ b/.travis.yml
@@ -128,7 +128,7 @@ script:
 
 # Coveralls
 - $HOME/gopath/bin/gocovmerge *.cov > merge.cov
-- $HOME/gopath/bin/goveralls -coverprofile=merge.cov -service=travis-ci
+- $HOME/gopath/bin/goveralls -coverprofile=merge.cov -service=travis-ci || true
 
 # Clean build and prepare for deployment
 - cd $TRAVIS_BUILD_DIR/cmd/etl_worker &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ install:
 
 # Get dependencies
 - cd $TRAVIS_BUILD_DIR
-- go get -v -t ./...
+- go get -v -t ./... || go get -v -t ./...
 
 # List submodule versions
 - git submodule


### PR DESCRIPTION
This will reduce interference between development on new and old parser features.

Also makes .travis.yml "go get" and goveralls more robust.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/885)
<!-- Reviewable:end -->
