### PR TITLE
Use GCS archive path date for row.Date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@
 # TODO(soltesz): Add deployment automation when fine-grained permissions are
 # possible.
 
+dist: bionic
 language: go
 go:
  - "1.13.8"

--- a/etl/etl.go
+++ b/etl/etl.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/civil"
 )
 
 // ProcessingError extends error to provide dataType and detail for metrics,
@@ -143,8 +144,9 @@ type TestSource interface {
 	NextTest(maxSize int64) (string, []byte, error)
 	Close() error
 
-	Detail() string // Detail for logs.
-	Type() string   // Data type for logs and metrics
+	Detail() string   // Detail for logs.
+	Type() string     // Data type for logs and metrics
+	Date() civil.Date // Date associated with test source
 }
 
 //========================================================================

--- a/parser/annotation.go
+++ b/parser/annotation.go
@@ -103,7 +103,7 @@ func (ap *AnnotationParser) ParseAndInsert(meta map[string]bigquery.Value, testN
 	// the given timestamp, regardless of the timestamp's timezone. Since we
 	// run our systems in UTC, all timestamps will be relative to UTC and as
 	// will these dates.
-	row.Date = civil.DateOf(raw.Timestamp)
+	row.Date = meta["date"].(civil.Date)
 
 	// Estimate the row size based on the input JSON size.
 	metrics.RowSizeHistogram.WithLabelValues(ap.TableName()).Observe(float64(len(test)))

--- a/parser/annotation_test.go
+++ b/parser/annotation_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/civil"
 	"github.com/m-lab/etl/parser"
 	"github.com/m-lab/go/rtx"
 )
@@ -39,6 +40,7 @@ func TestAnnotationParser_ParseAndInsert(t *testing.T) {
 
 			meta := map[string]bigquery.Value{
 				"filename": "gs://mlab-test-bucket/ndt/ndt7/2020/03/18/" + tt.file,
+				"date":     civil.Date{Year: 2020, Month: 3, Day: 18},
 			}
 
 			if err := n.ParseAndInsert(meta, tt.file, data); (err != nil) != tt.wantErr {

--- a/parser/ndt7_result.go
+++ b/parser/ndt7_result.go
@@ -93,7 +93,7 @@ func (dp *NDT7ResultParser) ParseAndInsert(meta map[string]bigquery.Value, testN
 	// the given timestamp, regardless of the timestamp's timezone. Since we
 	// run our systems in UTC, all timestamps will be relative to UTC and as
 	// will these dates.
-	row.Date = civil.DateOf(row.Raw.StartTime)
+	row.Date = meta["date"].(civil.Date)
 	if row.Raw.Download != nil {
 		row.A = downSummary(row.Raw.Download)
 	} else if row.Raw.Upload != nil {

--- a/parser/ndt7_result_test.go
+++ b/parser/ndt7_result_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/civil"
 	"github.com/go-test/deep"
 
 	"github.com/m-lab/etl/parser"
@@ -39,6 +40,7 @@ func TestNDT7ResultParser_ParseAndInsert(t *testing.T) {
 			}
 			meta := map[string]bigquery.Value{
 				"filename": "gs://mlab-test-bucket/ndt/ndt7/2020/03/18/ndt_ndt7_2020_03_18_20200318T003853.425987Z-ndt7-mlab3-syd03-ndt.tgz",
+				"date":     civil.Date{Year: 2020, Month: 3, Day: 18},
 			}
 
 			if err := n.ParseAndInsert(meta, tt.testName, resultData); (err != nil) != tt.wantErr {

--- a/parser/tcpinfo_test.go
+++ b/parser/tcpinfo_test.go
@@ -15,6 +15,7 @@ import (
 	v2 "github.com/m-lab/annotation-service/api/v2"
 
 	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/civil"
 	"github.com/m-lab/annotation-service/api"
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/parser"
@@ -52,7 +53,8 @@ func fileSource(fn string) (etl.TestSource, error) {
 	tarReader := tar.NewReader(rdr)
 
 	timeout := 16 * time.Millisecond
-	return &storage.GCSSource{TarReader: tarReader, Closer: raw, RetryBaseTime: timeout, TableBase: "test"}, nil
+	return &storage.GCSSource{TarReader: tarReader, Closer: raw,
+		RetryBaseTime: timeout, TableBase: "test", PathDate: civil.Date{Year: 2020, Month: 6, Day: 11}}, nil
 }
 
 type fakeAnnotator struct{}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -18,8 +18,8 @@ import (
 )
 
 var testBucket = "mlab-testing.appspot.com"
-var tarFile = "gs://" + testBucket + "/test.tar"
-var tgzFile = "gs://" + testBucket + "/test.tgz"
+var tarFile = "gs://" + testBucket + "/ndt/ndt5/2020/06/11/20200611T123456.12345Z-ndt5-mlab1-foo01-ndt.tar"
+var tgzFile = "gs://" + testBucket + "/ndt/ndt5/2020/06/11/20200611T123456.12345Z-ndt5-mlab1-foo01-ndt.tgz"
 
 func assertGCSourceIsTestSource(in etl.TestSource) {
 	func(in etl.TestSource) {}(&GCSSource{})
@@ -46,7 +46,11 @@ func TestNewTarReader(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping tests that access GCS")
 	}
-	src, err := NewTestSource(client, tarFile, "label")
+	dpf, err := etl.ValidateTestPath(tarFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src, err := NewTestSource(client, dpf, "label")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,7 +72,11 @@ func TestNewTarReaderGzip(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping tests that access GCS")
 	}
-	src, err := NewTestSource(client, tgzFile, "label")
+	dpf, err := etl.ValidateTestPath(tgzFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src, err := NewTestSource(client, dpf, "label")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,8 +106,12 @@ func init() {
 }
 
 func BenchmarkNewTarReader(b *testing.B) {
+	dpf, err := etl.ValidateTestPath(tarFile)
+	if err != nil {
+		b.Fatal(err)
+	}
 	for i := 0; i < b.N; i++ {
-		src, err := NewTestSource(client, tarFile, "label")
+		src, err := NewTestSource(client, dpf, "label")
 		if err == nil {
 			src.Close()
 		}
@@ -107,8 +119,12 @@ func BenchmarkNewTarReader(b *testing.B) {
 }
 
 func BenchmarkNewTarReaderGzip(b *testing.B) {
+	dpf, err := etl.ValidateTestPath(tgzFile)
+	if err != nil {
+		b.Fatal(err)
+	}
 	for i := 0; i < b.N; i++ {
-		src, err := NewTestSource(client, tgzFile, "label")
+		src, err := NewTestSource(client, dpf, "label")
 		if err == nil {
 			src.Close()
 		}

--- a/task/task.go
+++ b/task/task.go
@@ -12,12 +12,10 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
-	"cloud.google.com/go/civil"
 
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/metrics"
 	"github.com/m-lab/etl/storage"
-	"github.com/m-lab/go/rtx"
 )
 
 // Factory provides Get() which always returns a new, complete Task.
@@ -47,16 +45,11 @@ type Task struct {
 // NewTask constructs a task, injecting the source and the parser.
 func NewTask(filename string, src etl.TestSource, prsr etl.Parser) *Task {
 	// TODO - should the meta data be a nested type?
-	p, err := etl.ValidateTestPath(filename)
-	rtx.Must(err, "failed to parse filename")
-	archiveDate, err := time.Parse("2006/01/02", p.DatePath)
-	rtx.Must(err, "failed to parse archive date path")
-
 	meta := make(map[string]bigquery.Value, 3)
 	meta["filename"] = filename
 	meta["parse_time"] = time.Now()
 	meta["attempt"] = 1
-	meta["date"] = civil.DateOf(archiveDate)
+	meta["date"] = src.Date()
 	t := Task{src, prsr, meta, DefaultMaxFileSize}
 	return &t
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -36,7 +36,7 @@ func GetSource(client *gcs.Client, uri string) (etl.TestSource, etl.DataPath, in
 		log.Printf("Invalid datatype: %s", path)
 		return nil, etl.DataPath{}, http.StatusInternalServerError, err
 	}
-	tr, err := storage.NewTestSource(client, uri, label)
+	tr, err := storage.NewTestSource(client, path, label)
 	if err != nil {
 		metrics.TaskCount.WithLabelValues(string(dataType), "ETLSourceError").Inc()
 		log.Printf("Error opening gcs file: %v", err)


### PR DESCRIPTION
This change updates the source of the row.Date value from the measurement StartTime to the GCS path date.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/896)
<!-- Reviewable:end -->
