### PR TITLE
Prepare for cloudbuild migration 1 of 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,9 @@ script:
 
 # Clean build and prepare for deployment
 - cd $TRAVIS_BUILD_DIR/cmd/etl_worker &&
-  go build -v -ldflags "-X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h)" .
+  go build -v -ldflags "-X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h)
+    -X github.com/m-lab/etl/etl.Version=$TRAVIS_BRANCH$TRAVIS_TAG
+    -X github.com/m-lab/etl/etl.GitCommit=$(git log -1 --format=%H)" .
 - cd $TRAVIS_BUILD_DIR/cmd/update-schema &&
   go build -v
 - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ env:
 - PATH=$PATH:$HOME/gopath/bin
 
 before_install:
-- sudo apt-get install -y jq  # Dependency for sync_tables_with_schema.sh.
-
 # Coverage tools
 - go get github.com/mattn/goveralls
 - go get github.com/wadey/gocovmerge
@@ -169,8 +167,6 @@ deploy:
        SERVICE_ACCOUNT_mlab_sandbox $TRAVIS_BUILD_DIR/cmd/etl_worker app-batch.yaml
     && $TRAVIS_BUILD_DIR/travis/run_with_application_credentials.sh mlab-sandbox
        SERVICE_ACCOUNT_mlab_sandbox $TRAVIS_BUILD_DIR/cmd/update-schema update-schema
-#    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-sandbox batch nodryrun
-#    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-sandbox base_tables nodryrun
   skip_cleanup: true
   on:
     repo: m-lab/etl
@@ -183,7 +179,6 @@ deploy:
     $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_sandbox
     && $TRAVIS_BUILD_DIR/travis/run_with_application_credentials.sh mlab-sandbox
        SERVICE_ACCOUNT_mlab_sandbox $TRAVIS_BUILD_DIR/cmd/update-schema update-schema
-#   && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-sandbox base_tables nodryrun
   skip_cleanup: true
   on:
     repo: m-lab/etl
@@ -240,8 +235,6 @@ deploy:
        $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-staging data-processing ./apply-cluster.sh
     && $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
        SERVICE_ACCOUNT_mlab_staging $TRAVIS_BUILD_DIR/cmd/etl_worker app-batch.yaml
-#    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-staging batch nodryrun
-#    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-staging base_tables nodryrun
   skip_cleanup: true
   on:
     repo: m-lab/etl
@@ -281,7 +274,6 @@ deploy:
     $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_oti
     && $TRAVIS_BUILD_DIR/travis/run_with_application_credentials.sh mlab-oti
        SERVICE_ACCOUNT_mlab_oti $TRAVIS_BUILD_DIR/cmd/update-schema update-schema
-#    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-oti base_tables nodryrun
   skip_cleanup: true
   on:
     repo: m-lab/etl
@@ -299,7 +291,6 @@ deploy:
        SERVICE_ACCOUNT_mlab_oti $TRAVIS_BUILD_DIR/cmd/etl_worker app-batch.yaml
     && BIGQUERY_DATASET="tmp_ndt"
        $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-oti data-processing ./apply-cluster.sh
-#    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-oti batch nodryrun
   skip_cleanup: true
   on:
     repo: m-lab/etl
@@ -315,7 +306,6 @@ deploy:
     && $TRAVIS_BUILD_DIR/travis/run_with_application_credentials.sh mlab-oti
        SERVICE_ACCOUNT_mlab_oti $TRAVIS_BUILD_DIR/cmd/update-schema update-schema
     && gcloud app deploy --project=mlab-oti $TRAVIS_BUILD_DIR/appengine/queue.yaml
-#    && $TRAVIS_BUILD_DIR/etl-schema/schema/sync_tables_with_schema.sh mlab-oti base_tables nodryrun
   skip_cleanup: true
   on:
     repo: m-lab/etl

--- a/annotation/geo.go
+++ b/annotation/geo.go
@@ -10,7 +10,6 @@ import (
 	"log"
 	"net/http"
 	"net/url"
-	"os"
 	"runtime"
 	"strconv"
 	"time"
@@ -23,18 +22,22 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// AnnotatorURL holds the https address of the annotator.
-// TODO(gfr) See if there is a better way of determining
-// where to send the request (there almost certainly is)
-var AnnotatorURL = "https://annotator-dot-" +
-	os.Getenv("GCLOUD_PROJECT") +
-	".appspot.com"
+var (
+	// AnnotatorURL holds the https address of the annotator.
+	AnnotatorURL string
 
-// BaseURL provides the base URL for single annotation requests
-var BaseURL = AnnotatorURL + "/annotate?"
+	// BaseURL provides the base URL for single annotation requests
+	BaseURL string
 
-// BatchURL provides the base URL for batch annotation requests
-var BatchURL = AnnotatorURL + "/batch_annotate"
+	// BatchURL provides the base URL for batch annotation requests
+	BatchURL string
+)
+
+func SetupURLs(project string) {
+	AnnotatorURL = "https://annotator-dot-" + project + ".appspot.com"
+	BaseURL = AnnotatorURL + "/annotate?"
+	BatchURL = AnnotatorURL + "/batch_annotate"
+}
 
 // trackMissingResponses generates metrics for missing annotations.
 func trackMissingResponses(anno *api.GeoData) {

--- a/bq/bq_test.go
+++ b/bq/bq_test.go
@@ -135,7 +135,7 @@ func TestInsertConfig(t *testing.T) {
 	if isTravis {
 		return
 	}
-	os.Setenv("GCLOUD_PROJECT", "mlab-oti")
+	etl.GCloudProject = "mlab-oti"
 	in, err := bq.NewInserter(etl.SS, time.Now())
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/etl_worker/Dockerfile.k8s
+++ b/cmd/etl_worker/Dockerfile.k8s
@@ -1,5 +1,7 @@
 FROM golang:1.13 as builder
 
+ARG VERSION
+
 WORKDIR /go/src/github.com/m-lab/etl
 COPY . .
 
@@ -7,13 +9,15 @@ RUN go get -v ./...
 
 # This leave some dynamically linked lookups, but seems to work anyway.  But
 # it is unclear whether we might see random segfaults.
-RUN go install \
-    -tags netgo -a \
-    -v \
-    -ldflags "-linkmode external -extldflags -static -X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h)" \
-    ./cmd/etl_worker/...
+RUN go get \
+    -tags netgo -a -v \
+    -ldflags "-linkmode external -extldflags -static \
+      -X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h) \
+      -X github.com/m-lab/etl/etl.Version=$VERSION \
+      -X github.com/m-lab/etl/etl.GitCommit=$(git log -1 --format=%H)" \
+    ./cmd/etl_worker
 
-FROM alpine
+FROM alpine:3.12
 RUN apk add --no-cache ca-certificates
 
 COPY --from=builder /go/bin/etl_worker /bin/etl_worker

--- a/cmd/etl_worker/etl_worker_test.go
+++ b/cmd/etl_worker/etl_worker_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m-lab/go/osx"
+	"github.com/m-lab/etl/etl"
 )
 
 func init() {
@@ -34,16 +34,9 @@ func TestMain(t *testing.T) {
 	flag.Set("service_port", ":0")
 	flag.Set("max_active", "200")
 	flag.Set("prometheusx.listen-address", ":9090")
+	flag.Set("max_workers", "25")
+	flag.Set("gcloud_project", "mlab-testing")
 	mainCtx, mainCancel = context.WithCancel(context.Background())
-
-	vars := map[string]string{
-		"PROJECT":     "mlab-testing",
-		"MAX_WORKERS": "25",
-	}
-	for k, v := range vars {
-		cleanup := osx.MustSetenv(k, v)
-		defer cleanup()
-	}
 
 	go main()
 	defer mainCancel()
@@ -85,21 +78,14 @@ func TestMain(t *testing.T) {
 }
 
 func TestPollingMode(t *testing.T) {
+	flag.Set("service_port", ":0")
+	flag.Set("max_active", "200")
 	flag.Set("prometheusx.listen-address", ":9090")
+	flag.Set("max_workers", "25")
+	flag.Set("gcloud_project", "mlab-testing")
+	flag.Set("gardener_host", "gardener")
+	etl.GitCommit = "123456789ABCDEF"
 	mainCtx, mainCancel = context.WithCancel(context.Background())
-
-	vars := map[string]string{
-		"PROJECT":        "mlab-testing",
-		"GCLOUD_PROJECT": "mlab-testing",
-		"GARDENER_HOST":  "gardener",
-		"MAX_ACTIVE":     "200",
-		"SERVICE_PORT":   ":0",
-		"COMMIT_HASH":    "123456789ABCDEF",
-	}
-	for k, v := range vars {
-		cleanup := osx.MustSetenv(k, v)
-		defer cleanup()
-	}
 
 	go main()
 	defer mainCancel()

--- a/etl/globals_test.go
+++ b/etl/globals_test.go
@@ -3,7 +3,6 @@ package etl_test
 import (
 	"fmt"
 	"log"
-	"os"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -207,7 +206,7 @@ func TestDataset(t *testing.T) {
 	}
 
 	// Project shouldn't matter, so test different values to confirm.
-	os.Setenv("GCLOUD_PROJECT", "mlab-sandbox")
+	etl.GCloudProject = "mlab-sandbox"
 	for _, test := range tests {
 		etl.IsBatch = test.isBatch
 		got := test.dt.Dataset()
@@ -215,7 +214,7 @@ func TestDataset(t *testing.T) {
 			t.Errorf("for %s want: %s, got: %s.", test.dt, test.want, got)
 		}
 	}
-	os.Setenv("GCLOUD_PROJECT", "mlab-oti")
+	etl.GCloudProject = "mlab-oti"
 	for _, test := range tests {
 		etl.IsBatch = test.isBatch
 		got := test.dt.Dataset()
@@ -238,7 +237,7 @@ func TestDataset(t *testing.T) {
 	}
 
 	// Test override
-	os.Setenv("BIGQUERY_DATASET", "override")
+	etl.BigqueryDataset = "override"
 	for _, test := range override_tests {
 		etl.IsBatch = test.isBatch
 		got := test.dt.Dataset()
@@ -265,7 +264,7 @@ func TestBQProject(t *testing.T) {
 	// isBatch  state shouldn't matter, so test with both values
 	etl.IsBatch = true
 	for _, test := range tests {
-		os.Setenv("GCLOUD_PROJECT", test.gproject)
+		etl.GCloudProject = test.gproject
 		got := test.dt.BigqueryProject()
 		if got != test.want {
 			t.Errorf("for %s,%s, want: %s, got: %s.", test.dt, test.gproject, test.want, got)
@@ -273,7 +272,7 @@ func TestBQProject(t *testing.T) {
 	}
 	etl.IsBatch = false
 	for _, test := range tests {
-		os.Setenv("GCLOUD_PROJECT", test.gproject)
+		etl.GCloudProject = test.gproject
 		got := test.dt.BigqueryProject()
 		if got != test.want {
 			t.Errorf("for %s,%s, want: %s, got: %s.", test.dt, test.gproject, test.want, got)
@@ -281,7 +280,7 @@ func TestBQProject(t *testing.T) {
 	}
 
 	// Test override
-	os.Setenv("BIGQUERY_PROJECT", "override_project")
+	etl.BigqueryProject = "override_project"
 	override_tests := []struct {
 		dt       etl.DataType
 		gproject string
@@ -295,7 +294,7 @@ func TestBQProject(t *testing.T) {
 	}
 	etl.IsBatch = false
 	for _, test := range override_tests {
-		os.Setenv("GCLOUD_PROJECT", test.gproject)
+		etl.GCloudProject = test.gproject
 		got := test.dt.BigqueryProject()
 		if got != test.want {
 			t.Errorf("for %s,%s, want: %s, got: %s.", test.dt, test.gproject, test.want, got)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -12,27 +12,20 @@ import (
 	"log"
 	"math"
 	"net/http"
-	"os"
 	"runtime"
 	"runtime/debug"
 	"time"
 
+	"github.com/m-lab/etl/etl"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 func init() {
 	NumCPU.Set(float64(runtime.NumCPU()))
-
-	commit, ok := os.LookupEnv("GIT_COMMIT")
-	if ok {
-		CommitHash.WithLabelValues(commit).Set(1)
-	}
-
-	release, ok := os.LookupEnv("RELEASE_TAG")
-	if ok {
-		ReleaseTag.WithLabelValues(release).Set(1)
-	}
+	// Update metrics with static commit and version.
+	CommitHash.WithLabelValues(etl.GitCommit).Set(1)
+	ReleaseTag.WithLabelValues(etl.Version).Set(1)
 }
 
 var (

--- a/parser/base_test.go
+++ b/parser/base_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 	"time"
 
@@ -54,9 +53,6 @@ func assertTestRowAnnotatable(r *Row) {
 }
 
 func TestBase(t *testing.T) {
-	os.Setenv("RELEASE_TAG", "foobar")
-	parser.InitParserVersionForTest()
-
 	ins := &inMemoryInserter{}
 
 	// Set up fake annotation service
@@ -122,9 +118,6 @@ func TestBase(t *testing.T) {
 }
 
 func TestAsyncPut(t *testing.T) {
-	os.Setenv("RELEASE_TAG", "foobar")
-	parser.InitParserVersionForTest()
-
 	ins := &inMemoryInserter{}
 
 	// Set up fake annotation service
@@ -187,9 +180,6 @@ func TestAsyncPut(t *testing.T) {
 }
 
 func TestEmptyAnnotations(t *testing.T) {
-	os.Setenv("RELEASE_TAG", "foobar")
-	parser.InitParserVersionForTest()
-
 	ins := &inMemoryInserter{}
 
 	// Set up fake annotation service

--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -39,8 +39,6 @@ import (
 )
 
 var (
-	// NDTOmitDeltas flag indicates if deltas should be suppressed.
-	NDTOmitDeltas, _ = strconv.ParseBool(os.Getenv("NDT_OMIT_DELTAS"))
 	// NDTEstimateBW flag indicates if we should run BW estimation code
 	// and annotate rows.
 	NDTEstimateBW, _ = strconv.ParseBool(os.Getenv("NDT_ESTIMATE_BW"))
@@ -401,7 +399,7 @@ func (n *NDTParser) processTest(test *fileInfoAndData, testType string) {
 func (n *NDTParser) getDeltas(snaplog *web100.SnapLog, testType string) ([]schema.Web100ValueMap, int) {
 	deltas := []schema.Web100ValueMap{}
 	deltaFieldCount := 0
-	if NDTOmitDeltas {
+	if etl.OmitDeltas {
 		return deltas, deltaFieldCount
 	}
 	snapshotCount := 0

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -4,7 +4,6 @@ package parser
 
 import (
 	"log"
-	"os"
 	"reflect"
 
 	"cloud.google.com/go/bigquery"
@@ -24,12 +23,12 @@ var gParserVersion = "uninitialized"
 
 // initParserVersion initializes the gParserVersion variable for use by all parsers.
 func initParserVersion() string {
-	release, ok := os.LookupEnv("RELEASE_TAG")
-	if ok && release != "empty_tag" {
+	release := etl.Version
+	if release != "noversion" {
 		gParserVersion = "https://github.com/m-lab/etl/tree/" + release
 	} else {
-		hash := os.Getenv("COMMIT_HASH")
-		if len(hash) >= 8 {
+		hash := etl.GitCommit
+		if hash != "nocommit" && len(hash) >= 8 {
 			gParserVersion = "https://github.com/m-lab/etl/tree/" + hash[0:8]
 		} else {
 			gParserVersion = "local development"

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -16,6 +16,11 @@ import (
 	"github.com/m-lab/pipe"
 )
 
+func init() {
+	etl.Version = "foobar"
+	parser.InitParserVersionForTest()
+}
+
 // countingInserter counts the calls to InsertRows and Flush.
 // Inject into Parser for testing.
 type countingInserter struct {

--- a/parser/ss_test.go
+++ b/parser/ss_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 	"time"
 
@@ -67,9 +66,6 @@ func TestParseOneLine(t *testing.T) {
 }
 
 func TestSSInserter(t *testing.T) {
-	os.Setenv("RELEASE_TAG", "foobar")
-	parser.InitParserVersionForTest()
-
 	ins := &inMemoryInserter{}
 	// Completely fake annotation data.
 	responseJSON := `{"AnnotatorDate":"2018-12-05T00:00:00Z",

--- a/parser/tcpinfo_test.go
+++ b/parser/tcpinfo_test.go
@@ -113,7 +113,6 @@ func (nc nullCloser) Close() error { return nil }
 // NOTE: This uses a fake annotator which returns no annotations.
 // TODO: This test seems to be flakey in travis - sometimes only 357 tests instead of 362
 func TestTCPParser(t *testing.T) {
-	os.Setenv("RELEASE_TAG", "foobar")
 	parserVersion := parser.InitParserVersionForTest()
 
 	filename := "testdata/20190516T013026.744845Z-tcpinfo-mlab4-arn02-ndt.tgz"
@@ -223,9 +222,6 @@ func TestTCPParser(t *testing.T) {
 
 // This is a subset of TestTCPParser, but simpler, so might be useful.
 func TestTCPTask(t *testing.T) {
-	os.Setenv("RELEASE_TAG", "foobar")
-	parser.InitParserVersionForTest()
-
 	// Inject fake inserter and annotator
 	ins := newInMemorySink()
 	p := parser.NewTCPInfoParser(ins, "test", "_suffix", &fakeAnnotator{})
@@ -248,9 +244,6 @@ func TestTCPTask(t *testing.T) {
 }
 
 func TestBQSaver(t *testing.T) {
-	os.Setenv("RELEASE_TAG", "foobar")
-	parser.InitParserVersionForTest()
-
 	// Inject fake inserter and annotator
 	ins := newInMemorySink()
 	p := parser.NewTCPInfoParser(ins, "test", "_suffix", &fakeAnnotator{})
@@ -288,9 +281,6 @@ func TestBQSaver(t *testing.T) {
 func TestTaskToGCS(t *testing.T) {
 	t.Skip("Skipping test intended for manual experimentation")
 
-	os.Setenv("RELEASE_TAG", "foobar")
-	parser.InitParserVersionForTest()
-
 	c, err := storage.GetStorageClient(true)
 	if err != nil {
 		t.Fatal(err)
@@ -326,9 +316,6 @@ func TestTaskToGCS(t *testing.T) {
 }
 
 func BenchmarkTCPParser(b *testing.B) {
-	os.Setenv("RELEASE_TAG", "foobar")
-	parser.InitParserVersionForTest()
-
 	// Inject fake inserter and annotator
 	ins := newInMemorySink()
 	p := parser.NewTCPInfoParser(ins, "test", "_suffix", &fakeAnnotator{})


### PR DESCRIPTION
This change prepares for migration of the ETL build and deployment to cloudbuild, the first of two changes.

This change removes use of `os.Getenv` and `os.LookupEnv` throughout the sources in favor of flags that can be set using environment variables. In particular, this makes the `GitCommit` and `Version` variables set at build time, instead of reading them from the environment. In several other cases, this change means using global package variables until code is improved to set a "config" struct to pass around for access to these runtime flags.

NOTE: once this change is merged, the 'Version' will not be set correctly in mlab-staging for the universal gardener by the existing cloudbuild of the Dockerfile. The second change that completes the CB migration is ready and will resolve this.

TESTING: with the exception of the Version, I manually checked that current sandbox deployments appear to continue to work as before based on the [Pipeline][pipeline] grafana dashboards

[pipeline]: https://grafana.mlab-sandbox.measurementlab.net/d/000000037/pipeline-parser?orgId=1&var-datasource=Prometheus%20(mlab-sandbox)&var-interval=2m&var-table=ndt&var-service=All&var-show_count=sum%20by(service)&from=now-7d&to=now

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/972)
<!-- Reviewable:end -->
