### PR TITLE
Complete unit tests for ServerX and ClientX records in tcpinfo and pt parsers

### DIFF
--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -610,6 +610,7 @@ func (n *NDTParser) getAndInsertValues(test *fileInfoAndData, testType string) {
 			deltaFieldCount, test.fn, n.taskFileName)
 	}
 
+	// ArchiveURL must already be valid, so error is safe to ignore.
 	dp, _ := etl.ValidateTestPath(results["task_filename"].(string))
 	connSpec.Get("ServerX")["Site"] = dp.Site
 	connSpec.Get("ServerX")["Machine"] = dp.Host

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -3,12 +3,16 @@
 package parser_test
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/bigquery"
+	"github.com/m-lab/annotation-service/api"
+	v2 "github.com/m-lab/annotation-service/api/v2"
 	"github.com/m-lab/etl/bq"
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/metrics"
@@ -46,6 +50,20 @@ func (ti *countingInserter) InsertRows(data []interface{}) error {
 func (ti *countingInserter) Flush() error {
 	ti.FlushCount++
 	return nil
+}
+
+// newFakeAnnotator creates a new annotator that injects the given annotation
+// responses for unit testing.
+func newFakeAnnotator(ann map[string]*api.Annotations) *fakeAnnotator {
+	return &fakeAnnotator{ann: ann}
+}
+
+type fakeAnnotator struct {
+	ann map[string]*api.Annotations
+}
+
+func (ann *fakeAnnotator) GetAnnotations(ctx context.Context, date time.Time, ips []string, info ...string) (*v2.Response, error) {
+	return &v2.Response{AnnotatorDate: time.Now(), Annotations: ann.ann}, nil
 }
 
 func TestNormalizeIP(t *testing.T) {

--- a/parser/pt.go
+++ b/parser/pt.go
@@ -568,7 +568,7 @@ func (pt *PTParser) ParseAndInsert(meta map[string]bigquery.Value, testName stri
 	// Process json output from traceroute-caller
 	if strings.HasSuffix(testName, ".json") {
 		ptTest, err := ParsePT(testName, rawContent, pt.TableName(), pt.taskFileName)
-
+		fmt.Println("JSON PARSER!!!!!!")
 		if err == nil {
 			err := pt.AddRow(&ptTest)
 			if err == etl.ErrBufferFull {
@@ -587,6 +587,10 @@ func (pt *PTParser) ParseAndInsert(meta map[string]bigquery.Value, testName stri
 	if strings.HasSuffix(testName, ".jsonl") {
 		ptTest, err := ParseJSONL(testName, rawContent, pt.TableName(), pt.taskFileName)
 		if err == nil {
+			dp, _ := etl.ValidateTestPath(pt.taskFileName)
+			ptTest.ServerX.Site = dp.Site
+			ptTest.ServerX.Machine = dp.Host
+
 			err := pt.AddRow(&ptTest)
 			if err == etl.ErrBufferFull {
 				// Flush asynchronously, to improve throughput.

--- a/parser/pt.go
+++ b/parser/pt.go
@@ -498,6 +498,7 @@ func (pt *PTParser) InsertOneTest(oneTest cachedPTData) {
 		Destination: oneTest.Destination,
 		Hop:         oneTest.Hops,
 	}
+	// ArchiveURL must already be valid, so error is safe to ignore.
 	dp, _ := etl.ValidateTestPath(pt.taskFileName)
 	ptTest.ServerX.Site = dp.Site
 	ptTest.ServerX.Machine = dp.Host
@@ -586,6 +587,7 @@ func (pt *PTParser) ParseAndInsert(meta map[string]bigquery.Value, testName stri
 	if strings.HasSuffix(testName, ".jsonl") {
 		ptTest, err := ParseJSONL(testName, rawContent, pt.TableName(), pt.taskFileName)
 		if err == nil {
+			// ArchiveURL must already be valid, so error is safe to ignore.
 			dp, _ := etl.ValidateTestPath(pt.taskFileName)
 			ptTest.ServerX.Site = dp.Site
 			ptTest.ServerX.Machine = dp.Host

--- a/parser/pt.go
+++ b/parser/pt.go
@@ -568,7 +568,6 @@ func (pt *PTParser) ParseAndInsert(meta map[string]bigquery.Value, testName stri
 	// Process json output from traceroute-caller
 	if strings.HasSuffix(testName, ".json") {
 		ptTest, err := ParsePT(testName, rawContent, pt.TableName(), pt.taskFileName)
-		fmt.Println("JSON PARSER!!!!!!")
 		if err == nil {
 			err := pt.AddRow(&ptTest)
 			if err == etl.ErrBufferFull {

--- a/parser/pt_test.go
+++ b/parser/pt_test.go
@@ -14,7 +14,6 @@ import (
 	v2 "github.com/m-lab/annotation-service/api/v2"
 	"github.com/m-lab/etl/parser"
 	"github.com/m-lab/etl/schema"
-	"github.com/m-lab/go/pretty"
 )
 
 func TestParsePT(t *testing.T) {
@@ -256,7 +255,36 @@ func TestParseLegacyFormatData(t *testing.T) {
 }
 
 func TestParseJSONL(t *testing.T) {
-	m := map[string]*api.Annotations{}
+	m := map[string]*api.Annotations{
+		"91.213.30.229": &api.Annotations{
+			Geo: &api.GeolocationIP{
+				ContinentCode: "NA",
+				CountryCode:   "US",
+				Latitude:      1.0,
+				Longitude:     2.0,
+			},
+			Network: &api.ASData{
+				ASNumber: 1234,
+				Systems: []api.System{
+					{ASNs: []uint32{1234}},
+				},
+			},
+		},
+		"91.169.126.135": &api.Annotations{
+			Geo: &api.GeolocationIP{
+				ContinentCode: "EU",
+				CountryCode:   "DE",
+				Latitude:      3.0,
+				Longitude:     4.0,
+			},
+			Network: &api.ASData{
+				ASNumber: 4321,
+				Systems: []api.System{
+					{ASNs: []uint32{4321}},
+				},
+			},
+		},
+	}
 	ins := newInMemoryInserter()
 	pt := parser.NewPTParser(ins, newFakeAnnotator(m))
 
@@ -265,10 +293,6 @@ func TestParseJSONL(t *testing.T) {
 	if err != nil {
 		t.Fatalf(err.Error())
 		return
-	}
-	ptTest, err := parser.ParseJSONL("20190927T070859Z_ndt-qtfh8_1565996043_0000000000003B64.jsonl", []byte(rawData), "", "")
-	if err != nil {
-		t.Fatalf(err.Error())
 	}
 
 	url := "gs://archive-measurement-lab/ndt/traceroute/2019/09/27/20190927T000540.410989Z-traceroute-mlab2-nuq07-ndt.tgz"
@@ -284,12 +308,31 @@ func TestParseJSONL(t *testing.T) {
 	}
 	pt.Flush()
 
-	if ptTest.UUID != "ndt-qtfh8_1565996043_0000000000003B64" {
-		t.Fatalf("UUID parsing error %s", ptTest.UUID)
+	if len(ins.data) != 1 {
+		fmt.Println(len(ins.data))
+		t.Fatalf("Number of rows in inserter is wrong.")
 	}
 
-	pretty.Print(ptTest.ServerX)
-	pretty.Print(ptTest.ClientX)
+	ptTest := ins.data[0].(*schema.PTTest)
+	if ptTest.Parseinfo.TaskFileName != url {
+		t.Fatalf("Wrong TaskFilenName; got %q, want %q", ptTest.Parseinfo.TaskFileName, url)
+	}
+
+	if ptTest.UUID != "ndt-qtfh8_1565996043_0000000000003B64" {
+		t.Fatalf("Wrong UUID; got %q, want %q", ptTest.UUID, "ndt-qtfh8_1565996043_0000000000003B64")
+	}
+
+	// Verify the client and server annotations match.
+	cx := v2.ConvertAnnotationsToClientAnnotations(m["91.169.126.135"])
+	if diff := deep.Equal(&ptTest.ClientX, cx); diff != nil {
+		t.Errorf("ClientX annotation does not match; %#v", diff)
+	}
+	sx := v2.ConvertAnnotationsToServerAnnotations(m["91.213.30.229"])
+	sx.Site = "nuq07"
+	sx.Machine = "mlab2"
+	if diff := deep.Equal(&ptTest.ServerX, sx); diff != nil {
+		t.Errorf("ServerX annotation does not match; %#v", diff)
+	}
 }
 
 func TestParse(t *testing.T) {
@@ -345,13 +388,43 @@ func TestParse(t *testing.T) {
 
 func TestAnnotateAndPutAsync(t *testing.T) {
 	ins := newInMemoryInserter()
-	m := map[string]*api.Annotations{}
+	m := map[string]*api.Annotations{
+		"172.17.94.34": &api.Annotations{
+			Geo: &api.GeolocationIP{
+				ContinentCode: "NA",
+				CountryCode:   "US",
+				Latitude:      1.0,
+				Longitude:     2.0,
+			},
+			Network: &api.ASData{
+				ASNumber: 1234,
+				Systems: []api.System{
+					{ASNs: []uint32{1234}},
+				},
+			},
+		},
+		"74.125.224.100": &api.Annotations{
+			Geo: &api.GeolocationIP{
+				ContinentCode: "EU",
+				CountryCode:   "DE",
+				Latitude:      3.0,
+				Longitude:     4.0,
+			},
+			Network: &api.ASData{
+				ASNumber: 4321,
+				Systems: []api.System{
+					{ASNs: []uint32{4321}},
+				},
+			},
+		},
+	}
 	pt := parser.NewPTParser(ins, newFakeAnnotator(m))
 	rawData, err := ioutil.ReadFile("testdata/PT/20170320T23:53:10Z-172.17.94.34-33456-74.125.224.100-33457.paris")
 	if err != nil {
 		t.Fatalf("cannot read testdata.")
 	}
-	meta := map[string]bigquery.Value{"filename": "gs://fake-bucket/fake-archive.tgz"}
+	url := "gs://archive-measurement-lab/ndt/traceroute/2017/03/20/20170320T000540.410989Z-paris-traceroute-mlab4-nuq07-ndt.tgz"
+	meta := map[string]bigquery.Value{"filename": url}
 	err = pt.ParseAndInsert(meta, "testdata/PT/20170320T23:53:10Z-172.17.94.34-33456-74.125.224.100-33457.paris", rawData)
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -362,13 +435,26 @@ func TestAnnotateAndPutAsync(t *testing.T) {
 		t.Fatalf("Number of rows in PT table is wrong.")
 	}
 	pt.AnnotateAndPutAsync("traceroute")
-	//pt.Inserter.Flush()
+
 	if len(ins.data) != 1 {
 		fmt.Println(len(ins.data))
 		t.Fatalf("Number of rows in inserter is wrong.")
 	}
-	if ins.data[0].(*schema.PTTest).Parseinfo.TaskFileName != "gs://fake-bucket/fake-archive.tgz" {
-		t.Fatalf("Task filename is wrong.")
+	ptTest := ins.data[0].(*schema.PTTest)
+	if ptTest.Parseinfo.TaskFileName != url {
+		t.Fatalf("Wrong TaskFilenName; got %q, want %q", ptTest.Parseinfo.TaskFileName, url)
+	}
+
+	// Verify the client and server annotations match.
+	cx := v2.ConvertAnnotationsToClientAnnotations(m["74.125.224.100"])
+	if diff := deep.Equal(&ptTest.ClientX, cx); diff != nil {
+		t.Errorf("ClientX annotation does not match; %#v", diff)
+	}
+	sx := v2.ConvertAnnotationsToServerAnnotations(m["172.17.94.34"])
+	sx.Site = "nuq07"
+	sx.Machine = "mlab4"
+	if diff := deep.Equal(&ptTest.ServerX, sx); diff != nil {
+		t.Errorf("ServerX annotation does not match; %#v", diff)
 	}
 }
 

--- a/parser/pt_test.go
+++ b/parser/pt_test.go
@@ -9,8 +9,12 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
+	"github.com/go-test/deep"
+	"github.com/m-lab/annotation-service/api"
+	v2 "github.com/m-lab/annotation-service/api/v2"
 	"github.com/m-lab/etl/parser"
 	"github.com/m-lab/etl/schema"
+	"github.com/m-lab/go/pretty"
 )
 
 func TestParsePT(t *testing.T) {
@@ -252,7 +256,12 @@ func TestParseLegacyFormatData(t *testing.T) {
 }
 
 func TestParseJSONL(t *testing.T) {
-	rawData, err := ioutil.ReadFile("testdata/PT/20190927T070859Z_ndt-qtfh8_1565996043_0000000000003B64.jsonl")
+	m := map[string]*api.Annotations{}
+	ins := newInMemoryInserter()
+	pt := parser.NewPTParser(ins, newFakeAnnotator(m))
+
+	filename := "testdata/PT/20190927T070859Z_ndt-qtfh8_1565996043_0000000000003B64.jsonl"
+	rawData, err := ioutil.ReadFile(filename)
 	if err != nil {
 		t.Fatalf(err.Error())
 		return
@@ -262,9 +271,25 @@ func TestParseJSONL(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 
+	url := "gs://archive-measurement-lab/ndt/traceroute/2019/09/27/20190927T000540.410989Z-traceroute-mlab2-nuq07-ndt.tgz"
+	meta := map[string]bigquery.Value{"filename": url}
+	err = pt.ParseAndInsert(meta, filename, rawData)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if pt.NumRowsForTest() != 1 {
+		fmt.Println(pt.NumRowsForTest())
+		t.Fatalf("The data is not inserted, in buffer now.")
+	}
+	pt.Flush()
+
 	if ptTest.UUID != "ndt-qtfh8_1565996043_0000000000003B64" {
 		t.Fatalf("UUID parsing error %s", ptTest.UUID)
 	}
+
+	pretty.Print(ptTest.ServerX)
+	pretty.Print(ptTest.ClientX)
 }
 
 func TestParse(t *testing.T) {
@@ -320,7 +345,8 @@ func TestParse(t *testing.T) {
 
 func TestAnnotateAndPutAsync(t *testing.T) {
 	ins := newInMemoryInserter()
-	pt := parser.NewPTParser(ins, &fakeAnnotator{})
+	m := map[string]*api.Annotations{}
+	pt := parser.NewPTParser(ins, newFakeAnnotator(m))
 	rawData, err := ioutil.ReadFile("testdata/PT/20170320T23:53:10Z-172.17.94.34-33456-74.125.224.100-33457.paris")
 	if err != nil {
 		t.Fatalf("cannot read testdata.")
@@ -347,13 +373,46 @@ func TestAnnotateAndPutAsync(t *testing.T) {
 }
 
 func TestParseAndInsert(t *testing.T) {
+
+	m := map[string]*api.Annotations{
+		"2.80.132.33": &api.Annotations{
+			Geo: &api.GeolocationIP{
+				ContinentCode: "NA",
+				CountryCode:   "US",
+				Latitude:      1.0,
+				Longitude:     2.0,
+			},
+			Network: &api.ASData{
+				ASNumber: 1234,
+				Systems: []api.System{
+					{ASNs: []uint32{1234}},
+				},
+			},
+		},
+		"91.239.96.102": &api.Annotations{
+			Geo: &api.GeolocationIP{
+				ContinentCode: "NA",
+				CountryCode:   "US",
+				Latitude:      1.0,
+				Longitude:     2.0,
+			},
+			Network: &api.ASData{
+				ASNumber: 1234,
+				Systems: []api.System{
+					{ASNs: []uint32{1234}},
+				},
+			},
+		},
+	}
+
 	ins := newInMemoryInserter()
-	pt := parser.NewPTParser(ins, &fakeAnnotator{})
+	pt := parser.NewPTParser(ins, newFakeAnnotator(m))
 	rawData, err := ioutil.ReadFile("testdata/PT/20130524T00:04:44Z_ALL5729.paris")
 	if err != nil {
 		t.Fatalf("cannot read testdata.")
 	}
-	meta := map[string]bigquery.Value{"filename": "gs://fake-bucket/fake-archive.tgz"}
+	url := "gs://archive-measurement-lab/paris-traceroute/2013/05/24/20130524T000000Z-mlab3-akl01-paris-traceroute-0000.tgz"
+	meta := map[string]bigquery.Value{"filename": url}
 	err = pt.ParseAndInsert(meta, "testdata/PT/20130524T00:04:44Z_ALL5729.paris", rawData)
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -369,12 +428,25 @@ func TestParseAndInsert(t *testing.T) {
 		fmt.Println(len(ins.data))
 		t.Fatalf("Number of rows in inserter is wrong.")
 	}
-	if ins.data[0].(*schema.PTTest).Parseinfo.TaskFileName != "gs://fake-bucket/fake-archive.tgz" {
+	if ins.data[0].(*schema.PTTest).Parseinfo.TaskFileName != url {
 		t.Fatalf("Task filename is wrong.")
 	}
 	// echo -n 2013-05-24T00:04:44Z-91.239.96.102-2.80.132.33 | openssl dgst -binary -md5 | base64  | tr '/+' '_-' | tr -d '='
 	if ins.data[0].(*schema.PTTest).UUID != "R9_wGx1-cSmqtSAt5aQtNg" {
 		t.Fatalf("UUID is wrong; got %q, want %q", ins.data[0].(*schema.PTTest).UUID, "R9_wGx1-cSmqtSAt5aQtNg")
+	}
+	p := ins.data[0].(*schema.PTTest)
+
+	// Verify the client and server annotations match.
+	cx := v2.ConvertAnnotationsToClientAnnotations(m["91.239.96.102"])
+	if diff := deep.Equal(&p.ClientX, cx); diff != nil {
+		t.Errorf("ClientX annotation does not match; %#v", diff)
+	}
+	sx := v2.ConvertAnnotationsToServerAnnotations(m["2.80.132.33"])
+	sx.Site = "akl01"
+	sx.Machine = "mlab3"
+	if diff := deep.Equal(&p.ServerX, sx); diff != nil {
+		t.Errorf("ServerX annotation does not match; %#v", diff)
 	}
 }
 

--- a/parser/ss.go
+++ b/parser/ss.go
@@ -294,6 +294,7 @@ func (ss *SSParser) ParseAndInsert(meta map[string]bigquery.Value, testName stri
 			ssTest.TaskFileName = meta["filename"].(string)
 		}
 
+		// ArchiveURL must already be valid, so error is safe to ignore.
 		dp, _ := etl.ValidateTestPath(ssTest.TaskFileName)
 		ssTest.Web100_log_entry.Connection_spec.ServerX.Site = dp.Site
 		ssTest.Web100_log_entry.Connection_spec.ServerX.Machine = dp.Host

--- a/parser/tcpinfo.go
+++ b/parser/tcpinfo.go
@@ -192,6 +192,7 @@ func (p *TCPInfoParser) ParseAndInsert(fileMetadata map[string]bigquery.Value, t
 			// TODO - should populate other ServerInfo fields from siteinfo API.
 		}
 	}
+	// ArchiveURL must already be valid, so error is safe to ignore.
 	dp, _ := etl.ValidateTestPath(fileMetadata["filename"].(string))
 	row.ServerX.Site = dp.Site
 	row.ServerX.Machine = dp.Host

--- a/parser/tcpinfo_test.go
+++ b/parser/tcpinfo_test.go
@@ -233,9 +233,6 @@ func TestTCPParser(t *testing.T) {
 	}
 	marshalTime := time.Since(startMarshal)
 
-	//pretty.Print(largestRow.ServerX)
-	//pretty.Print(largestRow.Client)
-
 	duration := largestRow.FinalSnapshot.Timestamp.Sub(largestRow.Snapshots[0].Timestamp)
 	t.Log("Largest json is", len(largestJson), "bytes in", len(largestRow.Snapshots), "snapshots, over", duration, "with", len(largestJson)/len(largestRow.Snapshots), "json bytes/snap")
 	t.Log("Total of", totalSnaps, "snapshots decoded and marshalled")


### PR DESCRIPTION
This change completes the unit tests omitted from https://github.com/m-lab/etl/pull/1004

This change moves the `fakeAnnotator` type from the tcpinfo_test.go file to the common parser_test.go for use by multiple parsers.

This change adds ServerX and ClientX value tests to the tcpinfo parser.
This change adds ServerX and ClientX value tests to the pt parser for .paris and .jsonl file types.

Because correct annotations require well formatted archive URLs, additional changes ensure that valid URLs are provided to unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1007)
<!-- Reviewable:end -->
