### PR TITLE
Increase max instances

### DIFF
--- a/cmd/etl_worker/app-batch.yaml
+++ b/cmd/etl_worker/app-batch.yaml
@@ -21,7 +21,7 @@ resources:
 automatic_scaling:
   # This is intended for batch jobs.
   min_num_instances: 4
-  max_num_instances: 6
+  max_num_instances: 12
   # Very long cool down period, to reduce the likelihood of tasks being truncated.
   cool_down_period_sec: 1800
   # We don't care much about latency, so a high utilization is desireable.


### PR DESCRIPTION
The current AE batch parser instances are over saturated and task queues are timing out.

This change increases the max number of instances using the current etl-gardener queue settings (which are almost as low as they can go without turning any datatypes off).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/964)
<!-- Reviewable:end -->
