### PR TITLE
Add Fail fast option in ProcessAll, so that file write errors can be fatal.

### DIFF
--- a/parser/tcpinfo_test.go
+++ b/parser/tcpinfo_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
 	v2 "github.com/m-lab/annotation-service/api/v2"
 
 	"cloud.google.com/go/bigquery"
@@ -297,7 +296,7 @@ func TestTaskToGCS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rw, err := storage.NewRowWriter(context.Background(), stiface.AdaptClient(c), "archive-mlab-testing", "gfr/tcpinfo.json")
+	rw, err := storage.NewRowWriter(context.Background(), c, "archive-mlab-testing", "gfr/tcpinfo2.json")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/parser/tcpinfo_test.go
+++ b/parser/tcpinfo_test.go
@@ -129,7 +129,7 @@ func TestTCPParser(t *testing.T) {
 	task := task.NewTask(filename, src, p, nullCloser{})
 
 	startDecode := time.Now()
-	n, err := task.ProcessAllTests()
+	n, err := task.ProcessAllTests(false)
 	decodeTime := time.Since(startDecode)
 	if err != nil {
 		t.Fatal(err)
@@ -238,7 +238,7 @@ func TestTCPTask(t *testing.T) {
 
 	task := task.NewTask(filename, src, p, &nullCloser{})
 
-	n, err := task.ProcessAllTests()
+	n, err := task.ProcessAllTests(false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -263,7 +263,7 @@ func TestBQSaver(t *testing.T) {
 
 	task := task.NewTask(filename, src, p, &nullCloser{})
 
-	_, err = task.ProcessAllTests()
+	_, err = task.ProcessAllTests(false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -311,7 +311,7 @@ func TestTaskToGCS(t *testing.T) {
 
 	task := task.NewTask(filename, src, p, &nullCloser{})
 
-	n, err := task.ProcessAllTests()
+	n, err := task.ProcessAllTests(false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -343,7 +343,7 @@ func BenchmarkTCPParser(b *testing.B) {
 
 		task := task.NewTask(filename, src, p, &nullCloser{})
 
-		n, err = task.ProcessAllTests()
+		n, err = task.ProcessAllTests(false)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -69,7 +69,7 @@ func (src *GCSSource) nextHeader(trial int) (*tar.Header, bool, error) {
 			metrics.GCSRetryCount.WithLabelValues(
 				src.TableBase, "next", strconv.Itoa(trial), "other").Inc()
 		}
-		log.Printf("ERROR nextHeader: %v\n", err)
+		log.Printf("ERROR: nextHeader: %v\n", err)
 	}
 	return h, true, err
 }
@@ -91,7 +91,7 @@ func (src *GCSSource) nextData(h *tar.Header, trial int) ([]byte, bool, error) {
 			}
 			metrics.GCSRetryCount.WithLabelValues(
 				src.TableBase, "open zip", strconv.Itoa(trial), "zipReaderError").Inc()
-			log.Printf("Error zipReader(%d): %v in file %s\n", trial, err, h.Name)
+			log.Printf("ERROR: zipReader(%d): %v in file %s\n", trial, err, h.Name)
 			return nil, true, err
 		}
 		defer zipReader.Close()
@@ -116,7 +116,7 @@ func (src *GCSSource) nextData(h *tar.Header, trial int) ([]byte, bool, error) {
 			metrics.GCSRetryCount.WithLabelValues(
 				src.TableBase, phase, strconv.Itoa(trial), "other error").Inc()
 		}
-		log.Printf("ERROR nextData:%d [%s] %s (%d bytes) from %s\n", trial, err, h.Name, h.Size, src.FilePath)
+		log.Printf("ERROR: nextData:%d [%s] %s (%d bytes) from %s\n", trial, err, h.Name, h.Size, src.FilePath)
 		return nil, true, err
 	}
 
@@ -258,7 +258,7 @@ func NewTestSource(client stiface.Client, dp etl.DataPath, label string) (etl.Te
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	// TODO(prod) Evaluate whether this is long enough.
+	// TODO(prod) Evaluate whether timeout this is long enough.
 	// TODO - appengine requests time out after 60 minutes, so more than that doesn't help.
 	// SS processing sometimes times out with 1 hour.
 	// Is there a limit on http requests from task queue, or into flex instance?
@@ -334,7 +334,7 @@ func (sf *gcsSourceFactory) Get(ctx context.Context, dp etl.DataPath) (etl.TestS
 
 	tr, err := NewTestSource(sf.client, dp, label)
 	if err != nil {
-		log.Printf("Error opening gcs file: %v", err)
+		log.Printf("ERROR: opening gcs file: %v", err)
 		// TODO - anything better we could do here?
 		return nil, factory.NewError(dp.DataType, "ETLSourceError",
 			http.StatusInternalServerError,

--- a/task/task.go
+++ b/task/task.go
@@ -81,7 +81,7 @@ var emptyTest = logx.NewLogEvery(nil, time.Second)
 // injected parser to parse them, and inserts them into bigquery. Returns the
 // number of files processed.
 // TODO pass in the datatype label.
-func (tt *Task) ProcessAllTests() (int, error) {
+func (tt *Task) ProcessAllTests(failfast bool) (int, error) {
 	if tt.Parser == nil {
 		panic("Parser is nil")
 	}
@@ -161,6 +161,9 @@ OUTER:
 				tt.Type(), "ParseAndInsertError").Inc()
 			log.Printf("ERROR %v", loopErr)
 			// TODO(dev) Handle this error properly!
+			if failfast {
+				break OUTER
+			}
 			continue
 		}
 	}

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -111,7 +111,7 @@ func TestBadTarFileInput(t *testing.T) {
 
 	// Among other things, this requires that tp implements etl.Parser.
 	tt := task.NewTask("filename", rdr, tp, &NullCloser{})
-	fc, err := tt.ProcessAllTests()
+	fc, err := tt.ProcessAllTests(true)
 	if err.Error() != "Random Error" {
 		t.Error("Expected Random Error, but got " + err.Error())
 	}
@@ -171,7 +171,7 @@ func TestTarFileInput(t *testing.T) {
 
 	tt = task.NewTask("filename", rdr, tp, &NullCloser{})
 	tt.SetMaxFileSize(100)
-	fc, err := tt.ProcessAllTests()
+	fc, err := tt.ProcessAllTests(false)
 	if err != nil {
 		t.Error("Expected nil error, but got ", err)
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -114,7 +114,7 @@ func ProcessTestSource(src etl.TestSource, path etl.DataPath) (int, error) {
 	// The closer does nothing, so we could just provide a null closer.
 	tsk := task.NewTask(src.Detail(), src, p, &nullCloser{})
 
-	files, err := tsk.ProcessAllTests()
+	files, err := tsk.ProcessAllTests(false) // ignore most parse errors.
 
 	// Count the files processed per-host-module per-weekday.
 	// TODO(soltesz): evaluate separating hosts and pods as separate metrics.
@@ -206,7 +206,7 @@ func ProcessGKETask(path etl.DataPath, tf task.Factory) etl.ProcessingError {
 
 // DoGKETask creates task, processes all tests and handle metrics
 func DoGKETask(tsk *task.Task, path etl.DataPath) etl.ProcessingError {
-	files, err := tsk.ProcessAllTests()
+	files, err := tsk.ProcessAllTests(true) // fail fast on parsing errors.
 
 	dateFormat := "20060102"
 	date, dateErr := time.Parse(dateFormat, path.PackedDate)

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	gcs "cloud.google.com/go/storage"
+	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
 
 	"github.com/m-lab/etl/bq"
 	"github.com/m-lab/etl/etl"
@@ -24,7 +24,7 @@ func (nc nullCloser) Close() error { return nil }
 
 // GetSource gets the TestSource for the filename.
 // fn is a gs:// GCS uri.
-func GetSource(client *gcs.Client, uri string) (etl.TestSource, etl.DataPath, int, error) {
+func GetSource(client stiface.Client, uri string) (etl.TestSource, etl.DataPath, int, error) {
 	path, err := etl.ValidateTestPath(uri)
 	label := path.TableBase() // On error, this will be "invalid", so not all that useful.
 	if err != nil {
@@ -68,7 +68,7 @@ func ProcessTask(fn string) (int, error) {
 }
 
 // ProcessTaskWithClient handles processing with an injected client.
-func ProcessTaskWithClient(client *gcs.Client, fn string) (int, error) {
+func ProcessTaskWithClient(client stiface.Client, fn string) (int, error) {
 	tr, path, status, err := GetSource(client, fn)
 	if err != nil {
 		return status, err

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
+	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 
@@ -114,7 +115,7 @@ func TestProcessTask(t *testing.T) {
 	gcsClient := fromTar("test-bucket", "../testfiles/ndt.tar").Client()
 	filename := "gs://test-bucket/ndt/2018/05/09/20180509T101913Z-mlab1-mad03-ndt-0000.tgz"
 
-	status, err := worker.ProcessTaskWithClient(gcsClient, filename)
+	status, err := worker.ProcessTaskWithClient(stiface.AdaptClient(gcsClient), filename)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,7 +167,7 @@ func (fsf *fakeSinkFactory) Get(ctx context.Context, dp etl.DataPath) (row.Sink,
 }
 
 type fakeSourceFactory struct {
-	client *storage.Client
+	client stiface.Client
 }
 
 func (sf *fakeSourceFactory) Get(ctx context.Context, dp etl.DataPath) (etl.TestSource, etl.ProcessingError) {
@@ -182,7 +183,7 @@ func (sf *fakeSourceFactory) Get(ctx context.Context, dp etl.DataPath) (etl.Test
 
 func NewSourceFactory() factory.SourceFactory {
 	gcsClient := fromTar("test-bucket", "../testfiles/ndt.tar").Client()
-	return &fakeSourceFactory{client: gcsClient}
+	return &fakeSourceFactory{client: stiface.AdaptClient(gcsClient)}
 }
 
 func TestNilUploader(t *testing.T) {


### PR DESCRIPTION
When we move to GCS json output, we need to be able to terminate parsing if there is a write error.

This also migrates some APIs to use stiface.Client to allow future injection of fakes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/906)
<!-- Reviewable:end -->
