### PR TITLE
Tweak local mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ pipeline. The ETL worker is responsible for parsing data archives produced by
 
 ```sh
 go get ./cmd/etl_worker
+gcloud auth application-default login
 ~/bin/etl_worker -service_port :8080 -output_dir ./output -output local
 ```
 

--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -1,4 +1,3 @@
-// Sample
 package main
 
 import (
@@ -187,6 +186,7 @@ func handleLocalRequest(rw http.ResponseWriter, req *http.Request) {
 	ctx := context.Background()
 	obj, err := c.Bucket(dp.Bucket).Object(dp.Path).Attrs(ctx)
 	if err != nil {
+		log.Println(err)
 		rw.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintf(rw, "failed to get object attrs for %s / %s", dp.Bucket, dp.Path)
 		return
@@ -407,6 +407,9 @@ func main() {
 
 	flag.Parse()
 	rtx.Must(flagx.ArgsFromEnv(flag.CommandLine), "Could not get args from env")
+	if outputType.Value == "local" {
+		log.Println("To resolve oauth problems, run 'gcloud auth application-default login'")
+	}
 
 	go site.MustReload(mainCtx)
 

--- a/storage/localwriter.go
+++ b/storage/localwriter.go
@@ -31,7 +31,9 @@ func NewLocalWriter(dir string, path string) (row.Sink, error) {
 	if err != nil {
 		return nil, err
 	}
-	f, err := os.OpenFile(p, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	// All rows from an archive are appended in a single session, so this
+	// does not need O_APPEND.
+	f, err := os.OpenFile(p, os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
1.  Add a comment in etl_worker about default application credentials.
      ?? Should this just be in the README instead?
2. Remove the append option for local output, so that it overwrites instead of appending.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1027)
<!-- Reviewable:end -->
