### PR TITLE
Remove go-kit/kit from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	cloud.google.com/go/storage v1.14.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/fsouza/fake-gcs-server v1.23.1
-	github.com/go-kit/kit v0.10.0 // indirect
 	github.com/go-test/deep v1.0.7
 	github.com/google/go-jsonnet v0.17.0
 	github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8


### PR DESCRIPTION
When PR #1020 was merged, the following dependabot alert was raised:
![Screenshot 2021-10-01 4 49 46 PM](https://user-images.githubusercontent.com/21001496/135684650-32f9dcf3-b8dd-42b4-bb03-196e037bb5c0.png)

Following the module dependency graph, it's possible to trace the websocket module to go-kit/kit:
``go mod graph | grep websocket``
``go.etcd.io/etcd@v0.0.0-20191023171146-3cf2f69b5738 github.com/gorilla/websocket@v0.0.0-20170926233335-4201258b820c``
``go mod graph | grep go.etcd.io/etcd@v0.0.0-20191023171146-3cf2f69b5738``
``github.com/go-kit/kit@v0.10.0 go.etcd.io/etcd@v0.0.0-20191023171146-3cf2f69b5738``
``go mod graph | grep go-kit/kit@v0.10.0``
``github.com/m-lab/etl github.com/go-kit/kit@v0.10.0``

go-kit/kit was [added](https://github.com/m-lab/etl/pull/1020/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6) to the go.mod file when traceroute-caller was imported into ETL.
This can be verified by checking out an earlier version of ETL (before #1020 was merged) and running the command `go get github.com/m-lab/traceroute-caller`

On further inspection, it doesn't appear that go-kit/kit is directly required by ETL, so it can be removed from go.mod (even VS Code suggests to remove it, and it already appears in go.sum).
``cristinaleon@cristinaleon:~/go/src/github.com/m-lab/etl$ go mod why github.com/go-kit/kit``
``go: downloading github.com/go-kit/kit v0.10.0``
``# github.com/go-kit/kit``
``(main module does not need package github.com/go-kit/kit)``

The result is that websocket can no longer be traced back to go-kit/kit.
``cristinaleon@cristinaleon:~/go/src/github.com/m-lab/etl$ go mod graph | grep websocket``
``cristinaleon@cristinaleon:~/go/src/github.com/m-lab/etl$``






