### PR TITLE
Update pcap parser processing rate to 1 in 10 archives

### DIFF
--- a/active/active.go
+++ b/active/active.go
@@ -177,7 +177,7 @@ func (src *GCSSource) streamToPending(ctx context.Context, job tracker.Job) {
 	}
 
 	index := 0
-	dataType := etl.NameToDataType(job.Datatype)
+	dataType := etl.DataType(job.Datatype)
 	skipCount := dataType.SkipCount()
 
 	for _, f := range files {

--- a/active/active_test.go
+++ b/active/active_test.go
@@ -109,7 +109,7 @@ func standardLister() active.FileLister {
 
 func skipFilesListener(dataType string) active.FileLister {
 	client := gcsfake.GCSClient{}
-	bucket := "ndt/" + dataType + "/2019/01/01/"
+	bucket := path.Join("ndt/", dataType, "/2019/01/01/")
 	client.AddTestBucket("foobar",
 		&gcsfake.BucketHandle{
 			ObjAttrs: []*storage.ObjectAttrs{

--- a/active/active_test.go
+++ b/active/active_test.go
@@ -109,26 +109,26 @@ func standardLister() active.FileLister {
 
 func skipFilesListener(dataType string) active.FileLister {
 	client := gcsfake.GCSClient{}
-	bucket := path.Join("ndt/", dataType, "/2019/01/01/")
+	prefix := path.Join("ndt/", dataType, "/2019/01/01/")
 	client.AddTestBucket("foobar",
 		&gcsfake.BucketHandle{
 			ObjAttrs: []*storage.ObjectAttrs{
-				{Bucket: "foobar", Name: path.Join(bucket, "obj1"), Updated: time.Now()},
-				{Bucket: "foobar", Name: path.Join(bucket, "obj2"), Updated: time.Now()},
-				{Bucket: "foobar", Name: path.Join(bucket, "obj3"), Updated: time.Now()},
-				{Bucket: "foobar", Name: path.Join(bucket, "obj4"), Updated: time.Now()},
-				{Bucket: "foobar", Name: path.Join(bucket, "obj5"), Updated: time.Now()},
-				{Bucket: "foobar", Name: path.Join(bucket, "obj6"), Updated: time.Now()},
-				{Bucket: "foobar", Name: path.Join(bucket, "obj7"), Updated: time.Now()},
-				{Bucket: "foobar", Name: path.Join(bucket, "obj8"), Updated: time.Now()},
-				{Bucket: "foobar", Name: path.Join(bucket, "obj9"), Updated: time.Now()},
-				{Bucket: "foobar", Name: path.Join(bucket, "obj10"), Updated: time.Now()},
-				{Bucket: "foobar", Name: path.Join(bucket, "obj11"), Updated: time.Now()},
+				{Bucket: "foobar", Name: path.Join(prefix, "obj1"), Updated: time.Now()},
+				{Bucket: "foobar", Name: path.Join(prefix, "obj2"), Updated: time.Now()},
+				{Bucket: "foobar", Name: path.Join(prefix, "obj3"), Updated: time.Now()},
+				{Bucket: "foobar", Name: path.Join(prefix, "obj4"), Updated: time.Now()},
+				{Bucket: "foobar", Name: path.Join(prefix, "obj5"), Updated: time.Now()},
+				{Bucket: "foobar", Name: path.Join(prefix, "obj6"), Updated: time.Now()},
+				{Bucket: "foobar", Name: path.Join(prefix, "obj7"), Updated: time.Now()},
+				{Bucket: "foobar", Name: path.Join(prefix, "obj8"), Updated: time.Now()},
+				{Bucket: "foobar", Name: path.Join(prefix, "obj9"), Updated: time.Now()},
+				{Bucket: "foobar", Name: path.Join(prefix, "obj10"), Updated: time.Now()},
+				{Bucket: "foobar", Name: path.Join(prefix, "obj11"), Updated: time.Now()},
 			}})
 
 	bh, err := gcs.GetBucket(context.Background(), &client, "foobar")
 	rtx.Must(err, "GetBucket failed")
-	return active.FileListerFunc(bh, bucket, nil)
+	return active.FileListerFunc(bh, prefix, nil)
 
 }
 

--- a/active/active_test.go
+++ b/active/active_test.go
@@ -15,12 +15,17 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/iterator"
 
+	"github.com/m-lab/etl-gardener/tracker"
 	"github.com/m-lab/etl/active"
 	"github.com/m-lab/go/cloud/gcs"
 	"github.com/m-lab/go/logx"
 	"github.com/m-lab/go/rtx"
 
 	"github.com/m-lab/go/cloudtest/gcsfake"
+)
+
+var (
+	job = tracker.Job{}
 )
 
 func init() {
@@ -95,8 +100,28 @@ func testClient() stiface.Client {
 	return &client
 }
 
-func standardLister() active.FileLister {
-	bh, err := gcs.GetBucket(context.Background(), testClient(), "foobar")
+func testClientSkipFiles() stiface.Client {
+	client := gcsfake.GCSClient{}
+	client.AddTestBucket("foobar",
+		&gcsfake.BucketHandle{
+			ObjAttrs: []*storage.ObjectAttrs{
+				{Bucket: "foobar", Name: "ndt/ndt5/2019/01/01/obj1", Updated: time.Now()},
+				{Bucket: "foobar", Name: "ndt/ndt5/2019/01/01/obj2", Updated: time.Now()},
+				{Bucket: "foobar", Name: "ndt/ndt5/2019/01/01/obj3", Updated: time.Now()},
+				{Bucket: "foobar", Name: "ndt/ndt5/2019/01/01/obj4", Updated: time.Now()},
+				{Bucket: "foobar", Name: "ndt/ndt5/2019/01/01/obj5", Updated: time.Now()},
+				{Bucket: "foobar", Name: "ndt/ndt5/2019/01/01/obj6", Updated: time.Now()},
+				{Bucket: "foobar", Name: "ndt/ndt5/2019/01/01/obj7", Updated: time.Now()},
+				{Bucket: "foobar", Name: "ndt/ndt5/2019/01/01/obj8", Updated: time.Now()},
+				{Bucket: "foobar", Name: "ndt/ndt5/2019/01/01/obj9", Updated: time.Now()},
+				{Bucket: "foobar", Name: "ndt/ndt5/2019/01/01/obj10", Updated: time.Now()},
+				{Bucket: "foobar", Name: "ndt/ndt5/2019/01/01/obj11", Updated: time.Now()},
+			}})
+	return &client
+}
+
+func standardLister(client func() stiface.Client) active.FileLister {
+	bh, err := gcs.GetBucket(context.Background(), client(), "foobar")
 	rtx.Must(err, "GetBucket failed")
 	return active.FileListerFunc(bh, "ndt/ndt5/2019/01/01/", nil)
 }
@@ -123,7 +148,7 @@ func runAll(ctx context.Context, rSrc active.RunnableSource) (*errgroup.Group, e
 func TestGCSSourceBasic(t *testing.T) {
 	p := newCounter(t)
 	ctx := context.Background()
-	fs, err := active.NewGCSSource(ctx, "test", standardLister(), p.toRunnable)
+	fs, err := active.NewGCSSource(ctx, job, standardLister(testClient), p.toRunnable)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,7 +174,7 @@ func TestWithRunFailures(t *testing.T) {
 	p.addOutcome(os.ErrInvalid)
 
 	ctx := context.Background()
-	fs, err := active.NewGCSSource(ctx, "test", standardLister(), p.toRunnable)
+	fs, err := active.NewGCSSource(ctx, job, standardLister(testClient), p.toRunnable)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -174,7 +199,7 @@ func TestWithRunFailures(t *testing.T) {
 func TestExpiredContext(t *testing.T) {
 	p := newCounter(t)
 	ctx := context.Background()
-	fs, err := active.NewGCSSource(ctx, "test", standardLister(), p.toRunnable)
+	fs, err := active.NewGCSSource(ctx, job, standardLister(testClient), p.toRunnable)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -199,7 +224,7 @@ func TestWithStorageError(t *testing.T) {
 	p := newCounter(t)
 
 	ctx := context.Background()
-	fs, err := active.NewGCSSource(ctx, "test", ErroringLister, p.toRunnable)
+	fs, err := active.NewGCSSource(ctx, job, ErroringLister, p.toRunnable)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -214,7 +239,7 @@ func TestExpiredFileListerContext(t *testing.T) {
 	p := newCounter(t)
 
 	ctx := context.Background()
-	fs, err := active.NewGCSSource(ctx, "test", standardLister(), p.toRunnable)
+	fs, err := active.NewGCSSource(ctx, job, standardLister(testClient), p.toRunnable)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -235,5 +260,57 @@ func TestExpiredFileListerContext(t *testing.T) {
 	}
 	if err != context.Canceled {
 		t.Error("Should return os.ErrInvalid", err)
+	}
+}
+
+func TestSkipFiles(t *testing.T) {
+	tests := []struct {
+		name         string
+		successCount int
+		failureCount int
+	}{
+		{
+			name:         "pcap",
+			successCount: 2,
+			failureCount: 0,
+		},
+		{
+			name:         "ndt7",
+			successCount: 11,
+			failureCount: 0,
+		},
+		{
+			name:         "foo",
+			successCount: 11,
+			failureCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newCounter(t)
+			ctx := context.Background()
+			fs, err := active.NewGCSSource(ctx, tracker.Job{Datatype: tt.name}, standardLister(testClientSkipFiles), p.toRunnable)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			eg, err := runAll(ctx, fs)
+			if err != iterator.Done {
+				t.Fatal(err)
+			}
+			err = eg.Wait()
+			if err != nil {
+				t.Error(err)
+			}
+
+			if p.success != tt.successCount {
+				t.Errorf("for %s, %d should have succeeded, got %d", tt.name, tt.successCount, p.success)
+			}
+
+			if p.fail != tt.failureCount {
+				t.Errorf("for %s, %d should have failed, got %d", tt.name, tt.failureCount, p.fail)
+			}
+		})
 	}
 }

--- a/active/poller.go
+++ b/active/poller.go
@@ -154,7 +154,7 @@ func (g *GardenerAPI) JobFileSource(ctx context.Context, job tracker.Job,
 		return nil, err
 	}
 	lister := FileListerFunc(bh, prefix, filter)
-	gcsSource, err := NewGCSSource(ctx, job.Path(), lister, toRunnable)
+	gcsSource, err := NewGCSSource(ctx, job, lister, toRunnable)
 	if err != nil {
 		failMetric(job, "GCSSource")
 		return nil, err

--- a/etl/globals.go
+++ b/etl/globals.go
@@ -323,16 +323,7 @@ var (
 	// It allows us process fewer archives when there is a very high volume of data.
 	// TODO - this should be loaded from a config.
 	dataTypeToSkipCount = map[DataType]int{
-		ANNOTATION: 0,
-		NDT:        0,
-		SS:         0,
-		PCAP:       9,
-		PT:         0,
-		SW:         0,
-		TCPINFO:    0,
-		NDT5:       0,
-		NDT7:       0,
-		INVALID:    0,
+		PCAP: 9,
 	}
 )
 
@@ -347,22 +338,9 @@ func DirToTablename(dir string) string {
 	return dataTypeToTable[dirToDataType[dir]]
 }
 
-// NameToDataType returns the DataType corresponding to the type name.
-func NameToDataType(name string) DataType {
-	dataType, ok := dirToDataType[name]
-	if !ok {
-		return INVALID
-	}
-	return dataType
-}
-
 // SkipCount returns the number of files to skip when processing each DataType.
 func (dt DataType) SkipCount() int {
-	count, ok := dataTypeToSkipCount[dt]
-	if !ok {
-		return 0
-	}
-	return count
+	return dataTypeToSkipCount[dt]
 }
 
 // BigqueryProject returns the appropriate project.

--- a/etl/globals.go
+++ b/etl/globals.go
@@ -318,6 +318,22 @@ var (
 	}
 	// There is also a mapping of data types to queue names in
 	// queue_pusher.go
+
+	// Map from data type to number of files to skip when processing said type.
+	// It allows us process fewer archives when there is a very high volume of data.
+	// TODO - this should be loaded from a config.
+	dataTypeToSkipCount = map[DataType]int{
+		ANNOTATION: 0,
+		NDT:        0,
+		SS:         0,
+		PCAP:       9,
+		PT:         0,
+		SW:         0,
+		TCPINFO:    0,
+		NDT5:       0,
+		NDT7:       0,
+		INVALID:    0,
+	}
 )
 
 /*******************************************************************************
@@ -329,6 +345,24 @@ var (
 // DirToTablename translates gs dir to BQ tablename.
 func DirToTablename(dir string) string {
 	return dataTypeToTable[dirToDataType[dir]]
+}
+
+// NameToDataType returns the DataType corresponding to the type name.
+func NameToDataType(name string) DataType {
+	dataType, ok := dirToDataType[name]
+	if !ok {
+		return INVALID
+	}
+	return dataType
+}
+
+// SkipCount returns the number of files to skip when processing each DataType.
+func (dt DataType) SkipCount() int {
+	count, ok := dataTypeToSkipCount[dt]
+	if !ok {
+		return 0
+	}
+	return count
 }
 
 // BigqueryProject returns the appropriate project.

--- a/etl/globals_test.go
+++ b/etl/globals_test.go
@@ -369,36 +369,6 @@ func TestDirToTablename(t *testing.T) {
 	}
 }
 
-func TestNameToDataType(t *testing.T) {
-	tests := []struct {
-		name string
-		want etl.DataType
-	}{
-
-		{
-			name: "ndt7",
-			want: etl.NDT7,
-		},
-		{
-			name: "invalid",
-			want: etl.INVALID,
-		},
-		{
-			name: "foo",
-			want: etl.INVALID,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := etl.NameToDataType(tt.name)
-			if got != tt.want {
-				t.Errorf("NameToDataType() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestSkipCount(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/etl/globals_test.go
+++ b/etl/globals_test.go
@@ -368,3 +368,66 @@ func TestDirToTablename(t *testing.T) {
 		t.Errorf("DirToTablename() failed to translate PT dir name correctly.")
 	}
 }
+
+func TestNameToDataType(t *testing.T) {
+	tests := []struct {
+		name string
+		want etl.DataType
+	}{
+
+		{
+			name: "ndt7",
+			want: etl.NDT7,
+		},
+		{
+			name: "invalid",
+			want: etl.INVALID,
+		},
+		{
+			name: "foo",
+			want: etl.INVALID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := etl.NameToDataType(tt.name)
+			if got != tt.want {
+				t.Errorf("NameToDataType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSkipCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		dataType etl.DataType
+		want     int
+	}{
+		{
+			name:     "ndt7",
+			dataType: etl.NDT7,
+			want:     0,
+		},
+		{
+			name:     "pcap",
+			dataType: etl.PCAP,
+			want:     9,
+		},
+		{
+			name:     "invalid",
+			dataType: etl.INVALID,
+			want:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.dataType.SkipCount()
+			if got != tt.want {
+				t.Errorf("SkipCount() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Update pcap parser to process fewer archives (i.e., 1 in 10)

A similar concept exists in the legacy pipeline with the TASK_FILE_SKIP setting (e.g., https://github.com/m-lab/etl-gardener/blob/master/k8s/data-processing-cluster/deployments/etl-gardener-ndt.yml#L52)


Testing comparing the processing the logs to the archive entries

Log
https://pantheon.corp.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22mlab-sandbox%22%0Aresource.labels.location%3D%22us-east1%22%0Aresource.labels.cluster_name%3D%22data-processing%22%0Aresource.labels.namespace_name%3D%22default%22%0Alabels.k8s-pod%2Frun%3D%22etl-parser%22%20severity%3E%3DDEFAULT;timeRange=2021-08-12T17:13:17.000Z%2F2021-08-12T17:13:18.000Z;cursorTimestamp=2021-08-12T17:13:17.602104577Z?project=mlab-sandbox
![Screenshot 2021-08-12 1 46 21 PM](https://user-images.githubusercontent.com/21001496/129247315-a5148cd0-1fc8-474e-a0fb-3413a7fd0ab0.png)

Archive
https://pantheon.corp.google.com/storage/browser/archive-measurement-lab/ndt/pcap/2021/07/29?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&project=measurement-lab&prefix=&forceOnObjectsSortingFiltering=false
![Screenshot 2021-08-12 2 07 20 PM](https://user-images.githubusercontent.com/21001496/129247332-9067c8dd-85da-4b43-a015-c9381fd3c986.png)



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1014)
<!-- Reviewable:end -->
