### PR TITLE
Add handler for local output mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ go get ./cmd/etl_worker
 ~/bin/etl_worker -service_port :8080 -output_dir ./output -output local
 ```
 
-From the command line (or with a browser) make a request to the `local/writer`
+From the command line (or with a browser) make a request to the `/v2/worker`
 resource with a `filename=` parameter that names a valid M-Lab GCS archive.
 
 ```sh
 URL=gs://archive-measurement-lab/ndt/ndt7/2021/06/14/20210614T003000.696927Z-ndt7-mlab1-yul04-ndt.tgz
-curl "http://localhost:8080/local/worker?filename=$URL"
+curl "http://localhost:8080/v2/worker?filename=$URL"
 ```
 
 ## Generating Schema Docs

--- a/README.md
+++ b/README.md
@@ -1,15 +1,29 @@
 # etl
+
 | branch | travis-ci | report-card | coveralls |
 |--------|-----------|-----------|-------------|
 | master | [![Travis Build Status](https://travis-ci.org/m-lab/etl.svg?branch=master)](https://travis-ci.org/m-lab/etl) | | [![Coverage Status](https://coveralls.io/repos/m-lab/etl/badge.svg?branch=master)](https://coveralls.io/github/m-lab/etl?branch=master) |
 | integration | [![Travis Build Status](https://travis-ci.org/m-lab/etl.svg?branch=integration)](https://travis-ci.org/m-lab/etl) | [![Go Report Card](https://goreportcard.com/badge/github.com/m-lab/etl)](https://goreportcard.com/report/github.com/m-lab/etl) | [![Coverage Status](https://coveralls.io/repos/m-lab/etl/badge.svg?branch=integration)](https://coveralls.io/github/m-lab/etl?branch=integration) |
 
-MeasurementLab data ingestion pipeline.
+ETL (extract, transform, load) is a core component of the M-Lab data processing
+pipeline. The ETL worker is responsible for parsing data archives produced by
+[pusher](https://github.com/m-lab/pusher) and publishing M-Lab measurements to
+[BigQuery](https://www.measurementlab.net/data/docs/bq/quickstart/).
 
-To create e.g., NDT table (should rarely be required!!!):
-bq mk --time_partitioning_type=DAY --schema=schema/repeated.json mlab-sandbox:mlab_sandbox.ndt
+## Local Development
 
-Also see schema/README.md.
+```sh
+go get ./cmd/etl_worker
+~/bin/etl_worker -service_port :8080 -output_dir ./output -output local
+```
+
+From the command line (or with a browser) make a request to the `local/writer`
+resource with a `filename=` parameter that names a valid M-Lab GCS archive.
+
+```sh
+URL=gs://archive-measurement-lab/ndt/ndt7/2021/06/14/20210614T003000.696927Z-ndt7-mlab1-yul04-ndt.tgz
+curl "http://localhost:8080/local/worker?filename=$URL"
+```
 
 ## Generating Schema Docs
 

--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -435,10 +435,9 @@ func main() {
 	mux.HandleFunc("/_ah/health", healthCheckHandler) // legacy
 	mux.HandleFunc("/alive", healthCheckHandler)
 	mux.HandleFunc("/ready", healthCheckHandler)
-	if outputType.Value == "local" {
-		// Only register handler when output type is "local", e.g. for local development.
-		mux.HandleFunc("/local/worker", handleLocalRequest)
-	}
+
+	// Registers handler for v2 datatypes. Works with "local" output for local development.
+	mux.HandleFunc("/v2/worker", handleLocalRequest)
 
 	_ = startServers(mainCtx, mux)
 }

--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -175,10 +175,10 @@ func handleLocalRequest(rwr http.ResponseWriter, rq *http.Request) {
 	}
 	ctx := context.Background()
 
-	obj, err := c.Bucket(dp.Bucket).Object(dp.Path()).Attrs(ctx)
+	obj, err := c.Bucket(dp.Bucket).Object(dp.Path).Attrs(ctx)
 	if err != nil {
 		rwr.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintf(rwr, "failed to get object attrs for %s / %s", dp.Bucket, dp.Path())
+		fmt.Fprintf(rwr, "failed to get object attrs for %s / %s", dp.Bucket, dp.Path)
 		return
 	}
 

--- a/cmd/etl_worker/etl_worker_test.go
+++ b/cmd/etl_worker/etl_worker_test.go
@@ -173,12 +173,12 @@ func TestLocalRequest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resp, err := waitFor("http://" + mainSvr + "/local/worker?filename=" + tt.uri)
+			resp, err := waitFor("http://" + mainSvr + "/v2/worker?filename=" + tt.uri)
 			if err != nil {
 				t.Fatalf("http.Get returned unexpected error: %v", err)
 			}
 			if tt.wantStatus != resp.StatusCode {
-				t.Errorf("local/worker returned wrong status; got %d, want %d", resp.StatusCode, tt.wantStatus)
+				t.Errorf("v2/worker returned wrong status; got %d, want %d", resp.StatusCode, tt.wantStatus)
 			}
 			if tt.wantStatus != http.StatusOK {
 				return

--- a/cmd/etl_worker/etl_worker_test.go
+++ b/cmd/etl_worker/etl_worker_test.go
@@ -4,10 +4,13 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -125,4 +128,82 @@ func TestPollingMode(t *testing.T) {
 		t.Error("Expected 200:", *maxActiveTasks)
 	}
 
+}
+
+func TestLocalRequest(t *testing.T) {
+	outdir := t.TempDir()
+	flag.Set("output", "local")
+	flag.Set("output_dir", outdir)
+
+	mainCtx, mainCancel = context.WithCancel(context.Background())
+
+	go main()
+	defer mainCancel()
+
+	// Wait for the server to start and publish address.
+	mainSvr := <-mainServerAddr
+
+	// handleLocalRequest
+	tests := []struct {
+		name       string
+		uri        string
+		wantStatus int
+	}{
+		{
+			name:       "error-empty-uri",
+			uri:        "",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "error-malformed-uri",
+			uri:        "fake://bucket/path/not-found.tgz",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "error-valid-uri-does-not-exist",
+			uri:        "gs://no-such-bucket/ndt/2018/05/09/20180509T101913Z-mlab1-mad03-ndt-0000.tgz",
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			// Constructed archive with a single, truncated download measurement.
+			name:       "success",
+			uri:        "gs://archive-mlab-testing/ndt/ndt7/2021/06/17/20210617T003002.410133Z-ndt7-mlab1-foo01-ndt.tgz",
+			wantStatus: http.StatusOK,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := waitFor("http://" + mainSvr + "/local/worker?filename=" + tt.uri)
+			if err != nil {
+				t.Fatalf("http.Get returned unexpected error: %v", err)
+			}
+			if tt.wantStatus != resp.StatusCode {
+				t.Errorf("local/worker returned wrong status; got %d, want %d", resp.StatusCode, tt.wantStatus)
+			}
+			if tt.wantStatus != http.StatusOK {
+				return
+			}
+
+			// Check the outdir for the successful content of a localwriter.
+			p := filepath.Join(outdir, "ndt/ndt7/2021/06/17/20210617T003002.410133Z-ndt7-mlab1-foo01-ndt.tgz.jsonl")
+			f, err := os.Open(p)
+			if err != nil {
+				t.Fatalf("failed to read file: %v", err)
+			}
+			m := map[string]interface{}{}
+			d := json.NewDecoder(f)
+			count := 0
+			for d.More() {
+				err := d.Decode(&m)
+				if err != nil {
+					// This is not expected.
+					t.Fatal(err)
+				}
+				count++
+			}
+			if count != 1 {
+				t.Errorf("localwriter found multiple records; want 1, got %d", count)
+			}
+		})
+	}
 }

--- a/cmd/etl_worker/etl_worker_test.go
+++ b/cmd/etl_worker/etl_worker_test.go
@@ -156,7 +156,7 @@ func TestLocalRequest(t *testing.T) {
 		},
 		{
 			name:       "error-malformed-uri",
-			uri:        "fake://bucket/path/not-found.tgz",
+			uri:        "gs://bucket/path/not-found.tgz",
 			wantStatus: http.StatusBadRequest,
 		},
 		{

--- a/go.mod
+++ b/go.mod
@@ -15,14 +15,17 @@ require (
 	github.com/kr/pretty v0.2.1
 	github.com/m-lab/annotation-service v0.0.0-20200221173317-d968fe153a9c
 	github.com/m-lab/etl-gardener v0.0.0-20210310164025-d9582f1131b5
-	github.com/m-lab/go v0.1.44
+	github.com/m-lab/go v0.1.45
 	github.com/m-lab/ndt-server v0.20.5
 	github.com/m-lab/tcp-info v1.5.3
 	github.com/m-lab/uuid v0.0.0-20191115203855-549727171666 // indirect
 	github.com/m-lab/uuid-annotator v0.4.3
 	github.com/prometheus/client_golang v1.10.0
 	github.com/prometheus/client_model v0.2.0
+	github.com/sirupsen/logrus v1.8.1
 	github.com/valyala/gozstd v1.9.0
+	golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4
+	golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	google.golang.org/api v0.43.0
 	gopkg.in/m-lab/pipe.v3 v3.0.0-20180108231244-604e84f43ee0

--- a/go.sum
+++ b/go.sum
@@ -301,6 +301,8 @@ github.com/m-lab/etl-gardener v0.0.0-20210310164025-d9582f1131b5 h1:jCFqYBvYPEHq
 github.com/m-lab/etl-gardener v0.0.0-20210310164025-d9582f1131b5/go.mod h1:4hAG+N9lfh+vQ+FEcMFad0SOP74VJi5yeWk7ioHkvs0=
 github.com/m-lab/go v0.1.44 h1:aVI5k1M8q919m+3HIvrXOY/eMVaHAZPAflxnZ28o3q4=
 github.com/m-lab/go v0.1.44/go.mod h1:+C0ZBlRKsF7wIbqHRtiL8bqD6cOwlZXDTK/KQ7Iv434=
+github.com/m-lab/go v0.1.45 h1:z3aNaDUXDKeZp1tl40HMzPmDFPcz9qtAWyDAkh3kCfo=
+github.com/m-lab/go v0.1.45/go.mod h1:05mdACIqCaSuf57iYC6mDhomYdyzSgkWeR5CgZIXU6Y=
 github.com/m-lab/ndt-server v0.20.5 h1:EeNzNb1cfhdszJhlGrJAewraKDJGTlx64pvy/d/dpp0=
 github.com/m-lab/ndt-server v0.20.5/go.mod h1:ZLVRCEbCBkhh0pwNjnLpwaZnHOHGEH76H/fzIIVFRWw=
 github.com/m-lab/tcp-info v1.5.3 h1:4IspTPcNc8D8LNRvuFnID8gDiz+hxPAtYvpKZaiGGe8=
@@ -414,6 +416,7 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=


### PR DESCRIPTION
This change adds a new handler to the passive mode ETL worker to support v2 datatypes including during local development.

This change adds a new resource, `/v2/worker`, that is unconditionally available when the worker is started.
The `/v2/worker` handler accepts a `filename=` parameter (like the existing `/worker` handler used by the legacy pipeline). However, the `/v2/worker` only supports v2 datatypes.

With this handler, a developer can run the worker in "local" output mode to test behavior of a new parser without depending on BigQuery or other GCP services (other than the source archive in GCS). This handler also allows adhoc tests in GKE.

Instructions for use are now included in the README.md

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/994)
<!-- Reviewable:end -->
