### PR TITLE
Accepts JSON and JSONL suffixes for test filenames.

### DIFF
--- a/parser/disco.go
+++ b/parser/disco.go
@@ -42,8 +42,11 @@ func (dp *DiscoParser) TaskError() error {
 func (dp *DiscoParser) IsParsable(testName string, data []byte) (string, bool) {
 	// Files look like: "<date>-to-<date>-switch.json.gz"
 	// Notice the "-" before switch.
+	// Look for JSON and JSONL files.
 	if strings.HasSuffix(testName, "switch.json") ||
-		strings.HasSuffix(testName, "switch.json.gz") {
+		strings.HasSuffix(testName, "switch.jsonl") ||
+		strings.HasSuffix(testName, "switch.json.gz") ||
+		strings.HasSuffix(testName, "switch.jsonl.gz") {
 		return "switch", true
 	}
 	return "unknown", false


### PR DESCRIPTION
The rewritten DISCO outputs the same format at the old "utilization" experiment, but names the files with a suffix of `jsonl` instead of just `json`, since it is rightly JSONL. This PR just fixes to the parse to recognize files with a `jsonl` suffix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/922)
<!-- Reviewable:end -->
