### PR TITLE
Remove hopannotation1 schema stub

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -296,7 +296,9 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/oschwald/geoip2-golang v1.5.0 h1:igg2yQIrrcRccB1ytFXqBfOHCjXWIoMv85lVJ1ONZzw=
 github.com/oschwald/geoip2-golang v1.5.0/go.mod h1:xdvYt5xQzB8ORWFqPnqMwZpCpgNagttWdoZLlJQzg7s=
+github.com/oschwald/maxminddb-golang v1.8.0 h1:Uh/DSnGoxsyp/KYbY1AuP0tYEwfs0sCph9p/UMXK/Hk=
 github.com/oschwald/maxminddb-golang v1.8.0/go.mod h1:RXZtst0N6+FY/3qCNmZMBApR19cdQj43/NM9VkrNAis=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/parser/hopannotation1.go
+++ b/parser/hopannotation1.go
@@ -12,6 +12,7 @@ import (
 	"github.com/m-lab/etl/metrics"
 	"github.com/m-lab/etl/row"
 	"github.com/m-lab/etl/schema"
+	"github.com/m-lab/traceroute-caller/hopannotation"
 )
 
 //=====================================================================================
@@ -62,7 +63,7 @@ func (p *HopAnnotation1Parser) ParseAndInsert(fileMetadata map[string]bigquery.V
 		},
 	}
 
-	raw := schema.HopAnnotation1{}
+	raw := hopannotation.HopAnnotation1{}
 	err := json.Unmarshal(rawContent, &raw)
 	if err != nil {
 		metrics.TestCount.WithLabelValues(p.TableName(), "hopannotation1", "decode-location-error").Inc()

--- a/parser/hopannotation1_test.go
+++ b/parser/hopannotation1_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/m-lab/etl/parser"
 	"github.com/m-lab/etl/schema"
 	"github.com/m-lab/go/rtx"
+	"github.com/m-lab/traceroute-caller/hopannotation"
 	"github.com/m-lab/uuid-annotator/annotator"
 )
 
@@ -82,7 +83,7 @@ func TestHopAnnotation1Parser_ParseAndInsert(t *testing.T) {
 		Network: &expectedNetwork,
 	}
 
-	expectedRaw := schema.HopAnnotation1{
+	expectedRaw := hopannotation.HopAnnotation1{
 		ID:          "20210818_1e0b318cf3c2_91.189.88.152",
 		Timestamp:   time.Date(2021, 8, 18, 17, 44, 32, 0, time.UTC),
 		Annotations: &expectedAnnotations,

--- a/schema/hopannotation1.go
+++ b/schema/hopannotation1.go
@@ -1,29 +1,19 @@
 package schema
 
 import (
-	"time"
-
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/civil"
 	"github.com/m-lab/etl/row"
 	"github.com/m-lab/go/cloud/bqx"
-	"github.com/m-lab/uuid-annotator/annotator"
+	"github.com/m-lab/traceroute-caller/hopannotation"
 )
-
-// Schema stub for HopAnnotation1.
-// TODO(cristinaleon): Remove this definition when traceroute-caller is available.
-type HopAnnotation1 struct {
-	ID          string
-	Timestamp   time.Time
-	Annotations *annotator.ClientAnnotations
-}
 
 // HopAnnotation1Row describes a single BQ row of HopAnnotation1 data.
 type HopAnnotation1Row struct {
-	ID     string          `bigquery:"id"`
-	Parser ParseInfo       `bigquery:"parser"`
-	Date   civil.Date      `bigquery:"date"`
-	Raw    *HopAnnotation1 `json:",omitempty" bigquery:"raw"`
+	ID     string                        `bigquery:"id"`
+	Parser ParseInfo                     `bigquery:"parser"`
+	Date   civil.Date                    `bigquery:"date"`
+	Raw    *hopannotation.HopAnnotation1 `json:",omitempty" bigquery:"raw"`
 
 	// NOT part of struct schema. Included only to provide a fake annotator interface.
 	row.NullAnnotator `bigquery:"-"`


### PR DESCRIPTION
Remove hopannotation1 schema stub since it's now available in [traceroute-caller ](https://github.com/m-lab/traceroute-caller/blob/d84ea3d2eb8e2a08bb20439b3f8aead2fb0c8cc8/hopannotation/hopannotation.go#L78)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1024)
<!-- Reviewable:end -->
