### PR TITLE
Refactor main, add json output support

### DIFF
--- a/active/poller.go
+++ b/active/poller.go
@@ -3,6 +3,7 @@ package active
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -41,8 +42,8 @@ var JobFailures = promauto.NewCounterVec(
 
 // GardenerAPI encapsulates the backend paths and clients to connect to gardener and GCS.
 type GardenerAPI struct {
-	trackerBase url.URL
-	gcs         stiface.Client
+	trackerBase url.URL        // static after init
+	gcs         stiface.Client // static after init
 }
 
 // NewGardenerAPI creates a GardenerAPI.
@@ -200,6 +201,7 @@ func (g *GardenerAPI) Poll(ctx context.Context,
 	for {
 		select {
 		case <-ctx.Done():
+			log.Println("Poller context done")
 			return
 		default:
 			err := g.pollAndRun(ctx, toRunnable, throttle)
@@ -210,4 +212,10 @@ func (g *GardenerAPI) Poll(ctx context.Context,
 
 		<-ticker.C // Wait for next tick, to avoid fast spinning on errors.
 	}
+}
+
+// Status adds a small amount of status info to w.
+func (g *GardenerAPI) Status(w http.ResponseWriter) {
+	fmt.Fprintf(w, "Gardener API: %s\n", g.trackerBase.String())
+
 }

--- a/cmd/etl_worker/etl_worker_test.go
+++ b/cmd/etl_worker/etl_worker_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/m-lab/go/osx"
+)
+
+func init() {
+	// Always prepend the filename and line number.
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+}
+
+// Retries for up to 10 seconds.
+func waitFor(url string) (resp *http.Response, err error) {
+	for i := 0; i < 1000; i++ {
+		time.Sleep(10 * time.Millisecond)
+		resp, err = http.Get(url)
+		if err == nil {
+			break
+		}
+	}
+	return resp, err
+}
+
+func TestMain(t *testing.T) {
+	flag.Set("servicePort", ":0")
+	flag.Set("maxActiveTasks", "200")
+	flag.Set("prometheusx.listen-address", ":9090")
+	mainCtx, mainCancel = context.WithCancel(context.Background())
+
+	vars := map[string]string{
+		"PROJECT": "mlab-testing",
+	}
+	for k, v := range vars {
+		cleanup := osx.MustSetenv(k, v)
+		defer cleanup()
+	}
+
+	go main()
+	defer mainCancel()
+
+	// Wait for the server to start and publish address.
+	mainSvr := <-mainServerAddr
+
+	// Wait until the mainSvr is "ready"
+	resp, err := waitFor("http://" + mainSvr + "/ready")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// For now, the service comes up immediately serving "ok" for /ready
+	data, err := ioutil.ReadAll(resp.Body)
+	if string(data) != "ok" {
+		t.Fatal(string(data))
+	}
+	resp.Body.Close()
+	log.Println("ok")
+
+	// Now get the status
+	resp, err = waitFor("http://" + mainSvr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err = ioutil.ReadAll(resp.Body)
+	if !strings.Contains(string(data), "Workers") {
+		t.Error("Should contain 'Workers':\n", string(data))
+	}
+	resp.Body.Close()
+
+	if *maxActiveTasks != 200 {
+		t.Error("Expected 200:", *maxActiveTasks)
+	}
+
+}

--- a/cmd/etl_worker/etl_worker_test.go
+++ b/cmd/etl_worker/etl_worker_test.go
@@ -37,7 +37,8 @@ func TestMain(t *testing.T) {
 	mainCtx, mainCancel = context.WithCancel(context.Background())
 
 	vars := map[string]string{
-		"PROJECT": "mlab-testing",
+		"PROJECT":     "mlab-testing",
+		"MAX_WORKERS": "25",
 	}
 	for k, v := range vars {
 		cleanup := osx.MustSetenv(k, v)
@@ -85,13 +86,16 @@ func TestMain(t *testing.T) {
 
 func TestPollingMode(t *testing.T) {
 	flag.Set("prometheusx.listen-address", ":9090")
+	flag.Set("json_out", "true")
 	mainCtx, mainCancel = context.WithCancel(context.Background())
 
 	vars := map[string]string{
-		"PROJECT":       "mlab-testing",
-		"GARDENER_HOST": "foobar",
-		"MAX_ACTIVE":    "200",
-		"SERVICE_PORT":  ":0",
+		"PROJECT":        "mlab-testing",
+		"GCLOUD_PROJECT": "mlab-testing",
+		"GARDENER_HOST":  "foobar",
+		"MAX_ACTIVE":     "200",
+		"SERVICE_PORT":   ":0",
+		"COMMIT_HASH":    "123456789ABCDEF",
 	}
 	for k, v := range vars {
 		cleanup := osx.MustSetenv(k, v)
@@ -126,7 +130,12 @@ func TestPollingMode(t *testing.T) {
 	data, err = ioutil.ReadAll(resp.Body)
 	// Check expected GardenerAPI
 	if !strings.Contains(string(data), "http://foobar:8080") {
-		t.Error("Should contain 'GardenerAPI: http://foobar:8080':\n", string(data))
+		t.Error("Should contain 'Gardener API: http://foobar:8080':\n", string(data))
+	}
+	// Check expected GardenerAPI
+	expect := "Writing output to etl-mlab-testing"
+	if !strings.Contains(string(data), expect) {
+		t.Errorf("Should contain '%s':\n%s", expect, string(data))
 	}
 	resp.Body.Close()
 

--- a/cmd/etl_worker/etl_worker_test.go
+++ b/cmd/etl_worker/etl_worker_test.go
@@ -31,8 +31,8 @@ func waitFor(url string) (resp *http.Response, err error) {
 }
 
 func TestMain(t *testing.T) {
-	flag.Set("servicePort", ":0")
-	flag.Set("maxActiveTasks", "200")
+	flag.Set("service_port", ":0")
+	flag.Set("max_active", "200")
 	flag.Set("prometheusx.listen-address", ":9090")
 	mainCtx, mainCancel = context.WithCancel(context.Background())
 
@@ -72,6 +72,61 @@ func TestMain(t *testing.T) {
 	data, err = ioutil.ReadAll(resp.Body)
 	if !strings.Contains(string(data), "Workers") {
 		t.Error("Should contain 'Workers':\n", string(data))
+	}
+	if !strings.Contains(string(data), "BigQuery") {
+		t.Error("Should contain 'BigQuery':\n", string(data))
+	}
+	resp.Body.Close()
+
+	if *maxActiveTasks != 200 {
+		t.Error("Expected 200:", *maxActiveTasks)
+	}
+}
+
+func TestPollingMode(t *testing.T) {
+	flag.Set("prometheusx.listen-address", ":9090")
+	mainCtx, mainCancel = context.WithCancel(context.Background())
+
+	vars := map[string]string{
+		"PROJECT":       "mlab-testing",
+		"GARDENER_HOST": "foobar",
+		"MAX_ACTIVE":    "200",
+		"SERVICE_PORT":  ":0",
+	}
+	for k, v := range vars {
+		cleanup := osx.MustSetenv(k, v)
+		defer cleanup()
+	}
+
+	go main()
+	defer mainCancel()
+
+	// Wait for the server to start and publish address.
+	mainSvr := <-mainServerAddr
+
+	// Wait until the mainSvr is "ready"
+	resp, err := waitFor("http://" + mainSvr + "/ready")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// For now, the service comes up immediately serving "ok" for /ready
+	data, err := ioutil.ReadAll(resp.Body)
+	if string(data) != "ok" {
+		t.Fatal(string(data))
+	}
+	resp.Body.Close()
+	log.Println("ok")
+
+	// Now get the status
+	resp, err = waitFor("http://" + mainSvr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err = ioutil.ReadAll(resp.Body)
+	// Check expected GardenerAPI
+	if !strings.Contains(string(data), "http://foobar:8080") {
+		t.Error("Should contain 'GardenerAPI: http://foobar:8080':\n", string(data))
 	}
 	resp.Body.Close()
 

--- a/k8s/data-processing/deployments/parser.yml
+++ b/k8s/data-processing/deployments/parser.yml
@@ -39,7 +39,7 @@ spec:
         args: ["--prometheusx.listen-address=:9090",
                "--service_port=:8080",  # TODO - can this be bound to service-port defined below?
                "--maxActive=200",
-               "--jsonOutput=true",]
+               "--jsonOutput=false",]
         env:
         - name: RELEASE_TAG
           value: {{RELEASE_TAG}}

--- a/k8s/data-processing/deployments/parser.yml
+++ b/k8s/data-processing/deployments/parser.yml
@@ -36,7 +36,10 @@ spec:
       containers:
       - image: gcr.io/{{GCLOUD_PROJECT}}/github.com/m-lab/etl:{{GIT_COMMIT}}
         name: etl-parser
-        args: ["--prometheusx.listen-address=:9090"]
+        args: ["--prometheusx.listen-address=:9090",
+               "--service_port=:8080",  # TODO - can this be bound to service-port defined below?
+               "--maxActive=200",
+               "--jsonOutput=true",]
         env:
         - name: RELEASE_TAG
           value: {{RELEASE_TAG}}

--- a/storage/export_test.go
+++ b/storage/export_test.go
@@ -1,0 +1,3 @@
+package storage
+
+var PathAndFilename = pathAndFilename

--- a/storage/rowwriter.go
+++ b/storage/rowwriter.go
@@ -6,12 +6,16 @@ import (
 	"encoding/json"
 	"errors"
 	"log"
+	"net/http"
+	"strings"
 
 	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
+	"google.golang.org/api/googleapi"
+
 	"github.com/m-lab/etl/etl"
+	"github.com/m-lab/etl/factory"
 	"github.com/m-lab/etl/metrics"
 	"github.com/m-lab/etl/row"
-	"google.golang.org/api/googleapi"
 )
 
 // ObjectWriter creates a writer to a named object.
@@ -49,17 +53,6 @@ func NewRowWriter(ctx context.Context, client stiface.Client, bucket string, pat
 	writing <- struct{}{}
 
 	return &RowWriter{bucket: bucket, path: path, w: w, encoding: encoding, writing: writing}, nil
-}
-
-// SinkFactory implements factory.SinkFactory.
-type SinkFactory struct {
-	client stiface.Client
-}
-
-// Get mplements factory.SinkFactory
-func (sf *SinkFactory) Get(
-	ctx context.Context, path etl.DataPath) (*RowWriter, error) {
-	return nil, errors.New("not implemented")
 }
 
 // Acquire the encoding token.
@@ -159,4 +152,42 @@ func (rw *RowWriter) Close() error {
 		log.Println(rw.w.Attrs())
 	}
 	return err
+}
+
+// SinkFactory implements factory.SinkFactory.
+type SinkFactory struct {
+	client       stiface.Client
+	outputBucket string
+}
+
+// returns the full path/filename from a gs://bucket/path/filename string.
+func pathAndFilename(uri string) (string, error) {
+	parts := strings.SplitN(uri, "/", 4)
+	if len(parts) != 4 || parts[0] != "gs:" || len(parts[3]) == 0 {
+		return "", errors.New("Bad GCS path")
+	}
+	return parts[3], nil
+}
+
+// Get mplements factory.SinkFactory
+// TODO - should inject context?
+func (sf *SinkFactory) Get(ctx context.Context, path etl.DataPath) (row.Sink, etl.ProcessingError) {
+
+	fn, err := pathAndFilename(path.URI)
+	if err != nil {
+		return nil, factory.NewError(path.DataType, "InvalidPath",
+			http.StatusInternalServerError, err)
+	}
+	//gcsPath := fmt.Sprintf("%s/%s/%s/%s", path.DataType, path.ExpDir, path.DatePath, path.)
+	s, err := NewRowWriter(context.Background(), sf.client, sf.outputBucket, fn+".json")
+	if err != nil {
+		return nil, factory.NewError(path.DataType, "SinkFactory",
+			http.StatusInternalServerError, err)
+	}
+	return s, nil
+}
+
+// NewSinkFactory returns the default SinkFactory
+func NewSinkFactory(client stiface.Client, outputBucket string) factory.SinkFactory {
+	return &SinkFactory{client: client, outputBucket: outputBucket}
 }

--- a/storage/rowwriter_test.go
+++ b/storage/rowwriter_test.go
@@ -59,3 +59,22 @@ func TestRowWriter(t *testing.T) {
 		t.Error(diff)
 	}
 }
+
+func TestPathAndFilename(t *testing.T) {
+	if _, err := storage.PathAndFilename("foobar"); err == nil {
+		t.Error("Expected error")
+	}
+	if _, err := storage.PathAndFilename("gs://foobar"); err == nil {
+		t.Error("Expected error")
+	}
+	if _, err := storage.PathAndFilename("gs://foobar/"); err == nil {
+		t.Error("Expected error")
+	}
+	path, err := storage.PathAndFilename("gs://bucket/foo/bar.baz")
+	if err != nil {
+		t.Error("Unexpected error:", err)
+	}
+	if path != "foo/bar.baz" {
+		t.Error("Incorrect path:", path)
+	}
+}


### PR DESCRIPTION
1. Refactor main() a bit and add ArgsFromEnv support.
2. Add etl_worker_test.go to test main()
3. Add NewSinkFactory
4. Add flag and support for json output.
5. Add status output for json and polling modes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/908)
<!-- Reviewable:end -->
