### PR TITLE
Update annotation-service version to include fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/go-jsonnet v0.17.0
 	github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8
 	github.com/kr/pretty v0.2.1
-	github.com/m-lab/annotation-service v0.0.0-20210510161905-66746c999334
+	github.com/m-lab/annotation-service v0.0.0-20210628135754-865549cb023e
 	github.com/m-lab/etl-gardener v0.0.0-20210310164025-d9582f1131b5
 	github.com/m-lab/go v0.1.45
 	github.com/m-lab/ndt-server v0.20.5

--- a/go.sum
+++ b/go.sum
@@ -293,6 +293,8 @@ github.com/m-lab/annotation-service v0.0.0-20210427141535-6f5ace9e5186 h1:fQHu82
 github.com/m-lab/annotation-service v0.0.0-20210427141535-6f5ace9e5186/go.mod h1:bW5A2AmUqyh6kGbmu4X8fYK2pRcfTvTjAXW/+4VQZUA=
 github.com/m-lab/annotation-service v0.0.0-20210510161905-66746c999334 h1:z7xXMwBLYSkIZxeIlgo5qLmFAOJleeGsUiJFlOCSpjY=
 github.com/m-lab/annotation-service v0.0.0-20210510161905-66746c999334/go.mod h1:bW5A2AmUqyh6kGbmu4X8fYK2pRcfTvTjAXW/+4VQZUA=
+github.com/m-lab/annotation-service v0.0.0-20210628135754-865549cb023e h1:zJh3h0MFg+o/hjNFqTpoOC2zJWHep24fpuj3+7Cveto=
+github.com/m-lab/annotation-service v0.0.0-20210628135754-865549cb023e/go.mod h1:bW5A2AmUqyh6kGbmu4X8fYK2pRcfTvTjAXW/+4VQZUA=
 github.com/m-lab/etl-gardener v0.0.0-20210310164025-d9582f1131b5 h1:jCFqYBvYPEHqkwMD/idhnO2Q3E84bg3RVupgGm0aO6g=
 github.com/m-lab/etl-gardener v0.0.0-20210310164025-d9582f1131b5/go.mod h1:4hAG+N9lfh+vQ+FEcMFad0SOP74VJi5yeWk7ioHkvs0=
 github.com/m-lab/go v0.1.44 h1:aVI5k1M8q919m+3HIvrXOY/eMVaHAZPAflxnZ28o3q4=


### PR DESCRIPTION
Include fix from https://github.com/m-lab/annotation-service/pull/289 into etl.

This change allows server annotations from siteinfo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/997)
<!-- Reviewable:end -->
