### PR TITLE
Complete etl deployment migration to cloudbuild.yaml 2 of 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,327 +1,43 @@
-# Travis configuration for etl-worker.
+# Travis configuration for etl parser.
 #
-# etl-worker is a Go project supporting release automation to mlab-sandbox
-# for a single branch in the m-lab/etl repository. The steps it takes are:
+# etl parser is a Go project with release automation through Cloud Build.
 #
-#  * decrypt service account credentials
-#  * install the Google Cloud SDK command line tools (gcloud)
-#  * cache the gcloud installation and setup
-#  * test and build the go code
-#  * on success, deploy the result when the origin branch matches a supported
-#    deployment target.
+# The travis-ci.com configuration performs unit and integration tests, and code
+# coverage only.
 
 dist: bionic
 language: go
 go:
- - "1.13.8"
+ - "1.15.8"
 
 env:
 - PATH=$PATH:$HOME/gopath/bin
 
 before_install:
-# Coverage tools
+- echo Branch is ${TRAVIS_BRANCH} and Tag is ${TRAVIS_TAG}
+
+# Install coverage tools.
 - go get github.com/mattn/goveralls
 - go get github.com/wadey/gocovmerge
 
-- echo Branch is ${TRAVIS_BRANCH} and Tag is $TRAVIS_TAG
-
 # Install gcloud, for integration tests.
-# TODO: maybe just use travis apt: packages: ?
 - $TRAVIS_BUILD_DIR/travis/install_gcloud.sh
 - source "${HOME}/google-cloud-sdk/path.bash.inc"
 
-# Install test credentials.
-# The service account variables are uploaded to travis by running,
-# from root of repo directory:
-#  travis/setup_service_accounts_for_travis.sh
-#
-# Note that anyone with github ACLs to push to a branch can hack .travis.yml
-# and discover these credentials in the travis logs.
-- if [[ -n "$TEST_SERVICE_ACCOUNT_mlab_testing" ]] ; then
-  echo $TEST_SERVICE_ACCOUNT_mlab_testing | base64 -d > travis-testing.key ;
-  gcloud auth activate-service-account --key-file=travis-testing.key ;
-  fi
-
-# These directories will be cached on successful "script" builds, and restored,
-# if available, to save time on future builds.
-cache:
-  directories:
-    - "$HOME/google-cloud-sdk/"
-
 install:
-  # Install kexpand templating tool. Only works from HEAD.
-- go get github.com/kopeio/kexpand
-- $TRAVIS_BUILD_DIR/travis/install_gcloud.sh kubectl
-
-# Get dependencies
+# Get dependencies for repo and integration tests.
 - cd $TRAVIS_BUILD_DIR
-- go get -v -t ./... || go get -v -t ./...
-
-# List submodule versions
-- git submodule
+- go get -v -t ./...
+- go get -v -t -tags=integration ./...
 
 script:
-# To start the Go tests, run all the non-integration tests.
-# Currently skipping storage tests, because they depend on GCS, and there is
-# no emulator.
-# TODO - separate storage tests into integration and lightweight.
-- MODULES="active annotation bq etl metrics parser schema task web100"
-- for module in $MODULES; do
-    COVER_PKGS=${COVER_PKGS}./$module/..., ;
-  done
-- COVER_PKGS=${COVER_PKGS::-1}  # Trim the trailing comma
-- EC=0
-# Note that for modules in subdirectories, this replaces separating slashes with _.
-- for module in $MODULES; do
-    go test -v -coverpkg=$COVER_PKGS -coverprofile=${module//\//_}.cov github.com/m-lab/etl/$module ;
-    EC=$[ $EC || $? ] ;
-    echo "status $EC" ;
-  done
-- echo "summary status $EC" ;
-- if [[ $EC != 0 ]]; then false; fi ;
+# Run all unit tests that do not require service account credentials.
+- go test -v -coverprofile=_unit.cov ./...
 
-# Rerun modules with integration tests.  This means that some tests are repeated, but otherwise
-# we lose some coverage.  The corresponding cov files are overwritten, but that is OK since
-# the non-integration tests are repeated.  If we change the unit tests to NOT run when integration
-# test tag is set, then we would need to have separate cov files.
+# Run all integration tests that DO require service account credentials.
 # Note: we do not run integration tests from forked PRs b/c the SA is unavailable.
-# Note that for modules in subdirectories, this replaces separating slashes with _.
-- if [[ -n "$TEST_SERVICE_ACCOUNT_mlab_testing" ]] ; then
-  for module in metrics ; do
-    go test -v -coverpkg=$COVER_PKGS -coverprofile=${module//\//_}.cov github.com/m-lab/etl/$module -tags=integration ;
-    EC=$[ $EC || $? ] ;
-    echo "summary $EC" ;
-  done ;
-  echo "summary status $EC" ;
-  if [[ $EC != 0 ]]; then false; fi ;
-  fi
+- ./integration-testing.sh
 
-# Coveralls
-# Run "unit tests" with coverage.
-
-# Coveralls
+# Report coverage statistics to coveralls.io
 - $HOME/gopath/bin/gocovmerge *.cov > merge.cov
 - $HOME/gopath/bin/goveralls -coverprofile=merge.cov -service=travis-ci || true
-
-# Clean build and prepare for deployment
-- cd $TRAVIS_BUILD_DIR/cmd/etl_worker &&
-  go build -v -ldflags "-X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h)
-    -X github.com/m-lab/etl/etl.Version=$TRAVIS_BRANCH$TRAVIS_TAG
-    -X github.com/m-lab/etl/etl.GitCommit=$(git log -1 --format=%H)" .
-- cd $TRAVIS_BUILD_DIR/cmd/update-schema &&
-  go build -v
-- cd $TRAVIS_BUILD_DIR
-
-#################################################################################
-# Deployment Section
-#
-#  Overview:
-#   1.  Test in sandbox during development
-#   2.  Deploy to staging on commit to master
-#   3.  Deploy to prod when a branch is tagged with prod-* or xxx-prod-*
-#
-#  We want to test individual components in sandbox, and avoid stepping on each
-#  other, so we do NOT automate deployment to sandbox.  Each person should
-#  use a branch name to trigger the single deployment that they are working on.
-#
-#  We want to soak all code in staging before deploying to prod.  To avoid
-#  incompatible components, we deploy ALL elements to staging when we merge
-#  to master branch.
-#
-#  Deployments to prod are done by deliberately tagging a specific commit,
-#  typically in the master branch, with a tag starting with prod-*.
-#  DO NOT just tag the latest version in master, as someone may have
-#  pushed new code that hasn't had a chance to soak in staging.
-#
-#
-# Deploy steps never trigger on a new Pull Request. Deploy steps will trigger
-# on specific branch name patterns, after a merge to master, or on
-# an explicit tag that matches "on:" conditions.
-#################################################################################
-
-deploy:
-######################################################################
-#  Sandbox deployments
-#  - before code review for development code in a specific branch.
-######################################################################
-
-## Task Queues
-- provider: script
-  script:
-    $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_sandbox
-    && gcloud app deploy --project=mlab-sandbox $TRAVIS_BUILD_DIR/appengine/queue.yaml
-  skip_cleanup: true
-  on:
-    repo: m-lab/etl
-    all_branches: true
-    condition: $TRAVIS_BRANCH == tq-sandbox-* ||
-               $TRAVIS_BRANCH == ndt-sandbox-* ||
-               $TRAVIS_BRANCH == batch-sandbox-* ||
-               $TRAVIS_BRANCH == sandbox-*
-
-## Service: etl-batch-parser -- AppEngine Flexible Environment.
-- provider: script
-  script:
-    $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_sandbox
-    && $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-sandbox
-       SERVICE_ACCOUNT_mlab_sandbox $TRAVIS_BUILD_DIR/cmd/etl_worker app-batch.yaml
-    && $TRAVIS_BUILD_DIR/travis/run_with_application_credentials.sh mlab-sandbox
-       SERVICE_ACCOUNT_mlab_sandbox $TRAVIS_BUILD_DIR/cmd/update-schema update-schema
-  skip_cleanup: true
-  on:
-    repo: m-lab/etl
-    all_branches: true
-    condition: $TRAVIS_BRANCH == batch-sandbox-* || $TRAVIS_BRANCH == sandbox-*
-
-## Synchronize base_tables with etl-schemas.
-- provider: script
-  script:
-    $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_sandbox
-    && $TRAVIS_BUILD_DIR/travis/run_with_application_credentials.sh mlab-sandbox
-       SERVICE_ACCOUNT_mlab_sandbox $TRAVIS_BUILD_DIR/cmd/update-schema update-schema
-  skip_cleanup: true
-  on:
-    repo: m-lab/etl
-    all_branches: true
-    condition: $TRAVIS_BRANCH == sandbox-*
-
-
-## Service: etl-universal-parser -- AppEngine Flexible Environment.
-## The universal parser actively reprocesses existing data.  It will eventually replace etl-batch-parser
-## and all daily parsers.
-- provider: script
-  script:
-    $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_sandbox
-    && $TRAVIS_BUILD_DIR/travis/run_with_application_credentials.sh mlab-sandbox
-       SERVICE_ACCOUNT_mlab_sandbox $TRAVIS_BUILD_DIR/cmd/update-schema update-schema -updateType=standard
-    && BIGQUERY_DATASET="tmp_ndt"
-       $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-sandbox data-processing ./apply-cluster.sh
-  skip_cleanup: true
-  on:
-    repo: m-lab/etl
-    all_branches: true
-    condition: $TRAVIS_BRANCH == u-sandbox-* ||  $TRAVIS_BRANCH == universal-sandbox-*
-
-######################################################################
-#  Staging deployments
-#  Auto deployed on merge with master branch
-#  There are no mini-deployments here.  ALL elements are redeployed
-#  when merges to master occur, and they have no other trigger.
-#  NOTE: This may lead to timeouts.  Generally, triggering the build
-#        again will help, as the redeployment of the same image is
-#        faster than deployment of a new image.
-#        See:
-#  https://groups.google.com/forum/#!topic/google-appengine/hZMEkmmObDU
-#  https://groups.google.com/forum/#!topic/google-appengine/JTUfl-Kl_B0
-#  https://stackoverflow.com/questions/40205222/why-does-google-appengine-deployment-take-several-minutes-to-update-service
-#  https://stackoverflow.com/questions/37683120/gcloud-preview-app-deploy-process-takes-8-minutes-is-this-normal
-######################################################################
-
-###################### ALL ETL SERVICES ###############################
-# Deploys all staging services: NDT, BATCH, PT, SS, DISCO, GARDENER
-# NOTE:
-#  Failure in one of the deployments will terminate the deployment sequence, leaving
-#  the system in a mixed state.  This should be manually addresses ASAP.
-# TODO - should have a bash script to do this deployment, with possible parallelism
-# and better error handling.
-- provider: script
-  script:
-    $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_staging
-    && gcloud app deploy --project=mlab-staging $TRAVIS_BUILD_DIR/appengine/queue.yaml
-    && travis/kubectl.sh mlab-staging data-processing ./apply-cluster.sh
-    && $TRAVIS_BUILD_DIR/travis/run_with_application_credentials.sh mlab-staging
-       SERVICE_ACCOUNT_mlab_staging $TRAVIS_BUILD_DIR/cmd/update-schema update-schema
-    && BIGQUERY_DATASET="tmp_ndt"
-       $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-staging data-processing ./apply-cluster.sh
-    && $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-staging
-       SERVICE_ACCOUNT_mlab_staging $TRAVIS_BUILD_DIR/cmd/etl_worker app-batch.yaml
-  skip_cleanup: true
-  on:
-    repo: m-lab/etl
-    branch: master
-
-######################################################################
-#  Prod deployments
-#  Deployed on manual tagging with prod-*, ndt-prod-*, or small-prod-*
-#  Should be used AFTER code review, commit to master, and staging soak.
-#  Triggers when *ANY* branch is tagged with one of these tags'
-######################################################################
-
-###################### UNIVERSAL PARSER ###############################
-# Deploys Universal K8S Parser.
-# Triggers when *ANY* branch is tagged with u-prod-* OR prod-*
-- provider: script
-  script:
-    $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_oti
-    && $TRAVIS_BUILD_DIR/travis/run_with_application_credentials.sh mlab-oti
-       SERVICE_ACCOUNT_mlab_oti $TRAVIS_BUILD_DIR/cmd/update-schema update-schema -updateType=standard
-    && BIGQUERY_DATASET="tmp_ndt"
-       $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-oti data-processing ./apply-cluster.sh
-  on:
-    repo: m-lab/etl
-    all_branches: true
-    condition: $TRAVIS_TAG == prod-* || $TRAVIS_BRANCH == u-prod-*
-
-###################### SMALLER ETL SERVICES ###############################
-# Deploys smaller production services: PT, SS, DISCO
-# Triggers when *ANY* branch is tagged with small-prod-* OR prod-*
-# NOTE: See later target for ndt-prod-*, which also triggers on prod-*, and
-#       deploys the NDT daily pipelines.
-# NOTE: Failure in one of the deployments will terminate the deployment sequence,
-#       leaving the system in a mixed state.  This should be manually addresses ASAP.
-- provider: script
-  script:
-    $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_oti
-    && $TRAVIS_BUILD_DIR/travis/run_with_application_credentials.sh mlab-oti
-       SERVICE_ACCOUNT_mlab_oti $TRAVIS_BUILD_DIR/cmd/update-schema update-schema
-  skip_cleanup: true
-  on:
-    repo: m-lab/etl
-    all_branches: true
-    condition: $TRAVIS_TAG == small-prod-* || $TRAVIS_TAG == prod-*
-
-###################### BATCH SERVICES ###############################
-- provider: script
-  script:
-    $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_oti
-    && $TRAVIS_BUILD_DIR/travis/run_with_application_credentials.sh mlab-oti
-       SERVICE_ACCOUNT_mlab_oti $TRAVIS_BUILD_DIR/cmd/update-schema update-schema
-    && gcloud app deploy --project=mlab-oti $TRAVIS_BUILD_DIR/appengine/queue.yaml
-    && $TRAVIS_BUILD_DIR/travis/deploy_app.sh mlab-oti
-       SERVICE_ACCOUNT_mlab_oti $TRAVIS_BUILD_DIR/cmd/etl_worker app-batch.yaml
-    && BIGQUERY_DATASET="tmp_ndt"
-       $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-oti data-processing ./apply-cluster.sh
-  skip_cleanup: true
-  on:
-    repo: m-lab/etl
-    all_branches: true
-    condition: $TRAVIS_TAG == batch-prod-* || $TRAVIS_TAG == prod-*
-
-###################### NDT SERVICES ###############################
-# Deploys STREAMING NDT services, along with queue config.
-# Triggers when *ANY* branch is tagged with ndt-prod-* OR prod-*
-- provider: script
-  script:
-    $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_oti
-    && $TRAVIS_BUILD_DIR/travis/run_with_application_credentials.sh mlab-oti
-       SERVICE_ACCOUNT_mlab_oti $TRAVIS_BUILD_DIR/cmd/update-schema update-schema
-    && gcloud app deploy --project=mlab-oti $TRAVIS_BUILD_DIR/appengine/queue.yaml
-  skip_cleanup: true
-  on:
-    repo: m-lab/etl
-    all_branches: true
-    condition: $TRAVIS_TAG == ndt-prod-* || $TRAVIS_TAG == prod-*
-
-
-##################### UPDATE SCHEMAS ###############################
-# Updates or creates schemas in BigQuery
-- provider: script
-  script:
-    $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_oti
-    && $TRAVIS_BUILD_DIR/travis/run_with_application_credentials.sh mlab-oti
-       SERVICE_ACCOUNT_mlab_oti $TRAVIS_BUILD_DIR/cmd/update-schema update-schema
-  skip_cleanup: true
-  on:
-    repo: m-lab/etl
-    all_branches: true
-    condition: $TRAVIS_BRANCH == ndt-prod-* || $TRAVIS_BRANCH == prod-*

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -1,0 +1,24 @@
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:331.0.0
+
+
+# Fetch recent go version.
+ENV GOLANG_VERSION 1.15.8
+ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
+ENV GOLANG_DOWNLOAD_SHA256 d3379c32a90fdf9382166f8f48034c459a8cc433730bc9476d39d9082c94583b
+
+RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
+    && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
+    && tar -C /usr/local/ -xzf golang.tar.gz \
+    && rm golang.tar.gz
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+WORKDIR $GOPATH
+
+# Install binaries needed for builds and testing.
+RUN apt-get update
+RUN apt-get install -y jq gcc netcat
+RUN go get -v github.com/m-lab/gcp-config/cmd/cbif
+
+ENTRYPOINT ["/go/bin/cbif"]

--- a/apply-cluster.sh
+++ b/apply-cluster.sh
@@ -6,30 +6,24 @@
 #
 # Example:
 #
-#   PROJECT=mlab-sandbox CLUSTER=scraper-cluster ./apply-cluster.sh
+#   PROJECT_ID=mlab-sandbox CLOUDSDK_CONTAINER_CLUSTER=data-processing ./apply-cluster.sh
 
 set -x
 set -e
 set -u
 
-USAGE="PROJECT=<projectid> CLUSTER=<cluster> TRAVIS_TAG=<tag> TRAVIS_COMMIT=<commit> $0"
-PROJECT=${PROJECT:?Please provide project id: $USAGE}
-CLUSTER=${CLUSTER:?Please provide cluster name: $USAGE}
-TRAVIS_TAG=${TRAVIS_TAG:-empty_tag}
+USAGE="PROJECT_ID=<projectid> CLOUDSDK_CONTAINER_CLUSTER=<cluster> $0"
+PROJECT_ID=${PROJECT_ID:?Please provide project id: $USAGE}
+CLUSTER=${CLOUDSDK_CONTAINER_CLUSTER:?Please provide cluster name: $USAGE}
 BIGQUERY_DATASET=${BIGQUERY_DATASET:-empty_tag}
-TRAVIS_COMMIT=${TRAVIS_COMMIT:?Please provide travis commit: $USAGE}
 
 # Apply templates
-CFG=/tmp/${CLUSTER}-${PROJECT}.yml
-touch ${CFG}
-pwd
-kexpand expand --ignore-missing-keys k8s/${CLUSTER}/*/*.yml \
-    --value GCLOUD_PROJECT=${PROJECT} \
-    --value RELEASE_TAG=${TRAVIS_TAG} \
-    --value GIT_COMMIT=${TRAVIS_COMMIT} \
-    --value BIGQUERY_DATASET=${BIGQUERY_DATASET} \
-    > ${CFG}
-cat ${CFG}
+find k8s/${CLUSTER}/ -type f -exec \
+    sed -i \
+      -e 's/{{GIT_COMMIT}}/'${GIT_COMMIT}'/g' \
+      -e 's/{{GCLOUD_PROJECT}}/'${PROJECT_ID}'/g' \
+      -e 's/{{BIGQUERY_DATASET}}/'${BIGQUERY_DATASET}'/g' \
+      {} \;
 
 # This triggers deployment of the pod.
-kubectl apply -f ${CFG}
+kubectl apply --recursive -f k8s/${CLUSTER}

--- a/bq/bq_test.go
+++ b/bq/bq_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package bq_test
 
 import (

--- a/bq/gke_test.go
+++ b/bq/gke_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package bq_test
 
 import (

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,134 @@
+#################################################################################
+# Deployment Section
+#
+#  Overview:
+#   1.  Test in sandbox during development
+#   2.  Deploy to staging on commit to master
+#   3.  Deploy to prod when a branch is tagged with prod-* or xxx-prod-*
+#
+#  We want to test individual components in sandbox, and avoid stepping on each
+#  other, so we do NOT automate deployment to sandbox.  Each person should
+#  use a branch name to trigger the single deployment that they are working on.
+#
+#  We want to soak all code in staging before deploying to prod.  To avoid
+#  incompatible components, we deploy ALL elements to staging when we merge
+#  to master branch.
+#
+#  Deployments to prod are done by deliberately tagging a specific commit,
+#  typically in the master branch, with a tag starting with prod-*.
+#  DO NOT just tag the latest version in master, as someone may have
+#  pushed new code that hasn't had a chance to soak in staging.
+#
+#
+# Deploy steps never trigger on a new Pull Request. Deploy steps will trigger
+# on specific branch name patterns, after a merge to master, or on
+# an explicit tag that matches "on:" conditions.
+#################################################################################
+
+timeout: 1800s
+
+options:
+  env:
+  - PROJECT_ID=$PROJECT_ID
+  - GIT_COMMIT=$COMMIT_SHA
+
+steps:
+# Make all git tags available.
+- name: gcr.io/cloud-builders/git
+  id: "Unshallow git clone"
+  args: ["fetch", "--unshallow"]
+
+# Fetch travis submodule.
+- name: gcr.io/cloud-builders/git
+  id: "Update travis submodule"
+  args: ["submodule", "update", "--init", "--recursive"]
+
+# TODO: while local docker builds cache intermediate layers, CB does not.
+# Combine the Dockerfile.testing with the Dockerfile using --target and
+# --from-cache to speed up builds: See also:
+# https://andrewlock.net/caching-docker-layers-on-serverless-build-hosts-with-multi-stage-builds---target,-and---cache-from/
+- name: gcr.io/cloud-builders/docker
+  id: "Build the testing docker container"
+  args: [
+    "build", "-t", "etl-testing", "-f", "Dockerfile.testing", "."
+  ]
+
+- name: etl-testing
+  id: "Run all etl unit tests"
+  args:
+  - go version
+  - go get -v -t ./...
+  - go get -v -tags=integration -t ./...
+
+  # Run tests.
+  - go test -v -coverprofile=_unit.cov ./...
+  # TODO: race detected in TestGardenerAPI_RunAll
+  # - go test -v ./... -race
+  # Integration testing requires additional SA credentials.
+  - ./integration-testing.sh
+  # Build update-schema command, with binary in cloudbuild /workspace.
+  - go build ./cmd/update-schema
+  env:
+  - SERVICE_ACCOUNT_mlab_testing=$_SERVICE_ACCOUNT_MLAB_TESTING
+  - WORKSPACE_LINK=/go/src/github.com/m-lab/etl
+
+- name: gcr.io/cloud-builders/docker
+  id: "Build the etl docker container"
+  args: [
+    "build",
+      "--build-arg", "VERSION=${TAG_NAME}${BRANCH_NAME}",
+      "-t", "gcr.io/$PROJECT_ID/etl:$_DOCKER_TAG",
+      "-f", "cmd/etl_worker/Dockerfile.k8s", "."
+  ]
+
+- name: gcr.io/cloud-builders/docker
+  id: "Push the docker container to gcr.io"
+  args: [
+    "push", "gcr.io/$PROJECT_ID/etl:$_DOCKER_TAG"
+  ]
+
+- name: etl-testing
+  id: "Update table schemas before deploying parsers"
+  entrypoint: bash
+  args: [
+     '-c', './update-schema'
+  ]
+  env:
+  - GCLOUD_PROJECT=$PROJECT_ID
+
+# UNIVERSAL PARSER: Run apply-cluster.sh
+- name: gcr.io/cloud-builders/kubectl
+  id: "Deploy etl parser to data-processing cluster"
+  entrypoint: /bin/bash
+  args: [
+   '-c', '/builder/kubectl.bash version && ./apply-cluster.sh'
+  ]
+  env:
+  - BIGQUERY_DATASET=tmp_ndt
+  - CLOUDSDK_COMPUTE_REGION=$_CLUSTER_REGION
+  - CLOUDSDK_CONTAINER_CLUSTER=$_CLUSTER
+  - CLOUDSDK_CORE_PROJECT=$PROJECT_ID
+
+#########################################################
+# TODO: delete once legacy services are retired.
+
+# Use the GCR image as the base for the AppEngine deployment.
+- name: gcr.io/cloud-builders/gcloud
+  id: "Generate Dockerfile for AppEngine deployment"
+  entrypoint: bash
+  args: [
+     '-c', 'echo "FROM gcr.io/$PROJECT_ID/etl:$_DOCKER_TAG" > /workspace/cmd/etl_worker/Dockerfile',
+  ]
+
+# LEGACY PARSER: Deploy to app engine.
+- name: gcr.io/google.com/cloudsdktool/cloud-sdk
+  id: "Deploy etl batch parser to app engine"
+  args: [
+    'gcloud', 'app', 'deploy', '--project=$PROJECT_ID', 'appengine/queue.yaml'
+  ]
+
+- name: gcr.io/google.com/cloudsdktool/cloud-sdk
+  id: "Deploy etl batch parser to AppEngine"
+  args: [
+    'bash', '-c', 'cd cmd/etl_worker && gcloud --project=$PROJECT_ID app deploy --promote app-batch.yaml'
+  ]

--- a/cmd/etl_worker/Dockerfile.k8s
+++ b/cmd/etl_worker/Dockerfile.k8s
@@ -1,4 +1,4 @@
-FROM golang:1.13 as builder
+FROM golang:1.15.8 as builder
 
 ARG VERSION
 

--- a/cmd/etl_worker/app-batch.yaml
+++ b/cmd/etl_worker/app-batch.yaml
@@ -47,7 +47,7 @@ env_variables:
   PROMETHEUSX_LISTEN_ADDRESS: ':9090' # Must match one of the forwarded_ports above.
   BATCH_SERVICE: 'true'   # Allow instances to discover they are BATCH instances.
   MAX_WORKERS: 20
-  BIGQUERY_PROJECT: '${INJECTED_PROJECT}'  # Overrides GCLOUD_PROJECT
+  BIGQUERY_PROJECT: ''  # Overrides GCLOUD_PROJECT
   # BIGQUERY_DATASET: 'base_tables' # Overrided computed dataset.
   NDT_OMIT_DELTAS: 'true'
   # TODO add custom service-account, instead of using default credentials.

--- a/cmd/etl_worker/etl_worker_test.go
+++ b/cmd/etl_worker/etl_worker_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package main
 
 import (
@@ -33,7 +35,7 @@ func waitFor(url string) (resp *http.Response, err error) {
 func TestMain(t *testing.T) {
 	flag.Set("service_port", ":0")
 	flag.Set("max_active", "200")
-	flag.Set("prometheusx.listen-address", ":9090")
+	flag.Set("prometheusx.listen-address", ":0")
 	flag.Set("max_workers", "25")
 	flag.Set("gcloud_project", "mlab-testing")
 	mainCtx, mainCancel = context.WithCancel(context.Background())
@@ -80,7 +82,7 @@ func TestMain(t *testing.T) {
 func TestPollingMode(t *testing.T) {
 	flag.Set("service_port", ":0")
 	flag.Set("max_active", "200")
-	flag.Set("prometheusx.listen-address", ":9090")
+	flag.Set("prometheusx.listen-address", ":0")
 	flag.Set("max_workers", "25")
 	flag.Set("gcloud_project", "mlab-testing")
 	flag.Set("gardener_host", "gardener")

--- a/integration-testing.sh
+++ b/integration-testing.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Exit on error.
+set -e
+
+# Install test credentials for authentication:
+# * gcloud commands will use the activated service account.
+# * Go libraries will use the GOOGLE_APPLICATION_CREDENTIALS.
+if [[ -z "$SERVICE_ACCOUNT_mlab_testing" ]] ; then
+  echo "ERROR: testing service account is unavailable."
+  exit 1
+fi
+
+echo "$SERVICE_ACCOUNT_mlab_testing" > $PWD/creds.json
+# Make credentials available for Go libraries.
+export GOOGLE_APPLICATION_CREDENTIALS=$PWD/creds.json
+# TODO: update travis script to make this optional.
+if [[ ! -f ${HOME}/google-cloud-sdk/path.bash.inc ]] ; then
+  mkdir -p ${HOME}/google-cloud-sdk/ || :
+  touch ${HOME}/google-cloud-sdk/path.bash.inc || :
+fi
+# Make credentials available for gcloud commands.
+#travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_testing
+
+# NOTE: do this after setting the service account.
+#gcloud config set project mlab-testing
+
+go test -v -tags=integration -coverprofile=_integration.cov ./...

--- a/integration-testing.sh
+++ b/integration-testing.sh
@@ -3,26 +3,15 @@
 # Exit on error.
 set -e
 
-# Install test credentials for authentication:
-# * gcloud commands will use the activated service account.
-# * Go libraries will use the GOOGLE_APPLICATION_CREDENTIALS.
 if [[ -z "$SERVICE_ACCOUNT_mlab_testing" ]] ; then
-  echo "ERROR: testing service account is unavailable."
-  exit 1
+  echo "WARNING: testing service account is unavailable."
+  echo "WARNING: not running integration tests."
+  exit 0
 fi
 
+# Go libraries use the GOOGLE_APPLICATION_CREDENTIALS.
 echo "$SERVICE_ACCOUNT_mlab_testing" > $PWD/creds.json
-# Make credentials available for Go libraries.
 export GOOGLE_APPLICATION_CREDENTIALS=$PWD/creds.json
-# TODO: update travis script to make this optional.
-if [[ ! -f ${HOME}/google-cloud-sdk/path.bash.inc ]] ; then
-  mkdir -p ${HOME}/google-cloud-sdk/ || :
-  touch ${HOME}/google-cloud-sdk/path.bash.inc || :
-fi
-# Make credentials available for gcloud commands.
-#travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_testing
 
-# NOTE: do this after setting the service account.
-#gcloud config set project mlab-testing
-
+# Run integration tests.
 go test -v -tags=integration -coverprofile=_integration.cov ./...

--- a/k8s/data-processing/deployments/parser.yml
+++ b/k8s/data-processing/deployments/parser.yml
@@ -42,10 +42,6 @@ spec:
                "--max_active=100",
                ]
         env:
-        - name: RELEASE_TAG
-          value: {{RELEASE_TAG}}
-        - name: GIT_COMMIT
-          value: "{{GIT_COMMIT}}"
         - name: GCLOUD_PROJECT
           value: "{{GCLOUD_PROJECT}}"
         - name: BIGQUERY_DATASET

--- a/k8s/data-processing/deployments/parser.yml
+++ b/k8s/data-processing/deployments/parser.yml
@@ -34,7 +34,7 @@ spec:
       # For more background, see:
       # https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resource-qos.md
       containers:
-      - image: gcr.io/{{GCLOUD_PROJECT}}/github.com/m-lab/etl:{{GIT_COMMIT}}
+      - image: gcr.io/{{GCLOUD_PROJECT}}/etl:{{GIT_COMMIT}}
         name: etl-parser
         args: ["--prometheusx.listen-address=:9090",
                "--output=gcs",

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package storage
 
 import (

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package worker_test
 
 import (


### PR DESCRIPTION
This change completes the migration to cloudbuild started in https://github.com/m-lab/etl/pull/972

This change requires new Cloud Build trigger configurations and environment variables for deployment to data-processing cluster.

* _CLUSTER - the dat-processing cluster name
* _CLUSTER_REGION - the data-processing cluster region
* _DOCKER_TAG - the docker tag variable ($COMMIT_SHA in sandbox and staging, $TAG_NAME in mlab-oti)
* _SERVICE_ACCOUNT_MLAB_TESTING - the mlab-testing SA used for integration tests.

This change adds new files:

* Dockerfile.testing - used for unit testing Go sources from CB
* cloudbuild.yaml - used for performing the cloud build
* integration-testing.sh - used for running integration tests in travis and CB.

This change correctly adds some unit tests files to the "+build integration" tag because they depend on testing credentials to run successfully.

This change dramatically simplifies the .travis.yaml configuration, limiting it only to unit, integration testing, and code coverage.

Testing: manually verified that the etl parser continues to work as intended in sandbox using the Grafana Parser dashboards. manually verified that the "GitCommit" and "Version" are known to the worker at run time and that the correct values are present in newly parsed rows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/973)
<!-- Reviewable:end -->
