### PR TITLE
Rename metric to etl_task_total

### DIFF
--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -213,7 +213,7 @@ func handleRequest(rwr http.ResponseWriter, rq *http.Request) {
 
 	// Throttle by grabbing a semaphore from channel.
 	if shouldThrottle() {
-		metrics.TaskCount.WithLabelValues("unknown", "TooManyRequests").Inc()
+		metrics.TaskTotal.WithLabelValues("unknown", "TooManyRequests").Inc()
 		rwr.WriteHeader(http.StatusTooManyRequests)
 		fmt.Fprintf(rwr, `{"message": "Too many tasks."}`)
 		return
@@ -269,7 +269,7 @@ func subworker(rawFileName string, executionCount, retryCount int, age time.Dura
 	// This handles base64 encoding, and requires a gs:// prefix.
 	fn, err := etl.GetFilename(rawFileName)
 	if err != nil {
-		metrics.TaskCount.WithLabelValues("unknown", "BadRequest").Inc()
+		metrics.TaskTotal.WithLabelValues("unknown", "BadRequest").Inc()
 		log.Printf("Invalid filename: %s\n", fn)
 		return http.StatusBadRequest, `{"message": "Invalid filename."}`
 	}
@@ -302,7 +302,7 @@ func (r *runnable) Run(ctx context.Context) error {
 	dp, err := etl.ValidateTestPath(path)
 	if err != nil {
 		log.Printf("Invalid filename: %v\n", err)
-		metrics.TaskCount.WithLabelValues(string(etl.INVALID), "BadRequest").Inc()
+		metrics.TaskTotal.WithLabelValues(string(etl.INVALID), "BadRequest").Inc()
 		return err
 	}
 

--- a/cmd/update-schema/update.go
+++ b/cmd/update-schema/update.go
@@ -248,12 +248,12 @@ func updateStandardTables(project string) int {
 		errCount++
 	}
 
-	// if err := CreateOrUpdatePCAPRow(project, "tmp_ndt", "pcap"); err != nil {
-	// 	errCount++
-	// }
-	// if err := CreateOrUpdatePCAPRow(project, "raw_ndt", "pcap"); err != nil {
-	// 	errCount++
-	// }
+	if err := CreateOrUpdatePCAPRow(project, "tmp_ndt", "pcap"); err != nil {
+		errCount++
+	}
+	if err := CreateOrUpdatePCAPRow(project, "raw_ndt", "pcap"); err != nil {
+		errCount++
+	}
 
 	if err := CreateOrUpdateHopAnnotation1Row(project, "tmp_ndt", "hopannotation1"); err != nil {
 		errCount++

--- a/cmd/update-schema/update.go
+++ b/cmd/update-schema/update.go
@@ -248,12 +248,12 @@ func updateStandardTables(project string) int {
 		errCount++
 	}
 
-	if err := CreateOrUpdatePCAPRow(project, "tmp_ndt", "pcap"); err != nil {
-		errCount++
-	}
-	if err := CreateOrUpdatePCAPRow(project, "raw_ndt", "pcap"); err != nil {
-		errCount++
-	}
+	// if err := CreateOrUpdatePCAPRow(project, "tmp_ndt", "pcap"); err != nil {
+	// 	errCount++
+	// }
+	// if err := CreateOrUpdatePCAPRow(project, "raw_ndt", "pcap"); err != nil {
+	// 	errCount++
+	// }
 
 	if err := CreateOrUpdateHopAnnotation1Row(project, "tmp_ndt", "hopannotation1"); err != nil {
 		errCount++

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -180,15 +180,15 @@ var (
 		[]string{"rsync_host_module", "day_of_week"},
 	)
 
-	// TaskCount counts the number of tasks processed by the pipeline.
+	// TaskTotal counts the number of tasks processed by the pipeline.
 	//
 	// Provides metrics:
-	//   etl_task_count{table, package, status}
+	//   etl_task_total{table, package, status}
 	// Example usage:
-	//   metrics.TaskCount.WithLabelValues("ndt", "Task", "ok").Inc()
-	TaskCount = promauto.NewCounterVec(
+	//   metrics.TaskTotal.WithLabelValues("ndt", "Task", "ok").Inc()
+	TaskTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "etl_task_count",
+			Name: "etl_task_total",
 			Help: "Number of tasks/archive files processed.",
 		},
 		// table/datatype, and Status

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -99,7 +99,7 @@ func TestMetrics(t *testing.T) {
 	metrics.PTPollutedCount.WithLabelValues("x")
 	metrics.PTTestCount.WithLabelValues("x")
 	metrics.RowSizeHistogram.WithLabelValues("x")
-	metrics.TaskCount.WithLabelValues("x", "x")
+	metrics.TaskTotal.WithLabelValues("x", "x")
 	metrics.TestCount.WithLabelValues("x", "x", "x")
 	metrics.WarningCount.WithLabelValues("x", "x", "x")
 	metrics.WorkerCount.WithLabelValues("x")

--- a/task/task.go
+++ b/task/task.go
@@ -157,7 +157,7 @@ OUTER:
 		loopErr = tt.Parser.ParseAndInsert(tt.meta, testname, data)
 		// Shouldn't have any of these, as they should be handled in ParseAndInsert.
 		if loopErr != nil {
-			metrics.TaskCount.WithLabelValues(
+			metrics.TaskTotal.WithLabelValues(
 				tt.Type(), "ParseAndInsertError").Inc()
 			log.Printf("ERROR %v", loopErr)
 			// TODO(dev) Handle this error properly!

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package worker_test
@@ -131,14 +132,14 @@ func TestProcessTask(t *testing.T) {
 	metrics.FileCount.Collect(c)
 	checkCounter(t, c, 1)
 
-	metrics.TaskCount.Collect(c)
+	metrics.TaskTotal.Collect(c)
 	checkCounter(t, c, 1)
 
 	metrics.TestCount.Collect(c)
 	checkCounter(t, c, 1)
 
 	metrics.FileCount.Reset()
-	metrics.TaskCount.Reset()
+	metrics.TaskTotal.Reset()
 	metrics.TestCount.Reset()
 }
 
@@ -211,7 +212,7 @@ func TestNilUploader(t *testing.T) {
 	}
 
 	metrics.FileCount.Reset()
-	metrics.TaskCount.Reset()
+	metrics.TaskTotal.Reset()
 	metrics.TestCount.Reset()
 }
 
@@ -244,7 +245,7 @@ func TestProcessGKETask(t *testing.T) {
 	metrics.FileCount.Collect(c)
 	checkCounter(t, c, 488)
 
-	metrics.TaskCount.Collect(c)
+	metrics.TaskTotal.Collect(c)
 	checkCounter(t, c, 1)
 
 	metrics.TestCount.Collect(c)
@@ -254,6 +255,6 @@ func TestProcessGKETask(t *testing.T) {
 		t.Error("Expected 478 tests, got", up.Total)
 	}
 	metrics.FileCount.Reset()
-	metrics.TaskCount.Reset()
+	metrics.TaskTotal.Reset()
 	metrics.TestCount.Reset()
 }


### PR DESCRIPTION
Rename the `etl_task_count` metric to `etl_task_total` to honor prometheus best practices for metric naming: https://prometheus.io/docs/practices/naming/.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1040)
<!-- Reviewable:end -->
