### PR TITLE
Apply NormalizeIP to sidestream addresses during parsing

### DIFF
--- a/parser/ss.go
+++ b/parser/ss.go
@@ -110,6 +110,8 @@ func PackDataIntoSchema(ssValue map[string]string, logTime time.Time, testName s
 		return schema.SS{}, err
 	}
 
+	ssValue["LocalAddress"] = web100.NormalizeIP(ssValue["LocalAddress"])
+	ssValue["RemAddress"] = web100.NormalizeIP(ssValue["RemAddress"])
 	connSpec := &schema.Web100ConnectionSpecification{
 		Local_ip:    ssValue["LocalAddress"],
 		Local_af:    web100.ParseIPFamily(ssValue["LocalAddress"]),

--- a/web100/parse.go
+++ b/web100/parse.go
@@ -87,6 +87,17 @@ func NormalizeIPv6(ipStr string) (string, error) {
 	}
 }
 
+// NormalizeIP accepts an IPv4 or IPv6 address and returns a normalized version
+// of that string. This should be used to fix malformed IPv6 addresses in
+// web100 datasets.
+func NormalizeIP(ip string) string {
+	r, err := NormalizeIPv6(ip)
+	if err != nil {
+		return ip
+	}
+	return r
+}
+
 // ValidateIP validates (and possibly repairs) IP addresses.
 // Return nil if it is a valid IPv4 or IPv6 address (or can be repaired), non-nil otherwise.
 func ValidateIP(ipStr string) error {

--- a/web100/parse_test.go
+++ b/web100/parse_test.go
@@ -118,3 +118,39 @@ func BenchmarkValidateIPv4(b *testing.B) {
 		_ = web100.ValidateIP("1.2.3.4")
 	}
 }
+
+func TestNormalizeIP(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   string
+		want string
+	}{
+		{
+			name: "success-noop-ipv4",
+			ip:   "1.2.3.4",
+			want: "1.2.3.4",
+		},
+		{
+			name: "success-noop-ipv6",
+			ip:   "1:2:3::4",
+			want: "1:2:3::4",
+		},
+		{
+			name: "success-:::-ipv6",
+			ip:   "1:2:3:::4", // triple-colon format from web100.
+			want: "1:2:3::4",
+		},
+		{
+			name: "badformat-preserved-::::-ipv6",
+			ip:   "1:2:3::::4", // quad-colon format error, not normalized.
+			want: "1:2:3::::4",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := web100.NormalizeIP(tt.ip); got != tt.want {
+				t.Errorf("NormalizeIP() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change fixes the triple-colon formatting in sidestream IPv6 addresses.

Around 2.7B rows in sidestream include `:::` in the remote or local IP.

```
 web100_log_entry.connection_spec.remote_ip LIKE '%:::%' OR web100_log_entry.connection_spec.local_ip LIKE '%:::%'
```

This change uses a new function `NormalizeIP` that corrects this formatting. If the IP address is invalid for other reasons, it will be used as-is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1001)
<!-- Reviewable:end -->
