### PR TITLE
Use milliseconds not seconds

### DIFF
--- a/parser/ndt7_result.go
+++ b/parser/ndt7_result.go
@@ -186,8 +186,8 @@ func upRate(m []model.Measurement) float64 {
 func minRTT(m []model.Measurement) float64 {
 	var rtt float64
 	if len(m) > 0 {
-		// Convert to seconds.
-		rtt = float64(m[len(m)-1].TCPInfo.MinRTT) / 1000000
+		// Convert to milliseconds.
+		rtt = float64(m[len(m)-1].TCPInfo.MinRTT) / 1000
 	}
 	return rtt
 }

--- a/parser/ndt7_result_test.go
+++ b/parser/ndt7_result_test.go
@@ -57,7 +57,7 @@ func TestNDT7ResultParser_ParseAndInsert(t *testing.T) {
 					TestTime:           row.A.TestTime,
 					CongestionControl:  "bbr",
 					MeanThroughputMbps: 38.714033637501984,
-					MinRTT:             0.285804,
+					MinRTT:             285.804,
 					LossRate:           0.12029169202467564,
 				}
 				if diff := deep.Equal(row.A, exp); diff != nil {
@@ -96,7 +96,7 @@ func TestNDT7ResultParser_ParseAndInsert(t *testing.T) {
 					TestTime:           row.A.TestTime,
 					CongestionControl:  "bbr",
 					MeanThroughputMbps: 2.6848341983403983,
-					MinRTT:             0.173733,
+					MinRTT:             173.733,
 					LossRate:           0,
 				}
 				if diff := deep.Equal(row.A, exp); diff != nil {


### PR DESCRIPTION
Network researchers expect RTT to be in milliseconds. This change restores the MinRTT unit in the summary table to use `ms`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/938)
<!-- Reviewable:end -->
