### PR TITLE
Remove client and server annotations from ndt5 schema

### DIFF
--- a/schema/ndt5_result.go
+++ b/schema/ndt5_result.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/m-lab/go/cloud/bqx"
 	"github.com/m-lab/ndt-server/data"
-	"github.com/m-lab/uuid-annotator/annotator"
 
 	"github.com/m-lab/etl/row"
 )
@@ -48,10 +47,6 @@ type NDT5ResultRowStandardColumns struct {
 	Parser ParseInfo       `bigquery:"parser"`
 	Date   civil.Date      `bigquery:"date"`
 	Raw    data.NDT5Result `bigquery:"raw"`
-
-	// These will be populated by the join with the annotator data.
-	Server annotator.ServerAnnotations `bigquery:"server" json:"server"`
-	Client annotator.ClientAnnotations `bigquery:"client" json:"client"`
 
 	// NOT part of struct schema. Included only to provide a fake annotator interface.
 	row.NullAnnotator `bigquery:"-"`


### PR DESCRIPTION
The ndt7 schema does not include the server and client annotation fields because these fields are defined by the materialized join managed by etl-gardener.

This change removes the empty fields from the ndt5 schema because this data type should be managed like ndt7 wrt annotations.

Annotations pre-2020-03 will be exported by the annotation service to the annotation tables as part of future work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/963)
<!-- Reviewable:end -->
