### PR TITLE
Increase parser replicas to 6 to expedite annotation reprocessing

### DIFF
--- a/k8s/data-processing/deployments/parser.yml
+++ b/k8s/data-processing/deployments/parser.yml
@@ -4,7 +4,7 @@ metadata:
   name: etl-parser
   namespace: default
 spec:
-  replicas: 4
+  replicas: 6
   selector:
     matchLabels:
       # Used to match pre-existing pods that may be affected during updates.


### PR DESCRIPTION
Once the annotation export runs, the new archives must be reprocessed by the v2 pipeline before another run of the annotation export. During e2e testing in staging, this is a very slow e2e process. So, this change increases the parser instances to 6 to complete historical reprocessing more quickly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1035)
<!-- Reviewable:end -->
