### PR TITLE
Set ServerX fields for Site and Machine

### DIFF
--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -610,6 +610,10 @@ func (n *NDTParser) getAndInsertValues(test *fileInfoAndData, testType string) {
 			deltaFieldCount, test.fn, n.taskFileName)
 	}
 
+	dp, _ := etl.ValidateTestPath(results["task_filename"].(string))
+	connSpec.Get("ServerX")["Site"] = dp.Site
+	connSpec.Get("ServerX")["Machine"] = dp.Host
+
 	// TODO - estimate the size of the json (or fields) to allow more rows per request,
 	// but avoid going over the 10MB limit.
 	// Add row to buffer, possibly flushing buffer if it is full.
@@ -627,6 +631,7 @@ func (n *NDTParser) getAndInsertValues(test *fileInfoAndData, testType string) {
 		log.Println("insert-err: " + err.Error())
 		return
 	}
+
 	metrics.TestCount.WithLabelValues(
 		n.TableName(), testType, "ok").Inc()
 }

--- a/parser/ndt_test.go
+++ b/parser/ndt_test.go
@@ -205,6 +205,8 @@ func TestNDTParser(t *testing.T) {
 				},
 			},
 			"ServerX": schema.Web100ValueMap{
+				"Site":    "vie01",
+				"Machine": "mlab3",
 				"Network": schema.Web100ValueMap{
 					"ASName":   "Fake Server ISP",
 					"ASNumber": int64(456),

--- a/parser/ss.go
+++ b/parser/ss.go
@@ -294,6 +294,10 @@ func (ss *SSParser) ParseAndInsert(meta map[string]bigquery.Value, testName stri
 			ssTest.TaskFileName = meta["filename"].(string)
 		}
 
+		dp, _ := etl.ValidateTestPath(ssTest.TaskFileName)
+		ssTest.Web100_log_entry.Connection_spec.ServerX.Site = dp.Site
+		ssTest.Web100_log_entry.Connection_spec.ServerX.Machine = dp.Host
+
 		// Add row to buffer, possibly flushing buffer if it is full.
 		err = ss.AddRow(&ssTest)
 		if err == etl.ErrBufferFull {

--- a/parser/ss_test.go
+++ b/parser/ss_test.go
@@ -92,7 +92,9 @@ func TestSSInserter(t *testing.T) {
 		t.Fatalf("cannot read testdata.")
 	}
 
-	meta := map[string]bigquery.Value{"filename": filename}
+	taskFilename := "gs://archive-measurement-lab/sidestream/2019/11/20/20191120T010010Z-mlab1-ord03-sidestream-0000.tgz"
+
+	meta := map[string]bigquery.Value{"filename": taskFilename}
 	err = p.ParseAndInsert(meta, filename, rawData)
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -123,8 +125,8 @@ func TestSSInserter(t *testing.T) {
 	if inserted.ParseTime.After(time.Now()) {
 		t.Error("Should have inserted parse_time")
 	}
-	if inserted.TaskFileName != filename {
-		t.Error("Should have correct filename", filename, "!=", inserted.TaskFileName)
+	if inserted.TaskFileName != taskFilename {
+		t.Error("Should have correct filename", taskFilename, "!=", inserted.TaskFileName)
 	}
 
 	if inserted.ParserVersion != "https://github.com/m-lab/etl/tree/foobar" {
@@ -155,6 +157,8 @@ func TestSSInserter(t *testing.T) {
 			Longitude:  2,
 		},
 		ServerX: annotator.ServerAnnotations{
+			Site:    "ord03",
+			Machine: "mlab1",
 			Geo: &annotator.Geolocation{
 				PostalCode: "21320",
 				Latitude:   3.0,


### PR DESCRIPTION
This change assigns the `Site` and `Machine` fields of the `ServerX` server annotation record for the sidestream and ndt.web100 datatypes. This change will make the annotation export queries simpler b/c the values can be used as-is rather than re-calculated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1003)
<!-- Reviewable:end -->
