### PR TITLE
Complete implementation of GCS backend processing

### DIFF
--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -21,7 +21,6 @@ import (
 	"github.com/m-lab/go/rtx"
 
 	"github.com/m-lab/etl/active"
-	"github.com/m-lab/etl/bq"
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/factory"
 	"github.com/m-lab/etl/metrics"
@@ -255,9 +254,11 @@ func toRunnable(obj *gcs.ObjectAttrs) active.Runnable {
 	if err != nil {
 		return nil // TODO add an error?
 	}
+	// HACK for now
+	outputBucket := "json-" + os.Getenv("GCLOUD_PROJECT")
 	taskFactory := worker.StandardTaskFactory{
 		Annotator: factory.DefaultAnnotatorFactory(),
-		Sink:      bq.NewSinkFactory(),
+		Sink:      storage.NewSinkFactory(c, outputBucket),
 		Source:    storage.GCSSourceFactory(c),
 	}
 	return &runnable{&taskFactory, *obj}
@@ -298,7 +299,7 @@ func main() {
 	gardener := os.Getenv("GARDENER_HOST")
 	if len(gardener) > 0 {
 		log.Println("Using", gardener)
-		maxWorkers := 120
+		maxWorkers := 200
 		minPollingInterval := 10 * time.Second
 		gapi := mustGardenerAPI(mainCtx, gardener)
 		// Note that this does not currently track duration metric.

--- a/etl/globals.go
+++ b/etl/globals.go
@@ -137,6 +137,26 @@ func ValidateTestPath(path string) (DataPath, error) {
 	return dp, nil
 }
 
+// PathAndFilename returns the entire GCS path except for the gs://bucket/ prefix and .tgz suffix.
+func (dp DataPath) PathAndFilename() string {
+	e := dp.Embargo
+	//	if len(e) > 0 {
+	//		e = "-" + e
+	//	}
+	dt2 := dp.DataType2
+	if len(dt2) > 0 {
+		//dt2 = "-" + dt2
+	}
+	if dp.ExpDir == "" {
+		return fmt.Sprintf("%s/%s/%sT%sZ%s-%s-%s-%s-%s%s",
+			dp.DataType, dp.DatePath, dp.PackedDate, dp.PackedTime, dt2,
+			dp.Host, dp.Site, dp.Experiment, dp.FileNumber, e)
+	}
+	return fmt.Sprintf("%s/%s/%s/%sT%sZ-%s-%s-%s-%s-%s%s",
+		dp.ExpDir, dp.DataType, dp.DatePath, dp.PackedDate, dp.PackedTime, dt2,
+		dp.Host, dp.Site, dp.Experiment, dp.FileNumber, e)
+}
+
 // GetDataType finds the type of data stored in a file from its complete filename
 func (dp DataPath) GetDataType() DataType {
 	dt, ok := dirToDataType[dp.DataType]

--- a/etl/globals_test.go
+++ b/etl/globals_test.go
@@ -129,6 +129,10 @@ func TestValidateTestPath(t *testing.T) {
 					log.Println(tt.path)
 					t.Errorf("%s: %v\n", tt.name, diff)
 				}
+				recon := fmt.Sprintf("gs://%s/%s%s", got.Bucket, got.PathAndFilename(), tt.want.Suffix)
+				if recon != tt.path {
+					t.Error(tt.name, "expected:", tt.path, "got:", recon, "\n", tt.want)
+				}
 			}
 		})
 	}

--- a/parser/ndt7_result.go
+++ b/parser/ndt7_result.go
@@ -93,6 +93,20 @@ func (dp *NDT7ResultParser) ParseAndInsert(meta map[string]bigquery.Value, testN
 		return err
 	}
 
+	// This is a hack to deal with the ConnectionInfo fields that are not intended to be
+	// exported to bigquery.  With the GCS row.Sink, we convert to json, but we cannot
+	// tag the json, because the json tag is already used for the NDT7 client comms.
+	if row.Raw.Download != nil && row.Raw.Download.ServerMeasurements != nil {
+		for i := range row.Raw.Download.ServerMeasurements {
+			row.Raw.Download.ServerMeasurements[i].ConnectionInfo = nil
+		}
+	}
+	if row.Raw.Upload != nil && row.Raw.Upload.ServerMeasurements != nil {
+		for i := range row.Raw.Upload.ServerMeasurements {
+			row.Raw.Upload.ServerMeasurements[i].ConnectionInfo = nil
+		}
+	}
+
 	// NOTE: Civil is not TZ adjusted. It takes the year, month, and date from
 	// the given timestamp, regardless of the timestamp's timezone. Since we
 	// run our systems in UTC, all timestamps will be relative to UTC and as

--- a/parser/tcpinfo.go
+++ b/parser/tcpinfo.go
@@ -172,8 +172,11 @@ func (p *TCPInfoParser) ParseAndInsert(fileMetadata map[string]bigquery.Value, t
 	}
 
 	row := schema.TCPRow{}
-	// TODO - restore full snapshots, or implement smarter filtering.
-	row.Snapshots = thinSnaps(snaps)
+	if len(snaps) > 2000 {
+		row.Snapshots = snaps[0:2000]
+	} else {
+		row.Snapshots = snaps
+	}
 	row.FinalSnapshot = snaps[len(snaps)-1]
 	if row.FinalSnapshot.InetDiagMsg != nil {
 		row.SockID = row.FinalSnapshot.InetDiagMsg.ID.GetSockID()

--- a/parser/tcpinfo_test.go
+++ b/parser/tcpinfo_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
 	v2 "github.com/m-lab/annotation-service/api/v2"
 
 	"cloud.google.com/go/bigquery"
@@ -297,7 +296,7 @@ func TestTaskToGCS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rw, err := storage.NewRowWriter(context.Background(), stiface.AdaptClient(c), "archive-mlab-testing", "gfr/tcpinfo.json")
+	rw, err := storage.NewRowWriter(context.Background(), c, "archive-mlab-testing", "gfr/tcpinfo2.json")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/parser/tcpinfo_test.go
+++ b/parser/tcpinfo_test.go
@@ -129,7 +129,7 @@ func TestTCPParser(t *testing.T) {
 	task := task.NewTask(filename, src, p, nullCloser{})
 
 	startDecode := time.Now()
-	n, err := task.ProcessAllTests()
+	n, err := task.ProcessAllTests(false)
 	decodeTime := time.Since(startDecode)
 	if err != nil {
 		t.Fatal(err)
@@ -238,7 +238,7 @@ func TestTCPTask(t *testing.T) {
 
 	task := task.NewTask(filename, src, p, &nullCloser{})
 
-	n, err := task.ProcessAllTests()
+	n, err := task.ProcessAllTests(false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -263,7 +263,7 @@ func TestBQSaver(t *testing.T) {
 
 	task := task.NewTask(filename, src, p, &nullCloser{})
 
-	_, err = task.ProcessAllTests()
+	_, err = task.ProcessAllTests(false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -311,7 +311,7 @@ func TestTaskToGCS(t *testing.T) {
 
 	task := task.NewTask(filename, src, p, &nullCloser{})
 
-	n, err := task.ProcessAllTests()
+	n, err := task.ProcessAllTests(false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -343,7 +343,7 @@ func BenchmarkTCPParser(b *testing.B) {
 
 		task := task.NewTask(filename, src, p, &nullCloser{})
 
-		n, err = task.ProcessAllTests()
+		n, err = task.ProcessAllTests(false)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/parser/tcpinfo_test.go
+++ b/parser/tcpinfo_test.go
@@ -216,8 +216,11 @@ func TestTCPParser(t *testing.T) {
 		t.Error("Incorrect duration calculation", duration)
 	}
 
-	if totalSnaps != 1588 {
-		t.Error("expected 1588 (thinned) snapshots, got", totalSnaps)
+	if totalSnaps != 10429 {
+		if totalSnaps != 1588 {
+			t.Error("expected 1588 (thinned) snapshots, got", totalSnaps)
+		}
+		t.Error("expected 10429 snapshots, got", totalSnaps)
 	}
 }
 

--- a/storage/rowwriter.go
+++ b/storage/rowwriter.go
@@ -4,14 +4,16 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"log"
+	"net/http"
 
 	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
+	"google.golang.org/api/googleapi"
+
 	"github.com/m-lab/etl/etl"
+	"github.com/m-lab/etl/factory"
 	"github.com/m-lab/etl/metrics"
 	"github.com/m-lab/etl/row"
-	"google.golang.org/api/googleapi"
 )
 
 // ObjectWriter creates a writer to a named object.
@@ -49,17 +51,6 @@ func NewRowWriter(ctx context.Context, client stiface.Client, bucket string, pat
 	writing <- struct{}{}
 
 	return &RowWriter{bucket: bucket, path: path, w: w, encoding: encoding, writing: writing}, nil
-}
-
-// SinkFactory implements factory.SinkFactory.
-type SinkFactory struct {
-	client stiface.Client
-}
-
-// Get mplements factory.SinkFactory
-func (sf *SinkFactory) Get(
-	ctx context.Context, path etl.DataPath) (*RowWriter, error) {
-	return nil, errors.New("not implemented")
 }
 
 // Acquire the encoding token.
@@ -159,4 +150,27 @@ func (rw *RowWriter) Close() error {
 		log.Println(rw.w.Attrs())
 	}
 	return err
+}
+
+// SinkFactory implements factory.SinkFactory.
+type SinkFactory struct {
+	client       stiface.Client
+	outputBucket string
+}
+
+// Get mplements factory.SinkFactory
+// TODO - should inject context?
+func (sf *SinkFactory) Get(ctx context.Context, path etl.DataPath) (row.Sink, etl.ProcessingError) {
+	//gcsPath := fmt.Sprintf("%s/%s/%s/%s", path.DataType, path.ExpDir, path.DatePath, path.)
+	s, err := NewRowWriter(context.Background(), sf.client, sf.outputBucket, path.PathAndFilename()+".json")
+	if err != nil {
+		return nil, factory.NewError(path.DataType, "SinkFactory",
+			http.StatusInternalServerError, err)
+	}
+	return s, nil
+}
+
+// NewSinkFactory returns the default SinkFactory
+func NewSinkFactory(client stiface.Client, outputBucket string) factory.SinkFactory {
+	return &SinkFactory{client: client, outputBucket: outputBucket}
 }

--- a/task/task.go
+++ b/task/task.go
@@ -81,7 +81,7 @@ var emptyTest = logx.NewLogEvery(nil, time.Second)
 // injected parser to parse them, and inserts them into bigquery. Returns the
 // number of files processed.
 // TODO pass in the datatype label.
-func (tt *Task) ProcessAllTests() (int, error) {
+func (tt *Task) ProcessAllTests(failfast bool) (int, error) {
 	if tt.Parser == nil {
 		panic("Parser is nil")
 	}
@@ -161,6 +161,9 @@ OUTER:
 				tt.Type(), "ParseAndInsertError").Inc()
 			log.Printf("ERROR %v", loopErr)
 			// TODO(dev) Handle this error properly!
+			if failfast {
+				break OUTER
+			}
 			continue
 		}
 	}

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -111,7 +111,7 @@ func TestBadTarFileInput(t *testing.T) {
 
 	// Among other things, this requires that tp implements etl.Parser.
 	tt := task.NewTask("filename", rdr, tp, &NullCloser{})
-	fc, err := tt.ProcessAllTests()
+	fc, err := tt.ProcessAllTests(true)
 	if err.Error() != "Random Error" {
 		t.Error("Expected Random Error, but got " + err.Error())
 	}
@@ -171,7 +171,7 @@ func TestTarFileInput(t *testing.T) {
 
 	tt = task.NewTask("filename", rdr, tp, &NullCloser{})
 	tt.SetMaxFileSize(100)
-	fc, err := tt.ProcessAllTests()
+	fc, err := tt.ProcessAllTests(false)
 	if err != nil {
 		t.Error("Expected nil error, but got ", err)
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -114,7 +114,7 @@ func ProcessTestSource(src etl.TestSource, path etl.DataPath) (int, error) {
 	// The closer does nothing, so we could just provide a null closer.
 	tsk := task.NewTask(src.Detail(), src, p, &nullCloser{})
 
-	files, err := tsk.ProcessAllTests()
+	files, err := tsk.ProcessAllTests(false) // ignore most parse errors.
 
 	// Count the files processed per-host-module per-weekday.
 	// TODO(soltesz): evaluate separating hosts and pods as separate metrics.
@@ -206,7 +206,7 @@ func ProcessGKETask(path etl.DataPath, tf task.Factory) etl.ProcessingError {
 
 // DoGKETask creates task, processes all tests and handle metrics
 func DoGKETask(tsk *task.Task, path etl.DataPath) etl.ProcessingError {
-	files, err := tsk.ProcessAllTests()
+	files, err := tsk.ProcessAllTests(true) // fail fast on parsing errors.
 
 	dateFormat := "20060102"
 	date, dateErr := time.Parse(dateFormat, path.PackedDate)

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	gcs "cloud.google.com/go/storage"
+	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
 
 	"github.com/m-lab/etl/bq"
 	"github.com/m-lab/etl/etl"
@@ -24,7 +24,7 @@ func (nc nullCloser) Close() error { return nil }
 
 // GetSource gets the TestSource for the filename.
 // fn is a gs:// GCS uri.
-func GetSource(client *gcs.Client, uri string) (etl.TestSource, etl.DataPath, int, error) {
+func GetSource(client stiface.Client, uri string) (etl.TestSource, etl.DataPath, int, error) {
 	path, err := etl.ValidateTestPath(uri)
 	label := path.TableBase() // On error, this will be "invalid", so not all that useful.
 	if err != nil {
@@ -68,7 +68,7 @@ func ProcessTask(fn string) (int, error) {
 }
 
 // ProcessTaskWithClient handles processing with an injected client.
-func ProcessTaskWithClient(client *gcs.Client, fn string) (int, error) {
+func ProcessTaskWithClient(client stiface.Client, fn string) (int, error) {
 	tr, path, status, err := GetSource(client, fn)
 	if err != nil {
 		return status, err

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
+	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 
@@ -114,7 +115,7 @@ func TestProcessTask(t *testing.T) {
 	gcsClient := fromTar("test-bucket", "../testfiles/ndt.tar").Client()
 	filename := "gs://test-bucket/ndt/2018/05/09/20180509T101913Z-mlab1-mad03-ndt-0000.tgz"
 
-	status, err := worker.ProcessTaskWithClient(gcsClient, filename)
+	status, err := worker.ProcessTaskWithClient(stiface.AdaptClient(gcsClient), filename)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,7 +167,7 @@ func (fsf *fakeSinkFactory) Get(ctx context.Context, dp etl.DataPath) (row.Sink,
 }
 
 type fakeSourceFactory struct {
-	client *storage.Client
+	client stiface.Client
 }
 
 func (sf *fakeSourceFactory) Get(ctx context.Context, dp etl.DataPath) (etl.TestSource, etl.ProcessingError) {
@@ -182,7 +183,7 @@ func (sf *fakeSourceFactory) Get(ctx context.Context, dp etl.DataPath) (etl.Test
 
 func NewSourceFactory() factory.SourceFactory {
 	gcsClient := fromTar("test-bucket", "../testfiles/ndt.tar").Client()
-	return &fakeSourceFactory{client: gcsClient}
+	return &fakeSourceFactory{client: stiface.AdaptClient(gcsClient)}
 }
 
 func TestNilUploader(t *testing.T) {


### PR DESCRIPTION
Output rows to GCS instead of BigQuery
Handle Put errors better.
Store all snapshots (up to 2000) for tcpinfo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/902)
<!-- Reviewable:end -->
