### PR TITLE
Increase number of parser replicas to 6

### DIFF
--- a/k8s/data-processing/deployments/parser.yml
+++ b/k8s/data-processing/deployments/parser.yml
@@ -4,7 +4,7 @@ metadata:
   name: etl-parser
   namespace: default
 spec:
-  replicas: 2
+  replicas: 6
   selector:
     matchLabels:
       # Used to match pre-existing pods that may be affected during updates.


### PR DESCRIPTION
Increased the number of parser instances to better handle the amount of data introduced by the PCAP datatype

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1013)
<!-- Reviewable:end -->
