### PR TITLE
Adjust K8S parsers to use 15 cpus

### DIFF
--- a/k8s/data-processing/deployments/parser.yml
+++ b/k8s/data-processing/deployments/parser.yml
@@ -80,10 +80,10 @@ spec:
         resources:
           requests:
             memory: "15Gi"
-            cpu: "7"
+            cpu: "15"
           limits:
             memory: "20Gi"
-            cpu: "7"
+            cpu: "15"
 
       nodeSelector:
         parser-node: "true"


### PR DESCRIPTION
The 2.0 parsers are running on 16 cpu machines, but only using 7 cpus.  This allocates 15 cpus, which improves throughput and utilization, but also increases GCS and BQ costs by a very modest amount.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/981)
<!-- Reviewable:end -->
