### PR TITLE
Add standard and legacy update-schema types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -250,9 +250,7 @@ deploy:
   script:
     $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_sandbox
     && $TRAVIS_BUILD_DIR/travis/run_with_application_credentials.sh mlab-sandbox
-       SERVICE_ACCOUNT_mlab_sandbox $TRAVIS_BUILD_DIR/cmd/update-schema update-schema -updateType=ndt7
-    && $TRAVIS_BUILD_DIR/travis/run_with_application_credentials.sh mlab-sandbox
-       SERVICE_ACCOUNT_mlab_sandbox $TRAVIS_BUILD_DIR/cmd/update-schema update-schema -updateType=annotation
+       SERVICE_ACCOUNT_mlab_sandbox $TRAVIS_BUILD_DIR/cmd/update-schema update-schema -updateType=standard
     && BIGQUERY_DATASET="tmp_ndt"
        $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-sandbox data-processing ./apply-cluster.sh
   skip_cleanup: true
@@ -340,9 +338,7 @@ deploy:
   script:
     $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_oti
     && $TRAVIS_BUILD_DIR/travis/run_with_application_credentials.sh mlab-oti
-       SERVICE_ACCOUNT_mlab_oti $TRAVIS_BUILD_DIR/cmd/update-schema update-schema -updateType=ndt7
-    && $TRAVIS_BUILD_DIR/travis/run_with_application_credentials.sh mlab-oti
-       SERVICE_ACCOUNT_mlab_oti $TRAVIS_BUILD_DIR/cmd/update-schema update-schema -updateType=annotation
+       SERVICE_ACCOUNT_mlab_oti $TRAVIS_BUILD_DIR/cmd/update-schema update-schema -updateType=standard
     && BIGQUERY_DATASET="tmp_ndt"
        $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-oti data-processing ./apply-cluster.sh
   on:

--- a/appengine/queue_pusher/queue_pusher_test.go
+++ b/appengine/queue_pusher/queue_pusher_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"google.golang.org/appengine/aetest"
 )
@@ -68,7 +69,8 @@ func TestStats(t *testing.T) {
 		},
 	}
 
-	inst, err := aetest.NewInstance(nil)
+	opts := aetest.Options{StartupTimeout: time.Minute}
+	inst, err := aetest.NewInstance(&opts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/update-schema/update.go
+++ b/cmd/update-schema/update.go
@@ -103,10 +103,7 @@ func CreateOrUpdate(schema bigquery.Schema, project, dataset, table, partField s
 	return err
 }
 
-var (
-	updateType = flag.String("updateType", "", "Short name of datatype to be updated (tcpinfo, scamper, ...).")
-)
-
+// Only tables that support Standard Columns should be included here.
 func updateStandardTables(project string) int {
 	errCount := 0
 	if err := CreateOrUpdateNDT7ResultRow(project, "tmp_ndt", "ndt7"); err != nil {
@@ -147,6 +144,11 @@ func updateLegacyTables(project string) int {
 	return errCount
 }
 
+var (
+	updateType = flag.String("updateType", "", "Short name of datatype to be updated (tcpinfo, scamper, ...).")
+	project    = flag.String("gcloud_project", "", "GCP project to update")
+)
+
 // For now, this just updates all known tables for the provided project.
 func main() {
 	flag.Parse()
@@ -154,8 +156,7 @@ func main() {
 
 	errCount := 0
 
-	project := os.Getenv("GCLOUD_PROJECT")
-	if project == "" {
+	if *project == "" {
 		log.Fatal("Missing GCLOUD_PROJECT environment variable.")
 	}
 
@@ -166,52 +167,52 @@ func main() {
 		}
 		fallthrough
 	case "all": // Do everything
-		errCount += updateLegacyTables(project)
-		errCount += updateStandardTables(project)
+		errCount += updateLegacyTables(*project)
+		errCount += updateStandardTables(*project)
 
 	case "legacy":
-		errCount += updateLegacyTables(project)
+		errCount += updateLegacyTables(*project)
 
 	case "standard":
-		errCount += updateStandardTables(project)
+		errCount += updateStandardTables(*project)
 
 	case "tcpinfo":
-		if err := CreateOrUpdateTCPInfo(project, "base_tables", "tcpinfo"); err != nil {
+		if err := CreateOrUpdateTCPInfo(*project, "base_tables", "tcpinfo"); err != nil {
 			errCount++
 		}
-		if err := CreateOrUpdateTCPInfo(project, "batch", "tcpinfo"); err != nil {
+		if err := CreateOrUpdateTCPInfo(*project, "batch", "tcpinfo"); err != nil {
 			errCount++
 		}
 
 	case "traceroute":
-		if err := CreateOrUpdatePT(project, "base_tables", "traceroute"); err != nil {
+		if err := CreateOrUpdatePT(*project, "base_tables", "traceroute"); err != nil {
 			errCount++
 		}
-		if err := CreateOrUpdatePT(project, "batch", "traceroute"); err != nil {
+		if err := CreateOrUpdatePT(*project, "batch", "traceroute"); err != nil {
 			errCount++
 		}
 
 	case "ndt5":
-		if err := CreateOrUpdateNDT5ResultRow(project, "base_tables", "ndt5"); err != nil {
+		if err := CreateOrUpdateNDT5ResultRow(*project, "base_tables", "ndt5"); err != nil {
 			errCount++
 		}
-		if err := CreateOrUpdateNDT5ResultRow(project, "batch", "ndt5"); err != nil {
+		if err := CreateOrUpdateNDT5ResultRow(*project, "batch", "ndt5"); err != nil {
 			errCount++
 		}
 
 	case "ndt7":
-		if err := CreateOrUpdateNDT7ResultRow(project, "tmp_ndt", "ndt7"); err != nil {
+		if err := CreateOrUpdateNDT7ResultRow(*project, "tmp_ndt", "ndt7"); err != nil {
 			errCount++
 		}
-		if err := CreateOrUpdateNDT7ResultRow(project, "raw_ndt", "ndt7"); err != nil {
+		if err := CreateOrUpdateNDT7ResultRow(*project, "raw_ndt", "ndt7"); err != nil {
 			errCount++
 		}
 
 	case "annotation":
-		if err := CreateOrUpdateAnnotationRow(project, "tmp_ndt", "annotation"); err != nil {
+		if err := CreateOrUpdateAnnotationRow(*project, "tmp_ndt", "annotation"); err != nil {
 			errCount++
 		}
-		if err := CreateOrUpdateAnnotationRow(project, "raw_ndt", "annotation"); err != nil {
+		if err := CreateOrUpdateAnnotationRow(*project, "raw_ndt", "annotation"); err != nil {
 			errCount++
 		}
 

--- a/cmd/update-schema/update.go
+++ b/cmd/update-schema/update.go
@@ -107,6 +107,46 @@ var (
 	updateType = flag.String("updateType", "", "Short name of datatype to be updated (tcpinfo, scamper, ...).")
 )
 
+func updateStandardTables(project string) int {
+	errCount := 0
+	if err := CreateOrUpdateNDT7ResultRow(project, "tmp_ndt", "ndt7"); err != nil {
+		errCount++
+	}
+	if err := CreateOrUpdateNDT7ResultRow(project, "raw_ndt", "ndt7"); err != nil {
+		errCount++
+	}
+	if err := CreateOrUpdateAnnotationRow(project, "tmp_ndt", "annotation"); err != nil {
+		errCount++
+	}
+	if err := CreateOrUpdateAnnotationRow(project, "raw_ndt", "annotation"); err != nil {
+		errCount++
+	}
+	return errCount
+}
+
+func updateLegacyTables(project string) int {
+	errCount := 0
+	if err := CreateOrUpdateTCPInfo(project, "base_tables", "tcpinfo"); err != nil {
+		errCount++
+	}
+	if err := CreateOrUpdateTCPInfo(project, "batch", "tcpinfo"); err != nil {
+		errCount++
+	}
+	if err := CreateOrUpdatePT(project, "base_tables", "traceroute"); err != nil {
+		errCount++
+	}
+	if err := CreateOrUpdatePT(project, "batch", "traceroute"); err != nil {
+		errCount++
+	}
+	if err := CreateOrUpdateNDT5ResultRow(project, "base_tables", "ndt5"); err != nil {
+		errCount++
+	}
+	if err := CreateOrUpdateNDT5ResultRow(project, "batch", "ndt5"); err != nil {
+		errCount++
+	}
+	return errCount
+}
+
 // For now, this just updates all known tables for the provided project.
 func main() {
 	flag.Parse()
@@ -126,36 +166,14 @@ func main() {
 		}
 		fallthrough
 	case "all": // Do everything
-		if err := CreateOrUpdateTCPInfo(project, "base_tables", "tcpinfo"); err != nil {
-			errCount++
-		}
-		if err := CreateOrUpdateTCPInfo(project, "batch", "tcpinfo"); err != nil {
-			errCount++
-		}
-		if err := CreateOrUpdatePT(project, "base_tables", "traceroute"); err != nil {
-			errCount++
-		}
-		if err := CreateOrUpdatePT(project, "batch", "traceroute"); err != nil {
-			errCount++
-		}
-		if err := CreateOrUpdateNDT5ResultRow(project, "base_tables", "ndt5"); err != nil {
-			errCount++
-		}
-		if err := CreateOrUpdateNDT5ResultRow(project, "batch", "ndt5"); err != nil {
-			errCount++
-		}
-		if err := CreateOrUpdateNDT7ResultRow(project, "tmp_ndt", "ndt7"); err != nil {
-			errCount++
-		}
-		if err := CreateOrUpdateNDT7ResultRow(project, "raw_ndt", "ndt7"); err != nil {
-			errCount++
-		}
-		if err := CreateOrUpdateAnnotationRow(project, "tmp_ndt", "annotation"); err != nil {
-			errCount++
-		}
-		if err := CreateOrUpdateAnnotationRow(project, "raw_ndt", "annotation"); err != nil {
-			errCount++
-		}
+		errCount += updateLegacyTables(project)
+		errCount += updateStandardTables(project)
+
+	case "legacy":
+		errCount += updateLegacyTables(project)
+
+	case "standard":
+		errCount += updateStandardTables(project)
 
 	case "tcpinfo":
 		if err := CreateOrUpdateTCPInfo(project, "base_tables", "tcpinfo"); err != nil {


### PR DESCRIPTION
This mostly improves readability in .travis file for updating a subset of the schemas, corresponding to the Gardener v1 or v2 data types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/935)
<!-- Reviewable:end -->
