### PR TITLE
Build and ship in same environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
 # Dockerfile to contain the generate_schema_docs CLI.
 
+FROM golang:1.14.4-alpine3.12 AS build
+RUN apk update
+RUN apk add --virtual build-dependencies build-base gcc wget git linux-headers
 # Build the command.
-FROM golang:1.12 as build
-ENV CGO_ENABLED 0
 COPY . /go/src/github.com/m-lab/etl
 WORKDIR /go/src/github.com/m-lab/etl
 RUN go get -v github.com/m-lab/etl/cmd/generate_schema_docs
 
-# Build the image.
-FROM alpine
+# Now copy the resulting command into the minimal base image.
+FROM alpine:3.12
 COPY --from=build /go/bin/generate_schema_docs /
 WORKDIR /
 ENTRYPOINT ["/generate_schema_docs"]


### PR DESCRIPTION
Previously, the generate-schema-docs image was failing with errors like:

```
github.com/m-lab/ndt-server/bbr
../ndt-server/bbr/bbr.go:18:9: undefined: enableBBR
../ndt-server/bbr/bbr.go:23:9: undefined: getMaxBandwidthAndMinRTT
```

This turned out to be due to `CGO_ENABLED=0`, removing this requires that the build env and final env use the same base image, so that the few dynamic linked libraries match exactly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/903)
<!-- Reviewable:end -->
