### PR TITLE
Decrease number of parser replicas to 4

### DIFF
--- a/k8s/data-processing/deployments/parser.yml
+++ b/k8s/data-processing/deployments/parser.yml
@@ -4,7 +4,7 @@ metadata:
   name: etl-parser
   namespace: default
 spec:
-  replicas: 6
+  replicas: 4
   selector:
     matchLabels:
       # Used to match pre-existing pods that may be affected during updates.


### PR DESCRIPTION
Since the PCAP processing rate has been reduced to 10%, we should also decrease the number of parsers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1018)
<!-- Reviewable:end -->
