### PR TITLE
add ctx to Run()

### DIFF
--- a/active/active_test.go
+++ b/active/active_test.go
@@ -54,7 +54,7 @@ type runnable struct {
 	obj *storage.ObjectAttrs
 }
 
-func (r *runnable) Run() error {
+func (r *runnable) Run(ctx context.Context) error {
 	log.Println(r.obj.Name)
 	time.Sleep(10 * time.Millisecond)
 	return r.c.err()
@@ -107,7 +107,7 @@ func runAll(ctx context.Context, rSrc active.RunnableSource) (*errgroup.Group, e
 		log.Println("Starting func")
 
 		f := func() error {
-			err := run.Run()
+			err := run.Run(ctx)
 			return err
 		}
 

--- a/active/poller.go
+++ b/active/poller.go
@@ -113,7 +113,7 @@ func (g *GardenerAPI) RunAll(ctx context.Context, rSrc RunnableSource, job track
 			metrics.ActiveTasks.WithLabelValues(rSrc.Label()).Inc()
 			defer metrics.ActiveTasks.WithLabelValues(rSrc.Label()).Dec()
 
-			err := run.Run()
+			err := run.Run(ctx)
 			if err == nil {
 				update := tracker.UpdateURL(g.trackerBase, job, tracker.Parsing, run.Info())
 				if postErr := postAndIgnoreResponse(ctx, *update); postErr != nil {

--- a/active/runnable.go
+++ b/active/runnable.go
@@ -10,7 +10,7 @@ import (
 // A Runnable may return ErrShouldRetry if there was a non-persistent error.
 // TODO - should this instead be and interface, with Run() and ShouldRetry()?
 type Runnable interface {
-	Run() error
+	Run(context.Context) error
 	Info() string
 }
 

--- a/active/throttle.go
+++ b/active/throttle.go
@@ -45,10 +45,10 @@ type throttledRunnable struct {
 }
 
 // Run implements Source.Run
-func (tr *throttledRunnable) Run() error {
+func (tr *throttledRunnable) Run(ctx context.Context) error {
 	// The run function must release the token when it completes.
 	defer tr.release()
-	return tr.Runnable.Run()
+	return tr.Runnable.Run(ctx)
 }
 
 // Next implements Source.Next

--- a/active/throttle_test.go
+++ b/active/throttle_test.go
@@ -74,7 +74,7 @@ func (s *source) Label() string {
 	return "label"
 }
 
-func (sr *statsRunnable) Run() error {
+func (sr *statsRunnable) Run(ctx context.Context) error {
 	now := sr.stats.add()
 	defer sr.stats.end()
 

--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -223,7 +223,7 @@ type runnable struct {
 	gcs.ObjectAttrs
 }
 
-func (r *runnable) Run() error {
+func (r *runnable) Run(ctx context.Context) error {
 	path := fmt.Sprintf("gs://%s/%s", r.Bucket, r.Name)
 	dp, err := etl.ValidateTestPath(path)
 	if err != nil {
@@ -235,7 +235,7 @@ func (r *runnable) Run() error {
 	log.Println("Processing", path)
 
 	statusCode := http.StatusOK
-	pErr := worker.ProcessGKETask(dp, r.tf)
+	pErr := worker.ProcessGKETask(ctx, dp, r.tf)
 	if pErr != nil {
 		statusCode = pErr.Code()
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -184,7 +184,7 @@ func (tf *StandardTaskFactory) Get(ctx context.Context, dp etl.DataPath) (*task.
 // Used default BQ Sink, and GCS Source.
 // Returns an http status code and an error if the task did not complete
 // successfully.
-func ProcessGKETask(path etl.DataPath, tf task.Factory) etl.ProcessingError {
+func ProcessGKETask(ctx context.Context, path etl.DataPath, tf task.Factory) etl.ProcessingError {
 	// Count number of workers operating on each table.
 	metrics.WorkerCount.WithLabelValues(path.DataType).Inc()
 	defer metrics.WorkerCount.WithLabelValues(path.DataType).Dec()
@@ -193,11 +193,11 @@ func ProcessGKETask(path etl.DataPath, tf task.Factory) etl.ProcessingError {
 	metrics.WorkerState.WithLabelValues(path.DataType, "worker").Inc()
 	defer metrics.WorkerState.WithLabelValues(path.DataType, "worker").Dec()
 
-	tsk, err := tf.Get(nil, path)
+	tsk, err := tf.Get(ctx, path)
 	if err != nil {
 		metrics.TaskCount.WithLabelValues(err.DataType(), err.Detail()).Inc()
 		log.Printf("TaskFactory error: %v", err)
-		return err // http.StatusBadRequest, err
+		return err
 	}
 
 	defer tsk.Close()

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -203,7 +203,7 @@ func TestNilUploader(t *testing.T) {
 		t.Fatal(err, filename)
 	}
 	// TODO create a TaskFactory and use ProcessGKETask
-	pErr := worker.ProcessGKETask(path, &fakeFactory)
+	pErr := worker.ProcessGKETask(context.Background(), path, &fakeFactory)
 	if pErr == nil || pErr.Code() != http.StatusInternalServerError {
 		t.Fatal("Expected error with", http.StatusInternalServerError, "Got:", pErr)
 	}
@@ -231,7 +231,7 @@ func TestProcessGKETask(t *testing.T) {
 		t.Fatal(err, filename)
 	}
 	// TODO create a TaskFactory and use ProcessGKETask
-	pErr := worker.ProcessGKETask(path, &fakeFactory)
+	pErr := worker.ProcessGKETask(context.Background(), path, &fakeFactory)
 	if pErr != nil {
 		t.Fatal("Expected", http.StatusOK, "Got:", pErr)
 	}


### PR DESCRIPTION
A bug due to passing nil context was exposed yesterday.  Not sure why it seemed to work before.

This adds context to parameters where it is needed for Run().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/919)
<!-- Reviewable:end -->
