### PR TITLE
Add schema for pcap index

### DIFF
--- a/cmd/generate_schema_docs/main.go
+++ b/cmd/generate_schema_docs/main.go
@@ -155,6 +155,7 @@ func main() {
 		&schema.NDT7ResultRow{},
 		&schema.TCPRow{},
 		&schema.PTTest{},
+		&schema.PCAPRow{},
 		// TODO(https://github.com/m-lab/etl/issues/745): Add additional types once
 		// "standard columns" are resolved.
 	}

--- a/cmd/generate_schema_docs/main_test.go
+++ b/cmd/generate_schema_docs/main_test.go
@@ -39,4 +39,9 @@ func Test_main(t *testing.T) {
 	if err != nil {
 		t.Errorf("main() missing output file; missing schema_ndt5resultrow.md")
 	}
+
+	_, err = os.Stat(path.Join(tmpdir, "schema_pcaprow.md"))
+	if err != nil {
+		t.Errorf("main() missing output file; missing schema_pcaprow.md")
+	}
 }

--- a/cmd/update-schema/update.go
+++ b/cmd/update-schema/update.go
@@ -233,6 +233,14 @@ func updateStandardTables(project string) int {
 	if err := CreateOrUpdateAnnotationRow(project, "raw_ndt", "annotation"); err != nil {
 		errCount++
 	}
+
+	if err := CreateOrUpdatePCAPRow(project, "tmp_ndt", "pcap"); err != nil {
+		errCount++
+	}
+	if err := CreateOrUpdatePCAPRow(project, "raw_ndt", "pcap"); err != nil {
+		errCount++
+	}
+
 	return errCount
 }
 

--- a/cmd/update-schema/update.go
+++ b/cmd/update-schema/update.go
@@ -107,6 +107,13 @@ func CreateOrUpdateSwitchStats(project string, dataset string, table string) err
 	return CreateOrUpdate(schema, project, dataset, table, "")
 }
 
+func CreateOrUpdatePCAPRow(project string, dataset string, table string) error {
+	row := schema.PCAPRow{}
+	schema, err := row.Schema()
+	rtx.Must(err, "PCAPRow.Schema")
+	return CreateOrUpdate(schema, project, dataset, table, "Date")
+}
+
 // listTemplateTables finds all template tables for the given project, datatype, and base table name.
 // Because this function must enumerate all tables in the dataset to find matching names, it may be slow.
 func listTemplateTables(project, dataset, table string) ([]string, error) {
@@ -364,6 +371,14 @@ func main() {
 			errCount++
 		}
 		if err := CreateOrUpdateSwitchStats(*project, "batch", "switch"); err != nil {
+			errCount++
+		}
+
+	case "pcap":
+		if err := CreateOrUpdatePCAPRow(*project, "tmp_ndt", "pcap"); err != nil {
+			errCount++
+		}
+		if err := CreateOrUpdatePCAPRow(*project, "raw_ndt", "pcap"); err != nil {
 			errCount++
 		}
 

--- a/schema/descriptions/PCAPRow.yaml
+++ b/schema/descriptions/PCAPRow.yaml
@@ -1,6 +1,1 @@
-ID:
-  Description: UUID of the connection under consideration.
-Parser:
-  Description: Metadata about how the parser processed the measurement.
-Date:
-  Description: Date column is necessary for BigQuery's column-based partitioning.
+

--- a/schema/descriptions/PCAPRow.yaml
+++ b/schema/descriptions/PCAPRow.yaml
@@ -1,0 +1,6 @@
+ID:
+  Description: UUID of the connection under consideration.
+Parser:
+  Description: Metadata about how the parser processed the measurement.
+Date:
+  Description: Date column is necessary for BigQuery's column-based partitioning.

--- a/schema/descriptions/toplevel.yaml
+++ b/schema/descriptions/toplevel.yaml
@@ -9,7 +9,7 @@ ParseInfo.ParserVersion:
   Description: Version of the parser that processed this row.
 
 id:
-  Description: UUID of the connection under consideration
+  Description: UUID of the connection under consideration.
 test_id:
   Description: Original filename of measurement as written to disk and in the
     GCS archive.

--- a/schema/descriptions/toplevel.yaml
+++ b/schema/descriptions/toplevel.yaml
@@ -7,6 +7,9 @@ ParseInfo.ParseTime:
   Description: Time that the parser processed this row.
 ParseInfo.ParserVersion:
   Description: Version of the parser that processed this row.
+
+id:
+  Description: UUID of the connection under consideration
 test_id:
   Description: Original filename of measurement as written to disk and in the
     GCS archive.

--- a/schema/pcap.go
+++ b/schema/pcap.go
@@ -1,0 +1,27 @@
+package schema
+
+import (
+	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/civil"
+	"github.com/m-lab/go/cloud/bqx"
+)
+
+type PCAPRow struct {
+	ID     string     `bigquery:"id"`
+	Parser ParseInfo  `bigquery:"parser"`
+	Date   civil.Date `bigquery:"date"`
+}
+
+// Schema returns the Bigquery schema for Pcap
+func (row *PCAPRow) Schema() (bigquery.Schema, error) {
+	sch, err := bigquery.InferSchema(row)
+	if err != nil {
+		return bigquery.Schema{}, err
+	}
+	docs := FindSchemaDocsFor(row)
+	for _, doc := range docs {
+		bqx.UpdateSchemaDescription(sch, doc)
+	}
+	rr := bqx.RemoveRequired(sch)
+	return rr, nil
+}

--- a/schema/pcap.go
+++ b/schema/pcap.go
@@ -6,14 +6,14 @@ import (
 	"github.com/m-lab/go/cloud/bqx"
 )
 
-// PCAPRow describes a single BQ row of pcap (packet capture) data
+// PCAPRow describes a single BQ row of pcap (packet capture) data.
 type PCAPRow struct {
 	ID     string     `bigquery:"id"`
 	Parser ParseInfo  `bigquery:"parser"`
 	Date   civil.Date `bigquery:"date"`
 }
 
-// Schema returns the Bigquery schema for Pcap
+// Schema returns the Bigquery schema for Pcap.
 func (row *PCAPRow) Schema() (bigquery.Schema, error) {
 	sch, err := bigquery.InferSchema(row)
 	if err != nil {

--- a/schema/pcap.go
+++ b/schema/pcap.go
@@ -6,6 +6,7 @@ import (
 	"github.com/m-lab/go/cloud/bqx"
 )
 
+// PCAPRow describes a single BQ row of pcap (packet capture) data
 type PCAPRow struct {
 	ID     string     `bigquery:"id"`
 	Parser ParseInfo  `bigquery:"parser"`

--- a/schema/pcap_test.go
+++ b/schema/pcap_test.go
@@ -1,0 +1,33 @@
+package schema
+
+import (
+	"testing"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/m-lab/go/cloud/bqx"
+)
+
+func TestPCAPRow_Schema(t *testing.T) {
+	row := &PCAPRow{}
+	got, err := row.Schema()
+	if err != nil {
+		t.Errorf("PCAPRow.Schema() error %v, expected nil", err)
+		return
+	}
+	count := 0
+	bqx.WalkSchema(got, func(prefix []string, field *bigquery.FieldSchema) error {
+		for _, name := range []string{"id", "parser", "date"} {
+			if field.Name == name {
+				if field.Description == "" {
+					t.Errorf("PCAPRow.Schema() missing field.Description for %q", field.Name)
+				} else {
+					count++
+				}
+			}
+		}
+		return nil
+	})
+	if count != 3 {
+		t.Errorf("PCAPRow.Schema() missing expected fields: got %d, want 3", count)
+	}
+}


### PR DESCRIPTION
- Added new pcap datatype definition to [m-lab/etl/schema](https://github.com/m-lab/etl/tree/master/schema)
- Added pcap table creation to [update-schema](https://github.com/m-lab/etl/tree/master/cmd/update-schema)
- Added descriptions for PCAPRow schema

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1009)
<!-- Reviewable:end -->
