### PR TITLE
Allow parsing third-party archives

### DIFF
--- a/etl/globals.go
+++ b/etl/globals.go
@@ -68,7 +68,7 @@ const DatePathPattern = `(\d{4}/[01]\d/[0123]\d)/`
 const dateTime = `(\d{4}[01]\d[0123]\d)T(\d{6}(\.\d{0,6})?)Z`
 
 const type2 = `(?:-([a-z0-9-]+))?` // optional datatype string
-const mlabNSiteNN = `-(mlab\d)-([a-z]{3}\d[0-9t])-`
+const mlabNSiteNN = `-(mlab\d|third)-([a-z]{3}\d[0-9t]|party)-`
 
 // This parses the experiment name, optional -NNNN sequence number, and optional -e (for old embargoed files)
 const expNNNNE = `([a-z-]+)(?:-(\d{4}))?(-e)?`

--- a/etl/globals_test.go
+++ b/etl/globals_test.go
@@ -137,6 +137,16 @@ func TestValidateTestPath(t *testing.T) {
 				"archive-measurement-lab", "ndt", "scamper1", "2021/09/08", "20210908", "215656.886052", "scamper1", "mlab3", "bog03", "ndt", "", "", ".tgz",
 			},
 		},
+		{
+			name:     "thirdparty-annotation",
+			path:     `gs://archive-mlab-sandbox/ndt/annotation/2019/08/14/20211107T143735.458956Z-annotation-third-party-ndt.tgz`,
+			wantType: etl.ANNOTATION,
+			want: etl.DataPath{
+				`gs://archive-mlab-sandbox/ndt/annotation/2019/08/14/20211107T143735.458956Z-annotation-third-party-ndt.tgz`,
+				`ndt/annotation/2019/08/14/20211107T143735.458956Z-annotation-third-party-ndt.tgz`,
+				`archive-mlab-sandbox`, "ndt", "annotation", "2019/08/14", "20211107", "143735.458956", "annotation", "third", "party", "ndt", "", "", ".tgz",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This change updates the etl archive path parsing regular expression so that it will match the third-party archives generated by the synthetic uuid annotation export process. The synthetic archives reuse the "machine" field (normally `mlab[1-4]`) and the "site" field (normally `[a-z]{3}\d[0-9t]`) to also match "third" and "party" respectively.

With this change, thirdparty archives copied to the public archive will be natively parseable by the etl+gardener system.

For example:

```
gs://archive-mlab-sandbox/ndt/annotation/2019/07/12/20211107T143543.161376Z-annotation-third-party-ndt.tgz
```

Tested using the local output mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1029)
<!-- Reviewable:end -->
