### PR TITLE
k8s config to use 7 cpus, to allow mapping to "parser-pool"

### DIFF
--- a/k8s/data-processing/deployments/parser.yml
+++ b/k8s/data-processing/deployments/parser.yml
@@ -83,11 +83,11 @@ spec:
 
         resources:
           requests:
-            memory: "40Gi"
-            cpu: "14"
+            memory: "15Gi"
+            cpu: "7"
           limits:
-            memory: "55Gi"
-            cpu: "15"
+            memory: "20Gi"
+            cpu: "7"
 
       nodeSelector:
         parser-node: "true"


### PR DESCRIPTION
This reduces the cpu resource request to 7 cpus, for two reasons...
 1.  This will be more than adequate for the short term.
 2.  It will allow mapping the pods onto a new node-pool "parser-pool" with different scopes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/925)
<!-- Reviewable:end -->
