### PR TITLE
add missing filename to ParseInfo for tcpinfo

### DIFF
--- a/parser/tcpinfo.go
+++ b/parser/tcpinfo.go
@@ -183,6 +183,7 @@ func (p *TCPInfoParser) ParseAndInsert(fileMetadata map[string]bigquery.Value, t
 	row.TestTime = testMetadata.StartTime
 
 	row.ParseInfo = &schema.ParseInfoV0{ParseTime: time.Now(), ParserVersion: Version()}
+	row.ParseInfo.Filename = testName
 
 	if fileMetadata["filename"] != nil {
 		fn, ok := fileMetadata["filename"].(string)

--- a/parser/tcpinfo_test.go
+++ b/parser/tcpinfo_test.go
@@ -145,12 +145,12 @@ func (nc nullCloser) Close() error { return nil }
 func TestTCPParser(t *testing.T) {
 	parserVersion := parser.InitParserVersionForTest()
 
-	filename := "testdata/20190516T013026.744845Z-tcpinfo-mlab4-arn02-ndt.tgz"
-	url := "gs://fake-archive/ndt/tcpinfo/2019/05/16/" + filepath.Base(filename)
+	taskfilename := "testdata/20190516T013026.744845Z-tcpinfo-mlab4-arn02-ndt.tgz"
+	url := "gs://fake-archive/ndt/tcpinfo/2019/05/16/" + filepath.Base(taskfilename)
 
-	src, err := fileSource(filename)
+	src, err := fileSource(taskfilename)
 	if err != nil {
-		t.Fatal("Failed reading testdata from", filename)
+		t.Fatal("Failed reading testdata from", taskfilename)
 	}
 
 	// Inject fake inserter and annotator
@@ -190,7 +190,11 @@ func TestTCPParser(t *testing.T) {
 			t.Error("Should have inserted parse_time")
 		}
 		if row.ParseInfo.TaskFileName != url {
-			t.Error("Should have correct filename", filename, "!=", row.ParseInfo.TaskFileName)
+			t.Error("Should have correct taskfilename", taskfilename, "!=", row.ParseInfo.TaskFileName)
+		}
+
+		if !strings.Contains(row.ParseInfo.Filename, row.UUID) {
+			t.Errorf("Should have non empty filename containing UUID: %s not found in :%s:\n", row.UUID, row.ParseInfo.Filename)
 		}
 
 		if row.ParseInfo.ParserVersion != parserVersion {


### PR DESCRIPTION
Somehow missed this field for all this time.
Adds a unit test and code to populate the field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1017)
<!-- Reviewable:end -->
