### PR TITLE
Add method for GCS Path for DataPath type

### DIFF
--- a/etl/globals.go
+++ b/etl/globals.go
@@ -165,6 +165,17 @@ func (dp DataPath) TableBase() string {
 	return dp.GetDataType().Table()
 }
 
+// Path returns the GCS Path portion of a valid M-Lab GCS archive URI. Because
+// ValidateTestPath() has already validated the DataPath.URI, Path() returns
+// the empty string on error.
+func (dp DataPath) Path() string {
+	parts := strings.SplitN(dp.URI, "/", 4)
+	if len(parts) != 4 || parts[0] != "gs:" || len(parts[3]) == 0 {
+		return ""
+	}
+	return parts[3]
+}
+
 // IsBatchService return true if this is a batch service.
 func IsBatchService() bool {
 	return IsBatch

--- a/etl/globals_test.go
+++ b/etl/globals_test.go
@@ -53,6 +53,7 @@ func TestValidateTestPath(t *testing.T) {
 			wantType: etl.NDT,
 			want: etl.DataPath{
 				`gs://m-lab-sandbox/ndt/2016/01/26/20160126T000000Z-mlab1-prg01-ndt-0007.tgz`,
+				`ndt/2016/01/26/20160126T000000Z-mlab1-prg01-ndt-0007.tgz`,
 				"m-lab-sandbox", "", "ndt", "2016/01/26", "20160126", "000000", "", "mlab1", "prg01", "ndt", "0007", "", ".tgz",
 			},
 		},
@@ -62,6 +63,7 @@ func TestValidateTestPath(t *testing.T) {
 			wantType: etl.NDT,
 			want: etl.DataPath{
 				`gs://m-lab-sandbox/ndt/2016/07/14/20160714T123456Z-mlab1-lax04-ndt-0001.tar`,
+				`ndt/2016/07/14/20160714T123456Z-mlab1-lax04-ndt-0001.tar`,
 				"m-lab-sandbox", "", "ndt", "2016/07/14", "20160714", "123456", "", "mlab1", "lax04", "ndt", "0001", "", ".tar",
 			},
 		},
@@ -71,6 +73,7 @@ func TestValidateTestPath(t *testing.T) {
 			wantType: etl.NDT,
 			want: etl.DataPath{
 				`gs://m-lab-sandbox/ndt/2016/07/14/20160714T123456Z-mlab1-lax04-ndt-0001.tar.gz`,
+				`ndt/2016/07/14/20160714T123456Z-mlab1-lax04-ndt-0001.tar.gz`,
 				"m-lab-sandbox", "", "ndt", "2016/07/14", "20160714", "123456", "", "mlab1", "lax04", "ndt", "0001", "", ".tar.gz",
 			},
 		},
@@ -80,6 +83,7 @@ func TestValidateTestPath(t *testing.T) {
 			wantType: etl.SS,
 			want: etl.DataPath{
 				`gs://embargo-mlab-oti/sidestream/2018/02/27/20180227T000010Z-mlab1-dfw02-sidestream-0000-e.tgz`,
+				`sidestream/2018/02/27/20180227T000010Z-mlab1-dfw02-sidestream-0000-e.tgz`,
 				"embargo-mlab-oti", "", "sidestream", "2018/02/27", "20180227", "000010", "", "mlab1", "dfw02", "sidestream", "0000", "-e", ".tgz",
 			},
 		},
@@ -89,6 +93,7 @@ func TestValidateTestPath(t *testing.T) {
 			wantType: etl.TCPINFO,
 			want: etl.DataPath{
 				`gs://pusher-mlab-staging/ndt/tcpinfo/2019/05/25/20190525T020001.697396Z-tcpinfo-mlab4-ord01-ndt-0001.tgz`,
+				`ndt/tcpinfo/2019/05/25/20190525T020001.697396Z-tcpinfo-mlab4-ord01-ndt-0001.tgz`,
 				"pusher-mlab-staging", "ndt", "tcpinfo", "2019/05/25", "20190525", "020001.697396", "tcpinfo", "mlab4", "ord01", "ndt", "0001", "", ".tgz",
 			},
 		},
@@ -98,6 +103,7 @@ func TestValidateTestPath(t *testing.T) {
 			wantType: etl.PT,
 			want: etl.DataPath{
 				`gs://archive-mlab-oti/paris-traceroute/2019/06/11/20190611T000002Z-mlab2-bom01-paris-traceroute-0000.tgz`,
+				`paris-traceroute/2019/06/11/20190611T000002Z-mlab2-bom01-paris-traceroute-0000.tgz`,
 				"archive-mlab-oti", "", "paris-traceroute", "2019/06/11", "20190611", "000002", "", "mlab2", "bom01", "paris-traceroute", "0000", "", ".tgz",
 			},
 		},
@@ -107,6 +113,7 @@ func TestValidateTestPath(t *testing.T) {
 			wantType: etl.PT,
 			want: etl.DataPath{
 				`gs://archive-mlab-oti/ndt/traceroute/2019/06/20/20190620T224809.435046Z-traceroute-mlab1-den06-ndt-0001.tgz`,
+				`ndt/traceroute/2019/06/20/20190620T224809.435046Z-traceroute-mlab1-den06-ndt-0001.tgz`,
 				"archive-mlab-oti", "ndt", "traceroute", "2019/06/20", "20190620", "224809.435046", "traceroute", "mlab1", "den06", "ndt", "0001", "", ".tgz",
 			},
 		},
@@ -157,42 +164,6 @@ func TestDataPath_GetDataType(t *testing.T) {
 			}
 			if got := fn.GetDataType(); got != tt.want {
 				t.Errorf("DataPath.GetDataType() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestDataPath_Path(t *testing.T) {
-	tests := []struct {
-		name string
-		uri  string
-		want string
-	}{
-		{
-			name: "error-no-scheme",
-			uri:  "foobar",
-		},
-		{
-			name: "error-no-path",
-			uri:  "gs://foobar",
-		},
-		{
-			name: "error-empty-path",
-			uri:  "gs://foobar/",
-		},
-		{
-			name: "okay",
-			uri:  "gs://bucket/foo/bar.baz",
-			want: "foo/bar.baz",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dp := etl.DataPath{
-				URI: tt.uri,
-			}
-			if p := dp.Path(); p != tt.want {
-				t.Errorf("Expected error for %q, got %q", dp.URI, p)
 			}
 		})
 	}

--- a/etl/globals_test.go
+++ b/etl/globals_test.go
@@ -162,6 +162,42 @@ func TestDataPath_GetDataType(t *testing.T) {
 	}
 }
 
+func TestDataPath_Path(t *testing.T) {
+	tests := []struct {
+		name string
+		uri  string
+		want string
+	}{
+		{
+			name: "error-no-scheme",
+			uri:  "foobar",
+		},
+		{
+			name: "error-no-path",
+			uri:  "gs://foobar",
+		},
+		{
+			name: "error-empty-path",
+			uri:  "gs://foobar/",
+		},
+		{
+			name: "okay",
+			uri:  "gs://bucket/foo/bar.baz",
+			want: "foo/bar.baz",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dp := etl.DataPath{
+				URI: tt.uri,
+			}
+			if p := dp.Path(); p != tt.want {
+				t.Errorf("Expected error for %q, got %q", dp.URI, p)
+			}
+		})
+	}
+}
+
 func TestGetMetroName(t *testing.T) {
 	iata := etl.GetIATACode("20170501T000000Z-mlab1-acc02-paris-traceroute-0000.tgz")
 	if iata != "acc" {

--- a/storage/export_test.go
+++ b/storage/export_test.go
@@ -1,3 +1,1 @@
 package storage
-
-var PathAndFilename = pathAndFilename

--- a/storage/localwriter.go
+++ b/storage/localwriter.go
@@ -81,14 +81,10 @@ type LocalFactory struct {
 }
 
 // Get implements factory.SinkFactory for LocalWriters.
-func (lf *LocalFactory) Get(ctx context.Context, path etl.DataPath) (row.Sink, etl.ProcessingError) {
-	fn, err := pathAndFilename(path.URI)
+func (lf *LocalFactory) Get(ctx context.Context, dp etl.DataPath) (row.Sink, etl.ProcessingError) {
+	s, err := NewLocalWriter(lf.outputDir, dp.Path+".jsonl")
 	if err != nil {
-		return nil, factory.NewError(path.DataType, "InvalidPath", http.StatusInternalServerError, err)
-	}
-	s, err := NewLocalWriter(lf.outputDir, fn+".jsonl")
-	if err != nil {
-		return nil, factory.NewError(path.DataType, "LocalFactory", http.StatusInternalServerError, err)
+		return nil, factory.NewError(dp.DataType, "LocalFactory", http.StatusInternalServerError, err)
 	}
 	return s, nil
 }

--- a/storage/localwriter_test.go
+++ b/storage/localwriter_test.go
@@ -199,17 +199,11 @@ func TestNewLocalFactory(t *testing.T) {
 	tests := []struct {
 		name        string
 		outputDir   string
-		wantPathErr bool
 		wantOpenErr bool
 	}{
 		{
 			name:      "success",
 			outputDir: t.TempDir(),
-		},
-		{
-			name:        "error-path",
-			outputDir:   t.TempDir(),
-			wantPathErr: true,
 		},
 		{
 			name:        "error-open",
@@ -223,10 +217,6 @@ func TestNewLocalFactory(t *testing.T) {
 			d, err := etl.ValidateTestPath("gs://bucket/exp/ndt7/2021/06/01/20210601T101003.000001Z-ndt7-mlab4-foo01-exp.tgz")
 			rtx.Must(err, "failed to validate path")
 
-			if tt.wantPathErr {
-				d.URI = "gs://broken" // force URI parse to fail.
-			}
-
 			if tt.wantOpenErr {
 				// Make directory so open will fail.
 				err := os.MkdirAll(filepath.Join(tt.outputDir,
@@ -235,8 +225,8 @@ func TestNewLocalFactory(t *testing.T) {
 			}
 
 			lw, err := lf.Get(context.Background(), d)
-			if (err != nil) != (tt.wantPathErr || tt.wantOpenErr) {
-				t.Errorf("LocalFactory.Get() = %v, want %v", lw, tt.wantPathErr || tt.wantOpenErr)
+			if (err != nil) != tt.wantOpenErr {
+				t.Errorf("LocalFactory.Get() = %v, want %v", lw, tt.wantOpenErr)
 			}
 		})
 	}

--- a/storage/rowwriter.go
+++ b/storage/rowwriter.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"strings"
 	"time"
 
 	gcs "cloud.google.com/go/storage"
@@ -177,25 +176,16 @@ type SinkFactory struct {
 	outputBucket string
 }
 
-// returns the full path/filename from a gs://bucket/path/filename string.
-func pathAndFilename(uri string) (string, error) {
-	parts := strings.SplitN(uri, "/", 4)
-	if len(parts) != 4 || parts[0] != "gs:" || len(parts[3]) == 0 {
-		return "", errors.New("Bad GCS path")
-	}
-	return parts[3], nil
-}
-
 // Get implements factory.SinkFactory
-func (sf *SinkFactory) Get(ctx context.Context, path etl.DataPath) (row.Sink, etl.ProcessingError) {
-	fn, err := pathAndFilename(path.URI)
-	if err != nil {
-		return nil, factory.NewError(path.DataType, "InvalidPath",
-			http.StatusInternalServerError, err)
+func (sf *SinkFactory) Get(ctx context.Context, dp etl.DataPath) (row.Sink, etl.ProcessingError) {
+	fn := dp.Path()
+	if fn == "" {
+		return nil, factory.NewError(dp.DataType, "InvalidPath",
+			http.StatusInternalServerError, errors.New("empty gcs path"))
 	}
 	s, err := NewRowWriter(ctx, sf.client, sf.outputBucket, fn+".json")
 	if err != nil {
-		return nil, factory.NewError(path.DataType, "SinkFactory",
+		return nil, factory.NewError(dp.DataType, "SinkFactory",
 			http.StatusInternalServerError, err)
 	}
 	return s, nil

--- a/storage/rowwriter.go
+++ b/storage/rowwriter.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -178,12 +177,7 @@ type SinkFactory struct {
 
 // Get implements factory.SinkFactory
 func (sf *SinkFactory) Get(ctx context.Context, dp etl.DataPath) (row.Sink, etl.ProcessingError) {
-	fn := dp.Path()
-	if fn == "" {
-		return nil, factory.NewError(dp.DataType, "InvalidPath",
-			http.StatusInternalServerError, errors.New("empty gcs path"))
-	}
-	s, err := NewRowWriter(ctx, sf.client, sf.outputBucket, fn+".json")
+	s, err := NewRowWriter(ctx, sf.client, sf.outputBucket, dp.Path+".json")
 	if err != nil {
 		return nil, factory.NewError(dp.DataType, "SinkFactory",
 			http.StatusInternalServerError, err)

--- a/storage/rowwriter_test.go
+++ b/storage/rowwriter_test.go
@@ -59,22 +59,3 @@ func TestRowWriter(t *testing.T) {
 		t.Error(diff)
 	}
 }
-
-func TestPathAndFilename(t *testing.T) {
-	if _, err := storage.PathAndFilename("foobar"); err == nil {
-		t.Error("Expected error")
-	}
-	if _, err := storage.PathAndFilename("gs://foobar"); err == nil {
-		t.Error("Expected error")
-	}
-	if _, err := storage.PathAndFilename("gs://foobar/"); err == nil {
-		t.Error("Expected error")
-	}
-	path, err := storage.PathAndFilename("gs://bucket/foo/bar.baz")
-	if err != nil {
-		t.Error("Unexpected error:", err)
-	}
-	if path != "foo/bar.baz" {
-		t.Error("Incorrect path:", path)
-	}
-}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -242,12 +242,8 @@ func NewTestSource(client stiface.Client, dp etl.DataPath, label string) (etl.Te
 	if !strings.HasPrefix(dp.URI, "gs://") {
 		return nil, errors.New("invalid file path: " + dp.URI)
 	}
-	parts := strings.SplitN(dp.URI, "/", 4)
-	if len(parts) != 4 {
-		return nil, errors.New("invalid file path: " + dp.URI)
-	}
-	bucket := parts[2]
-	fn := parts[3]
+	bucket := dp.Bucket
+	fn := dp.Path()
 
 	archiveDate, err := time.Parse("2006/01/02", dp.DatePath)
 	if err != nil {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -243,7 +243,7 @@ func NewTestSource(client stiface.Client, dp etl.DataPath, label string) (etl.Te
 		return nil, errors.New("invalid file path: " + dp.URI)
 	}
 	bucket := dp.Bucket
-	fn := dp.Path()
+	fn := dp.Path
 
 	archiveDate, err := time.Parse("2006/01/02", dp.DatePath)
 	if err != nil {


### PR DESCRIPTION
This change adds a new helper method to recover the GCS "Path" portion of the URI. A common use case is extracting this path. As a result, this change reduces some ad-hoc parsing of the URI in favor of placing all URI parsing in the etl.DataPath type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/993)
<!-- Reviewable:end -->
