### PR TITLE
Add support for storage.LocalWriter

### DIFF
--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -52,7 +52,7 @@ var (
 // Flags.
 var (
 	outputType = flagx.Enum{
-		Options: []string{"gcs", "bigquery"},
+		Options: []string{"gcs", "bigquery", "local"},
 		Value:   "bigquery",
 	}
 
@@ -67,6 +67,7 @@ var (
 	omitDeltas      = flag.Bool("ndt_omit_deltas", false, "Whether to skip ndt.web100 snapshot deltas")
 	bigqueryProject = flag.String("bigquery_project", "", "Override GCLOUD_PROJECT for BigQuery operations")
 	bigqueryDataset = flag.String("bigquery_dataset", "", "Override the BigQuery dataset for output tables")
+	outputDir       = flag.String("output_dir", "", "If output type is 'local', write output to this directory")
 )
 
 // Other global values.
@@ -297,6 +298,8 @@ func toRunnable(obj *gcs.ObjectAttrs) active.Runnable {
 		sink = bq.NewSinkFactory()
 	case "gcs":
 		sink = storage.NewSinkFactory(c, outputBucket())
+	case "local":
+		sink = storage.NewLocalFactory(*outputDir)
 	}
 
 	taskFactory := worker.StandardTaskFactory{

--- a/storage/localwriter.go
+++ b/storage/localwriter.go
@@ -1,0 +1,102 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/m-lab/etl/etl"
+	"github.com/m-lab/etl/factory"
+	"github.com/m-lab/etl/metrics"
+	"github.com/m-lab/etl/row"
+)
+
+// LocalWriter provides a Sink interface for parsers to output to local files.
+type LocalWriter struct {
+	f    *os.File
+	rows int
+}
+
+// NewLocalWriter creates a new LocalWriter for output to the given dir and
+// path. On success, missing directories are created and a new file pointer is
+// allocated. Callers must call Close() to release this file pointer.
+func NewLocalWriter(dir string, path string) (row.Sink, error) {
+	p := filepath.Join(dir, path)
+	d := filepath.Dir(p) // path may include additional directory elements.
+	err := os.MkdirAll(d, os.ModePerm)
+	if err != nil {
+		return nil, err
+	}
+	f, err := os.OpenFile(p, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, err
+	}
+	l := &LocalWriter{
+		f: f,
+	}
+	return l, nil
+}
+
+// Commit writes the given rows to the local writer file immediately. This is in
+// contrast to the bigquery RowWriter does not make content available until
+// Close.
+func (lw *LocalWriter) Commit(rows []interface{}, label string) (int, error) {
+	buf := bytes.NewBuffer(nil)
+
+	for i := range rows {
+		j, err := json.Marshal(rows[i])
+		if err != nil {
+			metrics.BackendFailureCount.WithLabelValues(label, "encoding error").Inc()
+			return 0, err
+		}
+		metrics.RowSizeHistogram.WithLabelValues(label).Observe(float64(len(j)))
+		buf.Write(j)
+		buf.WriteByte('\n')
+	}
+	_, err := buf.WriteTo(lw.f)
+	if err != nil {
+		return 0, err
+	}
+	lw.rows += len(rows)
+	return len(rows), nil
+}
+
+// Close closes the underlying LocalWriter file object.
+func (lw *LocalWriter) Close() error {
+	err := lw.f.Close()
+	if err != nil {
+		return err
+	}
+	log.Printf("Successful LocalWriter.Close(); wrote %d rows to %s", lw.rows, lw.f.Name())
+	return nil
+}
+
+// LocalFactory creates LocalWriters sinks within a given output directory.
+type LocalFactory struct {
+	outputDir string
+}
+
+// Get implements factory.SinkFactory for LocalWriters.
+func (lf *LocalFactory) Get(ctx context.Context, path etl.DataPath) (row.Sink, etl.ProcessingError) {
+	fn, err := pathAndFilename(path.URI)
+	if err != nil {
+		return nil, factory.NewError(path.DataType, "InvalidPath", http.StatusInternalServerError, err)
+	}
+	s, err := NewLocalWriter(lf.outputDir, fn+".jsonl")
+	if err != nil {
+		return nil, factory.NewError(path.DataType, "LocalFactory", http.StatusInternalServerError, err)
+	}
+	return s, nil
+}
+
+// NewLocalFactory creates a new LocalFactory that produces LocalWriters that
+// output to the named output directory.
+func NewLocalFactory(outputDir string) factory.SinkFactory {
+	return &LocalFactory{
+		outputDir: outputDir,
+	}
+}

--- a/storage/localwriter_test.go
+++ b/storage/localwriter_test.go
@@ -229,10 +229,9 @@ func TestNewLocalFactory(t *testing.T) {
 
 			if tt.wantOpenErr {
 				// Make directory so open will fail.
-				err := os.MkdirAll(tt.outputDir, os.ModePerm)
+				err := os.MkdirAll(filepath.Join(tt.outputDir,
+					"exp/ndt7/2021/06/01/20210601T101003.000001Z-ndt7-mlab4-foo01-exp.tgz.jsonl"), os.ModePerm)
 				testingx.Must(t, err, "failed to mkdir")
-				err = os.Chmod(tt.outputDir, 0000)
-				testingx.Must(t, err, "failed to chmod")
 			}
 
 			lw, err := lf.Get(context.Background(), d)

--- a/storage/localwriter_test.go
+++ b/storage/localwriter_test.go
@@ -1,0 +1,234 @@
+package storage_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/m-lab/go/testingx"
+
+	"github.com/m-lab/etl/etl"
+	"github.com/m-lab/etl/row"
+	"github.com/m-lab/go/rtx"
+
+	"github.com/m-lab/etl/storage"
+)
+
+func TestLocalWriter_Commit(t *testing.T) {
+	tests := []struct {
+		name               string
+		dir                string
+		path               string
+		count              int
+		wantCommitJSONErr  bool
+		wantCommitWriteErr bool
+	}{
+		{
+			name:  "success",
+			dir:   "testdir",
+			path:  "this/is/a/test.json",
+			count: 1,
+		},
+		{
+			name:              "error-commit-json",
+			dir:               "testdir",
+			path:              "this/is/a/test.json",
+			wantCommitJSONErr: true,
+		},
+		{
+			name:               "error-commit-write",
+			dir:                "testdir",
+			path:               "this/is/a/test.json",
+			wantCommitWriteErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := storage.NewLocalWriter(tt.dir, tt.path)
+			if err != nil {
+				t.Errorf("NewLocalWriter() error = %v, wantErr nil", err)
+				return
+			}
+			defer func() {
+				if tt.dir != "" {
+					os.RemoveAll(tt.dir)
+				}
+			}()
+			rows := []interface{}{
+				"test",
+			}
+			if tt.wantCommitJSONErr {
+				// Append function pointer which will generate a JSON marshal error.
+				rows = append(rows, interface{}(got.Commit))
+			}
+			if tt.wantCommitWriteErr {
+				// force close before trying to commit values.
+				got.Close()
+			}
+			n, err := got.Commit(rows, "fake-output")
+			if n != tt.count {
+				t.Fatalf("LocalWriter.Commit() wrong count; got = %d, want %d", n, tt.count)
+			}
+			if (err != nil) != (tt.wantCommitJSONErr || tt.wantCommitWriteErr) {
+				t.Fatalf("LocalWriter.Commit() wrong err; got = %v, wantCommitJSONErr %v", err, tt.wantCommitJSONErr)
+			}
+			err = got.Close()
+			if (err != nil) != tt.wantCommitWriteErr {
+				t.Fatalf("LocalWriter.Close() error = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestLocalWriter_Close(t *testing.T) {
+	tests := []struct {
+		name    string
+		dir     string
+		path    string
+		count   int
+		wantErr bool
+	}{
+		{
+			name:  "success",
+			dir:   "testdir",
+			path:  "this/is/a/test.json",
+			count: 1,
+		},
+		{
+			name:    "error-commit-json",
+			dir:     "testdir",
+			path:    "this/is/a/test.json",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got row.Sink
+			var err error
+			if tt.wantErr {
+				// Explicit allocation will create nil file pointer, so Close will fail.
+				got = &storage.LocalWriter{}
+			} else {
+				got, err = storage.NewLocalWriter(tt.dir, tt.path)
+				if err != nil {
+					t.Errorf("NewLocalWriter() error = %v, wantErr nil", err)
+					return
+				}
+				defer func() {
+					if tt.dir != "" {
+						os.RemoveAll(tt.dir)
+					}
+				}()
+			}
+
+			err = got.Close()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("LocalWriter.Close() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+func TestNewLocalWriter(t *testing.T) {
+	tests := []struct {
+		name        string
+		dir         string
+		path        string
+		wantOpenErr bool
+	}{
+		{
+			name: "success",
+			dir:  "testdir",
+			path: "this/is/a/test.json",
+		},
+		{
+			name:        "error-open",
+			dir:         "testdir",
+			path:        "this",
+			wantOpenErr: true,
+		},
+		{
+			name:        "error-mkdir",
+			dir:         "testdir",
+			path:        "this/file.dir",
+			wantOpenErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantOpenErr {
+				// Make directory so open will fail.
+				err := os.MkdirAll(tt.dir, os.ModePerm)
+				testingx.Must(t, err, "failed to mkdir")
+				err = os.Chmod(tt.dir, 0000)
+				testingx.Must(t, err, "failed to chmod")
+			}
+			got, err := storage.NewLocalWriter(tt.dir, tt.path)
+			defer func() {
+				if tt.dir != "" {
+					os.RemoveAll(tt.dir)
+				}
+			}()
+
+			if tt.wantOpenErr {
+				if err == nil {
+					t.Errorf("NewLocalWriter() wantOpenErr %v, want error", err)
+				}
+				return
+			}
+
+			err = got.Close()
+			if err != nil {
+				t.Errorf("LocalWriter.Close() error = %v, want nil", err)
+			}
+		})
+	}
+}
+func TestNewLocalFactory(t *testing.T) {
+	tests := []struct {
+		name        string
+		outputDir   string
+		wantPathErr bool
+		wantOpenErr bool
+	}{
+		{
+			name:      "success",
+			outputDir: t.TempDir(),
+		},
+		{
+			name:        "error-path",
+			outputDir:   t.TempDir(),
+			wantPathErr: true,
+		},
+		{
+			name:        "error-open",
+			outputDir:   t.TempDir(),
+			wantOpenErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lf := storage.NewLocalFactory(tt.outputDir)
+			d, err := etl.ValidateTestPath("gs://bucket/exp/ndt7/2021/06/01/20210601T101003.000001Z-ndt7-mlab4-foo01-exp.tgz")
+			rtx.Must(err, "failed to validate path")
+
+			if tt.wantPathErr {
+				d.URI = "gs://broken" // force URI parse to fail.
+			}
+
+			if tt.wantOpenErr {
+				// Make directory so open will fail.
+				err := os.MkdirAll(tt.outputDir, os.ModePerm)
+				testingx.Must(t, err, "failed to mkdir")
+				err = os.Chmod(tt.outputDir, 0000)
+				testingx.Must(t, err, "failed to chmod")
+			}
+
+			lw, err := lf.Get(context.Background(), d)
+			if (err != nil) != (tt.wantPathErr || tt.wantOpenErr) {
+				t.Errorf("LocalFactory.Get() = %v, want %v", lw, tt.wantPathErr || tt.wantOpenErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds a new output mode to the ETL worker (aka parser) to support writing to local files. The `storage.LocalWriter` type implements the `row.Sink` interface. With this change there are now three output modes: "bigquery" (direct, original mode), "gcs" (for bq loads from gcs), "local" (new, added for local development).

The "local" output mode wites files like "gcs" mode (i.e. JSONL named after the archive) but to a local directory specified with the new `-output_dir` flag.

The LocalWriter is expected to help simplify local development of the etl worker, e.g. for a new datatype by removing some dependencies on BigQuery, table schemas, and updates.

Tested using unit tests and running locally using:

```
~/bin/etl_worker -prometheusx.listen-address :9991 -service_port :8081 -output_dir ./output -output local  -gardener_host localhost
```

This invocation is not included in the README yet b/c it is not repeatable. Because this is an exclusive option with other default, this should not impact current deployments.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/991)
<!-- Reviewable:end -->
