### PR TITLE
Various fixes

### DIFF
--- a/row/row.go
+++ b/row/row.go
@@ -313,9 +313,14 @@ func (pb *Base) TaskError() error {
 	return nil
 }
 
+var logAnnError = logx.NewLogEvery(nil, 60*time.Second)
+
 func (pb *Base) commit(rows []interface{}) error {
-	// TODO - care about error?
-	_ = pb.ann.Annotate(rows, pb.label)
+	err := pb.ann.Annotate(rows, pb.label)
+	if err != nil {
+		logAnnError.Println("annotation: ", err)
+	}
+
 	// TODO do we need these to be done in order.
 	// This is synchronous, blocking, and thread safe.
 	done, err := pb.sink.Commit(rows, pb.label)
@@ -351,7 +356,7 @@ func (pb *Base) Put(row Annotatable) {
 		// TODO consider making this asynchronous.
 		err := pb.commit(rows)
 		if err != nil {
-			log.Println(err)
+			log.Println(pb.label, err)
 		}
 	}
 }

--- a/schema/annotation.go
+++ b/schema/annotation.go
@@ -13,11 +13,11 @@ import (
 // AnnotationRow defines the BQ schema using 'Standard Columns' conventions for
 // the annotation datatype produced by the uuid-annotator.
 type AnnotationRow struct {
-	UUID   string                      `bigquery:"id"` // NOTE: there is no 'a' record for AnnotationRows.
-	Server annotator.ServerAnnotations `bigquery:"server"`
-	Client annotator.ClientAnnotations `bigquery:"client"`
-	Parser ParseInfo                   `bigquery:"parser"`
-	Date   civil.Date                  `bigquery:"date"`
+	UUID   string                      `bigquery:"id" json:"id"` // NOTE: there is no 'a' record for AnnotationRows.
+	Server annotator.ServerAnnotations `bigquery:"server" json:"server"`
+	Client annotator.ClientAnnotations `bigquery:"client" json:"client"`
+	Parser ParseInfo                   `bigquery:"parser" json:"parser"`
+	Date   civil.Date                  `bigquery:"date" json:"date"`
 
 	// NOTE: there is no 'Raw' field for annotation datatypes because the
 	// uuid-annotator output schema was designed to be used directly by the parser.


### PR DESCRIPTION
This PR:
  1. Improves some error logs and reduces spam
  2. Adds json tags to the annotations struct, so that JSON export matches BQ schema.
  3. Adds Close() to the row.Sink interface, and call it properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/897)
<!-- Reviewable:end -->
