### PR TITLE
Adds 10s to all v1 sample timestamps so that DISCOv1 matches DISCOv2-style timestamps

### DIFF
--- a/parser/disco.go
+++ b/parser/disco.go
@@ -103,6 +103,15 @@ func (dp *DiscoParser) ParseAndInsert(meta map[string]bigquery.Value, testName s
 				stats.Sample = tmp.Sample
 			} else {
 				stats.Sample = tmp.Sample[:len(tmp.Sample)-1]
+				// DISCOv1's Timestamp field in each sample represents the
+				// *beginning* of a 10s sample window, while v2's Timestamp
+				// represents the time at which the sample was taken, which is
+				// representative of the previous 10s. Since v2's behavior is
+				// what we want, we add 10s to all v1 Timestamps so that the
+				// timestamps represent the same thing for v1 and v2.
+				for i, v := range stats.Sample {
+					stats.Sample[i].Timestamp = v.Timestamp + 10
+				}
 			}
 		}
 


### PR DESCRIPTION
DISCOv1 sample timestamps represent the start/beginning of a 10s sample window, while v2 timestamps represent the end of a 10s sample window. Since the v2 behavior is more logical, for consistency, this PR adds 10s to all v1 sample timestamps so that they should match the *end* of the sample window, not the beginning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/954)
<!-- Reviewable:end -->
