### PR TITLE
Restore ndt5 schema updates

### DIFF
--- a/cmd/update-schema/update.go
+++ b/cmd/update-schema/update.go
@@ -138,13 +138,12 @@ func main() {
 		if err := CreateOrUpdatePT(project, "batch", "traceroute"); err != nil {
 			errCount++
 		}
-		/* Temporaily comment out due to NDT7 unstable schemas.
 		if err := CreateOrUpdateNDT5ResultRow(project, "base_tables", "ndt5"); err != nil {
 			errCount++
 		}
 		if err := CreateOrUpdateNDT5ResultRow(project, "batch", "ndt5"); err != nil {
 			errCount++
-		}*/
+		}
 
 	case "tcpinfo":
 		if err := CreateOrUpdateTCPInfo(project, "base_tables", "tcpinfo"); err != nil {


### PR DESCRIPTION
During the GCEE incident, redeploying the ETL batch parsers caused a new ndt5 schema in the parser that was not updated in the underlying batch and base_tables.

After manually restoring the ndt5 schemas in https://github.com/m-lab/dev-tracker/issues/597 this change restores "ndt5" steps in update-schema.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/890)
<!-- Reviewable:end -->
