### PR TITLE
refactor main, unit test, more status info

### DIFF
--- a/active/poller.go
+++ b/active/poller.go
@@ -3,6 +3,7 @@ package active
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -200,6 +201,7 @@ func (g *GardenerAPI) Poll(ctx context.Context,
 	for {
 		select {
 		case <-ctx.Done():
+			log.Println("Poller context done")
 			return
 		default:
 			err := g.pollAndRun(ctx, toRunnable, throttle)
@@ -210,4 +212,10 @@ func (g *GardenerAPI) Poll(ctx context.Context,
 
 		<-ticker.C // Wait for next tick, to avoid fast spinning on errors.
 	}
+}
+
+// Status adds a small amount of status info to w.
+func (g *GardenerAPI) Status(w http.ResponseWriter) {
+	fmt.Fprintf(w, "Gardener API: %s\n", g.trackerBase.String())
+
 }

--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -15,8 +15,10 @@ import (
 	"time"
 
 	gcs "cloud.google.com/go/storage"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"golang.org/x/sync/errgroup"
 
+	"github.com/m-lab/go/flagx"
+	"github.com/m-lab/go/httpx"
 	"github.com/m-lab/go/prometheusx"
 	"github.com/m-lab/go/rtx"
 
@@ -41,6 +43,19 @@ func init() {
 	// Always prepend the filename and line number.
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 }
+
+var (
+	maxActiveTasks = flag.Int64("max_active", 0, "Maximum number of active tasks")
+	gardenerHost   = flag.String("gardener_host", "", "Gardener host for jobs")
+
+	servicePort     = flag.String("service_port", ":8080", "The main (private) service port")
+	shutdownTimeout = flag.Duration("shutdown_timeout", 1*time.Minute, "Graceful shutdown time allowance")
+
+	mainCtx, mainCancel = context.WithCancel(context.Background())
+
+	// In active polling mode, this holds the GardenerAPI.
+	gardenerAPI *active.GardenerAPI
+)
 
 // Task Queue can always submit to an admin restricted URL.
 //   login: admin
@@ -69,6 +84,10 @@ func Status(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "Release: %s   Commit: unknown\n", os.Getenv("RELEASE_TAG"))
 	}
 
+	if gardenerAPI != nil {
+		gardenerAPI.Status(w)
+	}
+	fmt.Fprintf(w, "Writing output to BigQuery\n")
 	fmt.Fprintf(w, "<p>Workers: %d / %d</p>\n", atomic.LoadInt32(&inFlight), maxInFlight)
 	env := os.Environ()
 	for i := range env {
@@ -255,9 +274,12 @@ func toRunnable(obj *gcs.ObjectAttrs) active.Runnable {
 	if err != nil {
 		return nil // TODO add an error?
 	}
+
+	sink := bq.NewSinkFactory()
+
 	taskFactory := worker.StandardTaskFactory{
 		Annotator: factory.DefaultAnnotatorFactory(),
-		Sink:      bq.NewSinkFactory(),
+		Sink:      sink,
 		Source:    storage.GCSSourceFactory(c),
 	}
 	return &runnable{&taskFactory, *obj}
@@ -271,40 +293,73 @@ func mustGardenerAPI(ctx context.Context, jobServer string) *active.GardenerAPI 
 	return active.NewGardenerAPI(*base, active.MustStorageClient(ctx))
 }
 
-var mainCtx, mainCancel = context.WithCancel(context.Background())
+// Used for testing.
+var mainServerAddr = make(chan string, 1)
+
+// startServers does not return until context is cancelled.
+func startServers(ctx context.Context, mux http.Handler) *errgroup.Group {
+	// Expose prometheus and pprof metrics on a separate port.
+	promServer := prometheusx.MustServeMetrics()
+	defer promServer.Close()
+
+	// Start up the main job and update server.
+	server := &http.Server{
+		Addr:    *servicePort, // This used to be :8080
+		Handler: mux,
+	}
+
+	rtx.Must(httpx.ListenAndServeAsync(server), "Could not start main server")
+	// This publishes the service port for use in unit tests.
+	mainServerAddr <- server.Addr
+
+	select {
+	case <-ctx.Done():
+		log.Println("Shutting down servers")
+		ctx, cancel := context.WithTimeout(context.Background(), *shutdownTimeout)
+		defer cancel()
+		start := time.Now()
+		eg := errgroup.Group{}
+		eg.Go(func() error {
+			return server.Shutdown(ctx)
+		})
+		eg.Go(func() error {
+			return promServer.Shutdown(ctx)
+		})
+		eg.Wait()
+		log.Println("Shutdown took", time.Since(start))
+		return &eg
+	}
+}
 
 func main() {
 	defer mainCancel()
+
 	flag.Parse()
-
-	// Expose prometheus and pprof metrics on a separate port.
-	prometheusx.MustStartPrometheus(":9090")
-
-	http.HandleFunc("/", Status)
-	http.HandleFunc("/status", Status)
-	http.HandleFunc("/worker", metrics.DurationHandler("generic", handleRequest))
-	http.HandleFunc("/_ah/health", healthCheckHandler)
+	rtx.Must(flagx.ArgsFromEnv(flag.CommandLine), "Could not get args from env")
 
 	// Enable block profiling
 	runtime.SetBlockProfileRate(1000000) // One event per msec.
 
 	setMaxInFlight()
 
-	// We also setup another prometheus handler on a non-standard path. This
-	// path name will be accessible through the AppEngine service address,
-	// however it will be served by a random instance.
-	http.Handle("/random-metrics", promhttp.Handler())
-
 	gardener := os.Getenv("GARDENER_HOST")
 	if len(gardener) > 0 {
 		log.Println("Using", gardener)
-		maxWorkers := 120
 		minPollingInterval := 10 * time.Second
-		gapi := mustGardenerAPI(mainCtx, gardener)
+		gardenerAPI = mustGardenerAPI(mainCtx, gardener)
 		// Note that this does not currently track duration metric.
-		go gapi.Poll(mainCtx, toRunnable, maxWorkers, minPollingInterval)
+		go gardenerAPI.Poll(mainCtx, toRunnable, (int)(*maxActiveTasks), minPollingInterval)
 	} else {
 		log.Println("GARDENER_HOST not specified or empty")
 	}
-	rtx.Must(http.ListenAndServe(":8080", nil), "failed to listen")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", Status)
+	mux.HandleFunc("/status", Status)
+	mux.HandleFunc("/worker", metrics.DurationHandler("generic", handleRequest))
+	mux.HandleFunc("/_ah/health", healthCheckHandler)
+	mux.HandleFunc("/alive", healthCheckHandler)
+	mux.HandleFunc("/ready", healthCheckHandler)
+
+	_ = startServers(mainCtx, mux)
 }

--- a/cmd/etl_worker/etl_worker_test.go
+++ b/cmd/etl_worker/etl_worker_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/m-lab/go/osx"
+)
+
+func init() {
+	// Always prepend the filename and line number.
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+}
+
+// Retries for up to 10 seconds.
+func waitFor(url string) (resp *http.Response, err error) {
+	for i := 0; i < 1000; i++ {
+		time.Sleep(10 * time.Millisecond)
+		resp, err = http.Get(url)
+		if err == nil {
+			break
+		}
+	}
+	return resp, err
+}
+
+func TestMain(t *testing.T) {
+	flag.Set("service_port", ":0")
+	flag.Set("max_active", "200")
+	flag.Set("prometheusx.listen-address", ":9090")
+	mainCtx, mainCancel = context.WithCancel(context.Background())
+
+	vars := map[string]string{
+		"PROJECT":     "mlab-testing",
+		"MAX_WORKERS": "25",
+	}
+	for k, v := range vars {
+		cleanup := osx.MustSetenv(k, v)
+		defer cleanup()
+	}
+
+	go main()
+	defer mainCancel()
+
+	// Wait for the server to start and publish address.
+	mainSvr := <-mainServerAddr
+
+	// Wait until the mainSvr is "ready"
+	resp, err := waitFor("http://" + mainSvr + "/ready")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// For now, the service comes up immediately serving "ok" for /ready
+	data, err := ioutil.ReadAll(resp.Body)
+	if string(data) != "ok" {
+		t.Fatal(string(data))
+	}
+	resp.Body.Close()
+	log.Println("ok")
+
+	// Now get the status
+	resp, err = waitFor("http://" + mainSvr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err = ioutil.ReadAll(resp.Body)
+	if !strings.Contains(string(data), "Workers") {
+		t.Error("Should contain 'Workers':\n", string(data))
+	}
+	if !strings.Contains(string(data), "BigQuery") {
+		t.Error("Should contain 'BigQuery':\n", string(data))
+	}
+	resp.Body.Close()
+
+	if *maxActiveTasks != 200 {
+		t.Error("Expected 200:", *maxActiveTasks)
+	}
+}
+
+func TestPollingMode(t *testing.T) {
+	flag.Set("prometheusx.listen-address", ":9090")
+	mainCtx, mainCancel = context.WithCancel(context.Background())
+
+	vars := map[string]string{
+		"PROJECT":        "mlab-testing",
+		"GCLOUD_PROJECT": "mlab-testing",
+		"GARDENER_HOST":  "gardener",
+		"MAX_ACTIVE":     "200",
+		"SERVICE_PORT":   ":0",
+		"COMMIT_HASH":    "123456789ABCDEF",
+	}
+	for k, v := range vars {
+		cleanup := osx.MustSetenv(k, v)
+		defer cleanup()
+	}
+
+	go main()
+	defer mainCancel()
+
+	// Wait for the server to start and publish address.
+	mainSvr := <-mainServerAddr
+
+	// Wait until the mainSvr is "ready"
+	resp, err := waitFor("http://" + mainSvr + "/ready")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// For now, the service comes up immediately serving "ok" for /ready
+	data, err := ioutil.ReadAll(resp.Body)
+	if string(data) != "ok" {
+		t.Fatal(string(data))
+	}
+	resp.Body.Close()
+	log.Println("ok")
+
+	// Now get the status
+	resp, err = waitFor("http://" + mainSvr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err = ioutil.ReadAll(resp.Body)
+	// Check expected GardenerAPI
+	if !strings.Contains(string(data), "http://gardener:8080") {
+		t.Error("Should contain 'Gardener API: http://gardener:8080':\n", string(data))
+	}
+	resp.Body.Close()
+
+	if *maxActiveTasks != 200 {
+		t.Error("Expected 200:", *maxActiveTasks)
+	}
+
+}

--- a/k8s/data-processing/deployments/parser.yml
+++ b/k8s/data-processing/deployments/parser.yml
@@ -36,7 +36,10 @@ spec:
       containers:
       - image: gcr.io/{{GCLOUD_PROJECT}}/github.com/m-lab/etl:{{GIT_COMMIT}}
         name: etl-parser
-        args: ["--prometheusx.listen-address=:9090"]
+        args: ["--prometheusx.listen-address=:9090",
+               "--service_port=:8080",  # TODO - can this be bound to service-port defined below?
+               "--maxActive=200",
+               ]
         env:
         - name: RELEASE_TAG
           value: {{RELEASE_TAG}}

--- a/k8s/data-processing/deployments/parser.yml
+++ b/k8s/data-processing/deployments/parser.yml
@@ -37,7 +37,7 @@ spec:
       - image: gcr.io/{{GCLOUD_PROJECT}}/github.com/m-lab/etl:{{GIT_COMMIT}}
         name: etl-parser
         args: ["--prometheusx.listen-address=:9090",
-               "--service_port=:8080",  # TODO - can this be bound to service-port defined below?
+               "--service_port=:8080",  # If we move to jsonnet, this could be bound to service-port defined below
                "--maxActive=200",
                ]
         env:


### PR DESCRIPTION
1. Refactor main to make use of mainCtx, and make server setup clearer.
2. Unifies env and flags.
3. Add etl_worker_test to unit test parts of main.
4. Add Gardener info to status page

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/911)
<!-- Reviewable:end -->
