### PR TITLE
Add parser.GitCommit field into ParseInfo struct

### DIFF
--- a/parser/annotation.go
+++ b/parser/annotation.go
@@ -83,7 +83,7 @@ func (ap *AnnotationParser) ParseAndInsert(meta map[string]bigquery.Value, testN
 			Time:       time.Now(),
 			ArchiveURL: meta["filename"].(string),
 			Filename:   testName,
-			GitCommit:	GitCommit(),
+			GitCommit:  GitCommit(),
 		},
 	}
 

--- a/parser/annotation.go
+++ b/parser/annotation.go
@@ -83,6 +83,7 @@ func (ap *AnnotationParser) ParseAndInsert(meta map[string]bigquery.Value, testN
 			Time:       time.Now(),
 			ArchiveURL: meta["filename"].(string),
 			Filename:   testName,
+			GitCommit:	GitCommit(),
 		},
 	}
 

--- a/parser/annotation_test.go
+++ b/parser/annotation_test.go
@@ -2,15 +2,15 @@ package parser_test
 
 import (
 	"io/ioutil"
-	"testing"
 	"strings"
+	"testing"
 
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/civil"
-	"github.com/m-lab/etl/parser"
-	"github.com/m-lab/go/rtx"
-	"github.com/m-lab/etl/schema"
 	"github.com/go-test/deep"
+	"github.com/m-lab/etl/parser"
+	"github.com/m-lab/etl/schema"
+	"github.com/m-lab/go/rtx"
 )
 
 func TestAnnotationParser_ParseAndInsert(t *testing.T) {
@@ -54,13 +54,13 @@ func TestAnnotationParser_ParseAndInsert(t *testing.T) {
 				n.Flush()
 				row := ins.data[0].(*schema.AnnotationRow)
 
-				expPI := schema.ParseInfo {
+				expPI := schema.ParseInfo{
 					Version:    "https://github.com/m-lab/etl/tree/foobar",
 					Time:       row.Parser.Time,
 					ArchiveURL: "gs://mlab-test-bucket/ndt/ndt7/2020/03/18/ndt-njp6l_1585004303_00000000000170FA.json",
 					Filename:   "ndt-njp6l_1585004303_00000000000170FA.json",
 					Priority:   0,
-					GitCommit:	"12345678",
+					GitCommit:  "12345678",
 				}
 
 				if diff := deep.Equal(row.Parser, expPI); diff != nil {

--- a/parser/export_test.go
+++ b/parser/export_test.go
@@ -7,3 +7,7 @@ package parser
 // InitParserVersionForTest allows tests to rerun initParserVersion after initializing
 // environment variables.
 var InitParserVersionForTest = initParserVersion
+
+// InitParserGitCommitForTest allows test to rerun initParseGitCommit after initializing
+// environement variables.
+var InitParserGitCommitForTest = initParserGitCommit

--- a/parser/ndt7_result.go
+++ b/parser/ndt7_result.go
@@ -81,7 +81,7 @@ func (dp *NDT7ResultParser) ParseAndInsert(meta map[string]bigquery.Value, testN
 			Time:       time.Now(),
 			ArchiveURL: meta["filename"].(string),
 			Filename:   testName,
-			GitCommit:	GitCommit(),	
+			GitCommit:  GitCommit(),
 		},
 	}
 

--- a/parser/ndt7_result.go
+++ b/parser/ndt7_result.go
@@ -81,6 +81,7 @@ func (dp *NDT7ResultParser) ParseAndInsert(meta map[string]bigquery.Value, testN
 			Time:       time.Now(),
 			ArchiveURL: meta["filename"].(string),
 			Filename:   testName,
+			GitCommit:	GitCommit(),	
 		},
 	}
 

--- a/parser/ndt7_result_test.go
+++ b/parser/ndt7_result_test.go
@@ -70,7 +70,7 @@ func TestNDT7ResultParser_ParseAndInsert(t *testing.T) {
 					ArchiveURL: "gs://mlab-test-bucket/ndt/ndt7/2020/03/18/ndt_ndt7_2020_03_18_20200318T003853.425987Z-ndt7-mlab3-syd03-ndt.tgz",
 					Filename:   "ndt7-download-20200318T000657.568382877Z.ndt-knwp4_1583603744_000000000000590E.json",
 					Priority:   0,
-					GitCommit:	"12345678",
+					GitCommit:  "12345678",
 				}
 				if diff := deep.Equal(row.Parser, expPI); diff != nil {
 					pretty.Print(row.Parser)
@@ -109,7 +109,7 @@ func TestNDT7ResultParser_ParseAndInsert(t *testing.T) {
 					ArchiveURL: "gs://mlab-test-bucket/ndt/ndt7/2020/03/18/ndt_ndt7_2020_03_18_20200318T003853.425987Z-ndt7-mlab3-syd03-ndt.tgz",
 					Filename:   "ndt7-upload-20200318T001352.496224022Z.ndt-knwp4_1583603744_0000000000005CF2.json",
 					Priority:   0,
-					GitCommit:	"12345678",
+					GitCommit:  "12345678",
 				}
 				if diff := deep.Equal(row.Parser, expPI); diff != nil {
 					t.Errorf("NDT7ResultParser.ParseAndInsert() different summary: %s", strings.Join(diff, "\n"))

--- a/parser/ndt7_result_test.go
+++ b/parser/ndt7_result_test.go
@@ -70,6 +70,7 @@ func TestNDT7ResultParser_ParseAndInsert(t *testing.T) {
 					ArchiveURL: "gs://mlab-test-bucket/ndt/ndt7/2020/03/18/ndt_ndt7_2020_03_18_20200318T003853.425987Z-ndt7-mlab3-syd03-ndt.tgz",
 					Filename:   "ndt7-download-20200318T000657.568382877Z.ndt-knwp4_1583603744_000000000000590E.json",
 					Priority:   0,
+					GitCommit:	"12345678",
 				}
 				if diff := deep.Equal(row.Parser, expPI); diff != nil {
 					pretty.Print(row.Parser)
@@ -108,6 +109,7 @@ func TestNDT7ResultParser_ParseAndInsert(t *testing.T) {
 					ArchiveURL: "gs://mlab-test-bucket/ndt/ndt7/2020/03/18/ndt_ndt7_2020_03_18_20200318T003853.425987Z-ndt7-mlab3-syd03-ndt.tgz",
 					Filename:   "ndt7-upload-20200318T001352.496224022Z.ndt-knwp4_1583603744_0000000000005CF2.json",
 					Priority:   0,
+					GitCommit:	"12345678",
 				}
 				if diff := deep.Equal(row.Parser, expPI); diff != nil {
 					t.Errorf("NDT7ResultParser.ParseAndInsert() different summary: %s", strings.Join(diff, "\n"))

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -45,8 +45,8 @@ func initParserVersion() string {
 // initParserGitCommit initializes the gParserGitCommit variable for use by all parsers.
 func initParserGitCommit() string {
 	hash := etl.GitCommit
-	if hash != "nocommit" && len(hash) >= 8 {
-		gParserGitCommit = hash[0:8]
+	if hash != "nocommit" {
+		gParserGitCommit = hash
 	}
 	return gParserGitCommit
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -21,9 +21,15 @@ import (
 
 func init() {
 	initParserVersion()
+	initParserGitCommit()
 }
 
-var gParserVersion = "uninitialized"
+const uninitialized = "uninitialized"
+
+var( 
+	gParserVersion = uninitialized
+	gParserGitCommit = uninitialized
+)
 
 // initParserVersion initializes the gParserVersion variable for use by all parsers.
 func initParserVersion() string {
@@ -31,19 +37,28 @@ func initParserVersion() string {
 	if release != "noversion" {
 		gParserVersion = "https://github.com/m-lab/etl/tree/" + release
 	} else {
-		hash := etl.GitCommit
-		if hash != "nocommit" && len(hash) >= 8 {
-			gParserVersion = "https://github.com/m-lab/etl/tree/" + hash[0:8]
-		} else {
-			gParserVersion = "local development"
-		}
+		gParserVersion = "local development"
 	}
 	return gParserVersion
+}
+
+// initParserGitCommit initializes the gParserGitCommit variable for use by all parsers.
+func initParserGitCommit() string {
+	hash := etl.GitCommit
+	if hash != "nocommit" && len(hash) >= 8 {
+		gParserGitCommit = hash[0:8]
+	}
+	return gParserGitCommit
 }
 
 // Version returns the parser version used by parsers to annotate data rows.
 func Version() string {
 	return gParserVersion
+}
+
+// GitCommit returns the git commit hash of the build.
+func GitCommit() string {
+	return gParserGitCommit
 }
 
 // NewSinkParser creates an appropriate parser for a given data type.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -26,8 +26,8 @@ func init() {
 
 const uninitialized = "uninitialized"
 
-var( 
-	gParserVersion = uninitialized
+var (
+	gParserVersion   = uninitialized
 	gParserGitCommit = uninitialized
 )
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -17,10 +17,10 @@ import (
 )
 
 func init() {
-	etl.Version = "foobar"	
+	etl.Version = "foobar"
 	parser.InitParserVersionForTest()
 
-	etl.GitCommit ="12345678"
+	etl.GitCommit = "12345678"
 	parser.InitParserGitCommitForTest()
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -17,8 +17,11 @@ import (
 )
 
 func init() {
-	etl.Version = "foobar"
+	etl.Version = "foobar"	
 	parser.InitParserVersionForTest()
+
+	etl.GitCommit ="12345678"
+	parser.InitParserGitCommitForTest()
 }
 
 // countingInserter counts the calls to InsertRows and Flush.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -18,7 +18,7 @@ type ParseInfo struct {
 	ArchiveURL string
 	Filename   string
 	Priority   int64
-	GitCommit	string
+	GitCommit  string
 }
 
 // FindSchemaDocsFor should be used by parser row types to associate bigquery

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -18,6 +18,7 @@ type ParseInfo struct {
 	ArchiveURL string
 	Filename   string
 	Priority   int64
+	GitCommit	string
 }
 
 // FindSchemaDocsFor should be used by parser row types to associate bigquery


### PR DESCRIPTION
Summary:
Adding GitCommit field to ParseInfo struct

Description:
This struct is used by NDT7 and Annotation
NDT5 uses another version called ParseInfoV0, so it's not in scope for this change

Testing:
Change includes unit tests and will also be tested by checking the table schema

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1005)
<!-- Reviewable:end -->
