### PR TITLE
Add ServerX and ClientX annotation fields to sidestream schema and parser

### DIFF
--- a/schema/sidestream_schema.go
+++ b/schema/sidestream_schema.go
@@ -7,7 +7,9 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"github.com/m-lab/annotation-service/api"
+	apiv2 "github.com/m-lab/annotation-service/api/v2"
 	"github.com/m-lab/go/cloud/bqx"
+	"github.com/m-lab/uuid-annotator/annotator"
 )
 
 type Web100ConnectionSpecification struct {
@@ -18,6 +20,10 @@ type Web100ConnectionSpecification struct {
 	Remote_port        int64             `json:"remote_port" bigquery:"remote_port"`
 	Local_geolocation  api.GeolocationIP `json:"local_geolocation" bigquery:"local_geolocation"`
 	Remote_geolocation api.GeolocationIP `json:"remote_geolocation" bigquery:"remote_geolocation"`
+
+	// ServerX and ClientX are for the synthetic UUID annotator export process.
+	ServerX annotator.ServerAnnotations
+	ClientX annotator.ClientAnnotations
 }
 
 type Web100Snap struct {
@@ -223,8 +229,12 @@ func (ss *SS) AnnotateClients(annMap map[string]*api.Annotations) error {
 		ann, ok := annMap[connSpec.Remote_ip]
 		if ok && ann.Geo != nil {
 			connSpec.Remote_geolocation = *ann.Geo
+
+			// Copy the geo and network information using uuid-annotator types.
+			c := apiv2.ConvertAnnotationsToClientAnnotations(ann)
+			connSpec.ClientX.Geo = c.Geo
+			connSpec.ClientX.Network = c.Network
 		}
-		// TODO Handle ASN
 	}
 	return nil
 }
@@ -235,7 +245,11 @@ func (ss *SS) AnnotateServer(local *api.Annotations) error {
 	if local != nil && local.Geo != nil {
 		// TODO - this should probably be a pointer
 		connSpec.Local_geolocation = *local.Geo
-		// TODO Handle ASN
+
+		// Copy the geo and network information using uuid-annotator types.
+		s := apiv2.ConvertAnnotationsToServerAnnotations(local)
+		connSpec.ServerX.Geo = s.Geo
+		connSpec.ServerX.Network = s.Network
 	}
 	return nil
 }


### PR DESCRIPTION
This change updates the sidestream schema with the same fields added to the ndt.web100 schema in https://github.com/m-lab/etl/pull/999

The ServerX and ClientX fields are exact copies of the uuid-annotator structures populated with the results from the annotation-service. This change should make annotation export queries simpler because whole records can be used in the result as-is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1000)
<!-- Reviewable:end -->
