### PR TITLE
Add ServerX and ClientX annotation fields to ndt.web100 schema and parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/go-jsonnet v0.17.0
 	github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8
 	github.com/kr/pretty v0.2.1
-	github.com/m-lab/annotation-service v0.0.0-20210628135754-865549cb023e
+	github.com/m-lab/annotation-service v0.0.0-20210707211452-d9dc04efa2ae
 	github.com/m-lab/etl-gardener v0.0.0-20210310164025-d9582f1131b5
 	github.com/m-lab/go v0.1.45
 	github.com/m-lab/ndt-server v0.20.5

--- a/go.sum
+++ b/go.sum
@@ -295,6 +295,8 @@ github.com/m-lab/annotation-service v0.0.0-20210510161905-66746c999334 h1:z7xXMw
 github.com/m-lab/annotation-service v0.0.0-20210510161905-66746c999334/go.mod h1:bW5A2AmUqyh6kGbmu4X8fYK2pRcfTvTjAXW/+4VQZUA=
 github.com/m-lab/annotation-service v0.0.0-20210628135754-865549cb023e h1:zJh3h0MFg+o/hjNFqTpoOC2zJWHep24fpuj3+7Cveto=
 github.com/m-lab/annotation-service v0.0.0-20210628135754-865549cb023e/go.mod h1:bW5A2AmUqyh6kGbmu4X8fYK2pRcfTvTjAXW/+4VQZUA=
+github.com/m-lab/annotation-service v0.0.0-20210707211452-d9dc04efa2ae h1:jAVpWkYi0cSaKE8DeuyhXOXx6eo0uErvQHR3C5Lh39s=
+github.com/m-lab/annotation-service v0.0.0-20210707211452-d9dc04efa2ae/go.mod h1:bW5A2AmUqyh6kGbmu4X8fYK2pRcfTvTjAXW/+4VQZUA=
 github.com/m-lab/etl-gardener v0.0.0-20210310164025-d9582f1131b5 h1:jCFqYBvYPEHqkwMD/idhnO2Q3E84bg3RVupgGm0aO6g=
 github.com/m-lab/etl-gardener v0.0.0-20210310164025-d9582f1131b5/go.mod h1:4hAG+N9lfh+vQ+FEcMFad0SOP74VJi5yeWk7ioHkvs0=
 github.com/m-lab/go v0.1.44 h1:aVI5k1M8q919m+3HIvrXOY/eMVaHAZPAflxnZ28o3q4=

--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -823,7 +823,6 @@ func copyStructToMapDirectly(sourceStruct interface{}, destinationMap map[string
 		v := f.Interface()
 		switch t := v.(type) {
 		case string:
-			// TODO - are these still needed?  Does the omitempty cover it?
 			if t == "" {
 				continue
 			}
@@ -832,6 +831,9 @@ func copyStructToMapDirectly(sourceStruct interface{}, destinationMap map[string
 				continue
 			}
 		case uint32:
+			if t == 0 {
+				continue
+			}
 			// NOTE: bigquery.Value does not support unsigned int types. The
 			// annotation-service API returns uint32 for the ASNumber field.
 			// When copying this value, convert it to an int64 so that it is

--- a/parser/ndt_test.go
+++ b/parser/ndt_test.go
@@ -10,7 +10,7 @@ import (
 	"cloud.google.com/go/bigquery"
 
 	"github.com/go-test/deep"
-	"github.com/m-lab/go/pretty"
+	"github.com/kr/pretty"
 
 	v2as "github.com/m-lab/annotation-service/api/v2"
 
@@ -200,8 +200,8 @@ func TestNDTParser(t *testing.T) {
 					"Missing":  false,
 				},
 				"Geo": schema.Web100ValueMap{
-					"Latitude":  float64(1),
-					"Longitude": float64(2),
+					"Latitude":  1.0,
+					"Longitude": 2.0,
 				},
 			},
 			"ServerX": schema.Web100ValueMap{
@@ -212,8 +212,8 @@ func TestNDTParser(t *testing.T) {
 					"Missing":  false,
 				},
 				"Geo": schema.Web100ValueMap{
-					"Latitude":  float64(3),
-					"Longitude": float64(4),
+					"Latitude":  3.0,
+					"Longitude": 4.0,
 				},
 			},
 		},

--- a/parser/ndt_test.go
+++ b/parser/ndt_test.go
@@ -10,7 +10,7 @@ import (
 	"cloud.google.com/go/bigquery"
 
 	"github.com/go-test/deep"
-	"github.com/kr/pretty"
+	"github.com/m-lab/go/pretty"
 
 	v2as "github.com/m-lab/annotation-service/api/v2"
 
@@ -116,9 +116,9 @@ func TestNDTParser(t *testing.T) {
 	// Completely fake annotation data.
 	responseJSON := `{"AnnotatorDate":"2018-12-05T00:00:00Z",
 		"Annotations":{
-				   "45.56.98.222":{"Geo":{"postal_code":"45569"}, "Network":{"Systems":[{"ASNs":[123]}]}},
-				   "213.208.152.37":{"Geo":{"postal_code":"21320"}, "Network":{"Systems":[{"ASNs":[456]}]}}
-				   }}`
+		   "45.56.98.222":{"Geo":{"postal_code":"45569", "latitude": 1.0, "longitude": 2.0}, "Network":{"ASName":"Fake Client ISP", "ASNumber": 123, "Systems":[{"ASNs":[123]}]}},
+		   "213.208.152.37":{"Geo":{"postal_code":"21320", "latitude": 3.0, "longitude": 4.0}, "Network":{"ASName":"Fake Server ISP", "ASNumber": 456, "CIDR": "213.208.152.0/26", "Systems":[{"ASNs":[456]}]}}
+	   }}`
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, responseJSON)
 	}))
@@ -190,7 +190,31 @@ func TestNDTParser(t *testing.T) {
 				"network": schema.Web100ValueMap{"asn": int64(123)},
 			},
 			"server": schema.Web100ValueMap{
-				"network": schema.Web100ValueMap{"asn": int64(456)},
+				"network":   schema.Web100ValueMap{"asn": int64(456)},
+				"iata_code": "VIE",
+			},
+			"ClientX": schema.Web100ValueMap{
+				"Network": schema.Web100ValueMap{
+					"ASName":   "Fake Client ISP",
+					"ASNumber": int64(123),
+					"Missing":  false,
+				},
+				"Geo": schema.Web100ValueMap{
+					"Latitude":  1,
+					"Longitude": 2,
+				},
+			},
+			"ServerX": schema.Web100ValueMap{
+				"Network": schema.Web100ValueMap{
+					"ASName":   "Fake Server ISP",
+					"ASNumber": int64(456),
+					"CIDR":     "213.208.152.0/26",
+					"Missing":  false,
+				},
+				"Geo": schema.Web100ValueMap{
+					"Latitude":  3,
+					"Longitude": 4,
+				},
 			},
 		},
 		"web100_log_entry": schema.Web100ValueMap{
@@ -282,7 +306,12 @@ func compare(t *testing.T, actual schema.Web100ValueMap, expected schema.Web100V
 					match = false
 				}
 			}
-
+		case bool:
+			if act.(bool) != v {
+				t.Logf("Wrong bool for key %q: got %t; want %t",
+					key, v, act.(bool))
+				match = false
+			}
 		default:
 			fmt.Printf("Unsupported type. %T\n", v)
 			panic(nil)

--- a/parser/ndt_test.go
+++ b/parser/ndt_test.go
@@ -200,8 +200,8 @@ func TestNDTParser(t *testing.T) {
 					"Missing":  false,
 				},
 				"Geo": schema.Web100ValueMap{
-					"Latitude":  1,
-					"Longitude": 2,
+					"Latitude":  float64(1),
+					"Longitude": float64(2),
 				},
 			},
 			"ServerX": schema.Web100ValueMap{
@@ -212,8 +212,8 @@ func TestNDTParser(t *testing.T) {
 					"Missing":  false,
 				},
 				"Geo": schema.Web100ValueMap{
-					"Latitude":  3,
-					"Longitude": 4,
+					"Latitude":  float64(3),
+					"Longitude": float64(4),
 				},
 			},
 		},
@@ -305,6 +305,12 @@ func compare(t *testing.T, actual schema.Web100ValueMap, expected schema.Web100V
 						key, v, act.([]float64))
 					match = false
 				}
+			}
+		case float64:
+			if v != act.(float64) {
+				t.Logf("Wrong floats for key %q: got %f; want %v",
+					key, v, act.(float64))
+				match = false
 			}
 		case bool:
 			if act.(bool) != v {

--- a/schema/ndt_web100.go
+++ b/schema/ndt_web100.go
@@ -6,6 +6,7 @@ import (
 	"cloud.google.com/go/bigquery"
 	"github.com/m-lab/annotation-service/api"
 	"github.com/m-lab/go/cloud/bqx"
+	"github.com/m-lab/uuid-annotator/annotator"
 )
 
 // NDTWeb100 is a mirror struct of the BQ schema. This type is NOT USED by the parser.
@@ -53,6 +54,10 @@ type ndtConnectionSpec struct {
 	ServerGeolocation   api.GeolocationIP `bigquery:"server_geolocation"`
 	Client              ndtClientNetwork  `bigquery:"client"`
 	Server              ndtServerNetwork  `bigquery:"server"`
+
+	// ServerX and ClientX are for the synthetic UUID annotator export process.
+	ServerX annotator.ServerAnnotations
+	ClientX annotator.ClientAnnotations
 }
 
 type network struct {
@@ -61,12 +66,10 @@ type network struct {
 
 type ndtClientNetwork struct {
 	Network network `bigquery:"network"`
-	// api.ASData         // Include extended asn data from  annotation-service
 }
 type ndtServerNetwork struct {
 	IataCode string  `bigquery:"iata_code"`
 	Network  network `bigquery:"network"`
-	// api.ASData         // Include extended asn data from  annotation-service
 }
 
 type web100ConnectionSpec struct {

--- a/schema/web100.go
+++ b/schema/web100.go
@@ -203,6 +203,16 @@ func FullConnectionSpec() Web100ValueMap {
 		"websockets":            false,
 		"client_geolocation":    FullGeolocation(),
 		"server_geolocation":    FullGeolocation(),
+		"client":                Web100ValueMap{},
+		"server":                Web100ValueMap{},
+		"ClientX": Web100ValueMap{
+			"Geo":     Web100ValueMap{},
+			"Network": Web100ValueMap{},
+		},
+		"ServerX": Web100ValueMap{
+			"Geo":     Web100ValueMap{},
+			"Network": Web100ValueMap{},
+		},
 	}
 }
 
@@ -212,6 +222,26 @@ func EmptyConnectionSpec() Web100ValueMap {
 		"server_geolocation": EmptyGeolocation(),
 		"client":             Web100ValueMap{"network": make(Web100ValueMap, 2)},
 		"server":             Web100ValueMap{"network": make(Web100ValueMap, 2)},
+		"ClientX": Web100ValueMap{
+			"Geo": Web100ValueMap{},
+			"Network": Web100ValueMap{
+				"CIDR":     "",
+				"ASNumber": 0,
+				"ASName":   "",
+				"Missing":  false,
+				"Systems":  []Web100ValueMap{},
+			},
+		},
+		"ServerX": Web100ValueMap{
+			"Geo": Web100ValueMap{},
+			"Network": Web100ValueMap{
+				"CIDR":     "",
+				"ASNumber": 0,
+				"ASName":   "",
+				"Missing":  false,
+				"Systems":  []Web100ValueMap{},
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
This change adds two new fields to the ndt.web100 schema and parser. The ServerX and ClientX fields are exact copies of the uuid-annotator structures populated with the results from the annotation-service.

This change should make annotation export queries simpler because whole records can be used in the result as-is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/999)
<!-- Reviewable:end -->
