### PR TITLE
Enable GCS json output

### DIFF
--- a/k8s/data-processing/deployments/parser.yml
+++ b/k8s/data-processing/deployments/parser.yml
@@ -37,8 +37,9 @@ spec:
       - image: gcr.io/{{GCLOUD_PROJECT}}/github.com/m-lab/etl:{{GIT_COMMIT}}
         name: etl-parser
         args: ["--prometheusx.listen-address=:9090",
+               "--output=gcs",
                "--service_port=:8080",  # If we move to jsonnet, this could be bound to service-port defined below
-               "--max_active=200",
+               "--max_active=100",
                ]
         env:
         - name: RELEASE_TAG

--- a/parser/ndt7_result.go
+++ b/parser/ndt7_result.go
@@ -93,6 +93,20 @@ func (dp *NDT7ResultParser) ParseAndInsert(meta map[string]bigquery.Value, testN
 		return err
 	}
 
+	// This is a hack to deal with the ConnectionInfo fields that are not intended to be
+	// exported to bigquery.  With the GCS row.Sink, we convert to json, but we cannot
+	// tag the json, because the json tag is already used for the NDT7 client comms.
+	if row.Raw.Download != nil && row.Raw.Download.ServerMeasurements != nil {
+		for i := range row.Raw.Download.ServerMeasurements {
+			row.Raw.Download.ServerMeasurements[i].ConnectionInfo = nil
+		}
+	}
+	if row.Raw.Upload != nil && row.Raw.Upload.ServerMeasurements != nil {
+		for i := range row.Raw.Upload.ServerMeasurements {
+			row.Raw.Upload.ServerMeasurements[i].ConnectionInfo = nil
+		}
+	}
+
 	// NOTE: Civil is not TZ adjusted. It takes the year, month, and date from
 	// the given timestamp, regardless of the timestamp's timezone. Since we
 	// run our systems in UTC, all timestamps will be relative to UTC and as


### PR DESCRIPTION
This enables output to GCS for the K8S parsers.  It does not impact the legacy parsing pipeline.
It also:
  1.  Adds handling of ndt7 ConnectionInfo fields, that were previously suppressed using a bigquery tag.
  2.  Reduces the max tasks to 100, as 200 seems to be unnecessarily high.  There is modest loss of CPU utilization, but same or better throughput, suggesting there was some thrashing at 200.

Before merging this, we should also:
1. Create the etl-mlab-staging bucket.
2. Have the gardener PR ready to merge that handle loading of data from GCS.  The old gardener will still drive reprocessing, but will not load the data from GCS, so tables won't actually get updated, and will likely be overwritten with empty partitions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/923)
<!-- Reviewable:end -->
