### PR TITLE
Add script to delete extra appengine services

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -140,3 +140,9 @@ steps:
   args: [
     'bash', '-c', 'cd cmd/etl_worker && gcloud --project=$PROJECT_ID app deploy --promote app-batch.yaml'
   ]
+
+- name: gcr.io/google.com/cloudsdktool/cloud-sdk
+  id: "Delete non-serving appengine versions"
+  args: [
+    'bash', '-c', './delete-appengine.sh'
+  ]

--- a/delete-appengine.sh
+++ b/delete-appengine.sh
@@ -45,5 +45,7 @@ gcloud --project=${PROJECT_ID} \
        }
     }' | \
     while read service version ; do 
-        echo gcloud app versions delete --service $service $version
+        echo "Deleting $service $version"
+        gcloud --project=${PROJECT_ID} \
+            app versions delete --service $service $version
     done

--- a/delete-appengine.sh
+++ b/delete-appengine.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# delete-appengine.sh deletes all service versions after the first 9 with a
+# zero traffic split. This script is meant to run as a late step of the
+# cloudbuild deployment. Running this regularly will keep the number of
+# versions around 10 per service (for rollbacks) and below 210 globally (the
+# hard limit imposed by AppEngine).
+
+# Example: Below is example output from `gcloud app versions list`. The
+# 'TRAFFIC_SPLIT' determines whether any traffic is directed to this service.
+# Standard environment services (i.e. non-flex) are always in 'SERVING' state.
+#
+# SERVICE                 VERSION.ID       TRAFFIC_SPLIT  LAST_DEPLOYED              SERVING_STATUS
+# annotator               20210702t202340  0.00           2021-07-02T16:33:46-04:00  STOPPED
+# annotator               20210713t053025  1.00           2021-07-13T01:40:43-04:00  SERVING
+# locate                  20180425t084144  0.00           2018-04-25T08:42:52-04:00  STOPPED
+# locate                  20190305t132521  0.00           2019-03-05T13:26:34-05:00  STOPPED
+# locate                  20190305t135528  0.00           2019-03-05T13:57:06-05:00  SERVING
+# locate                  20190305t184900  0.00           2019-03-05T18:50:09-05:00  STOPPED
+# locate                  20190314t100404  1.00           2019-03-14T10:05:20-04:00  SERVING
+# default                 20200507t202419  0.00           2020-05-07T16:25:06-04:00  SERVING
+# default                 20200507t210846  0.00           2020-05-07T17:09:25-04:00  SERVING
+# default                 20200508t184639  0.00           2020-05-08T14:47:22-04:00  SERVING
+# default                 20200508t192236  0.00           2020-05-08T15:23:13-04:00  SERVING
+# default                 20200511t171409  0.00           2020-05-11T13:15:00-04:00  SERVING
+# default                 20200514t140435  0.00           2020-05-14T10:05:25-04:00  SERVING
+# default                 20200520t171631  0.00           2020-05-20T13:17:23-04:00  SERVING
+# default                 20200520t174419  0.00           2020-05-20T13:45:05-04:00  SERVING
+# default                 20200526t210545  0.00           2020-05-26T17:06:37-04:00  SERVING
+# default                 20200630t221216  0.00           2020-06-30T18:13:18-04:00  SERVING
+# default                 20200817t211428  0.00           2020-08-17T17:15:35-04:00  SERVING
+# default                 20200817t212515  0.00           2020-08-17T17:25:59-04:00  SERVING
+
+# Delete service versions after the first 9 with a zero traffic split.
+gcloud --project=${PROJECT_ID} app versions list | \
+    awk '{
+       if ($3 == 0) {
+         count[$1]+=1
+       };
+       if (count[$1] > 9 && $3 == 0) {
+         print $1, $2
+       }
+    }' | \
+    while read service version ; do 
+        echo gcloud app versions delete --service $service $version
+    done

--- a/delete-appengine.sh
+++ b/delete-appengine.sh
@@ -1,44 +1,47 @@
 #!/bin/bash
 #
-# delete-appengine.sh deletes all service versions after the first 9 with a
-# zero traffic split. This script is meant to run as a late step of the
-# cloudbuild deployment. Running this regularly will keep the number of
-# versions around 10 per service (for rollbacks) and below 210 globally (the
-# hard limit imposed by AppEngine).
+# delete-appengine.sh deletes all service versions after the 9 most recently
+# deployed versions with zero traffic split. This script is meant to run as a
+# late step of the cloudbuild deployment. Running this regularly will keep the
+# number of versions around 10 per service (for rollbacks) and below 210
+# globally (the hard limit imposed by AppEngine).
 
 # Example: Below is example output from `gcloud app versions list`. The
 # 'TRAFFIC_SPLIT' determines whether any traffic is directed to this service.
 # Standard environment services (i.e. non-flex) are always in 'SERVING' state.
+# The service versions are ordered by SERVICE name (ascending) then
+# LAST_DEPLOYED (descending).
 #
 # SERVICE                 VERSION.ID       TRAFFIC_SPLIT  LAST_DEPLOYED              SERVING_STATUS
-# annotator               20210702t202340  0.00           2021-07-02T16:33:46-04:00  STOPPED
 # annotator               20210713t053025  1.00           2021-07-13T01:40:43-04:00  SERVING
-# locate                  20180425t084144  0.00           2018-04-25T08:42:52-04:00  STOPPED
-# locate                  20190305t132521  0.00           2019-03-05T13:26:34-05:00  STOPPED
-# locate                  20190305t135528  0.00           2019-03-05T13:57:06-05:00  SERVING
-# locate                  20190305t184900  0.00           2019-03-05T18:50:09-05:00  STOPPED
-# locate                  20190314t100404  1.00           2019-03-14T10:05:20-04:00  SERVING
-# default                 20200507t202419  0.00           2020-05-07T16:25:06-04:00  SERVING
-# default                 20200507t210846  0.00           2020-05-07T17:09:25-04:00  SERVING
-# default                 20200508t184639  0.00           2020-05-08T14:47:22-04:00  SERVING
-# default                 20200508t192236  0.00           2020-05-08T15:23:13-04:00  SERVING
-# default                 20200511t171409  0.00           2020-05-11T13:15:00-04:00  SERVING
-# default                 20200514t140435  0.00           2020-05-14T10:05:25-04:00  SERVING
-# default                 20200520t171631  0.00           2020-05-20T13:17:23-04:00  SERVING
-# default                 20200520t174419  0.00           2020-05-20T13:45:05-04:00  SERVING
-# default                 20200526t210545  0.00           2020-05-26T17:06:37-04:00  SERVING
-# default                 20200630t221216  0.00           2020-06-30T18:13:18-04:00  SERVING
-# default                 20200817t211428  0.00           2020-08-17T17:15:35-04:00  SERVING
-# default                 20200817t212515  0.00           2020-08-17T17:25:59-04:00  SERVING
+# annotator               20210702t202340  0.00           2021-07-02T16:33:46-04:00  STOPPED
+# locate                  20211101t225708  1.00           2021-11-01T18:58:52-04:00  SERVING
+# locate                  20211027t205713  0.00           2021-10-27T17:10:45-04:00  STOPPED
+# locate                  20211026t195123  0.00           2021-10-26T16:04:28-04:00  STOPPED
+# locate                  20211026t174157  0.00           2021-10-26T13:55:53-04:00  STOPPED
+# locate                  20211020t220644  0.00           2021-10-20T18:20:54-04:00  STOPPED
+# default                 20211012t163346  1.00           2021-10-12T12:35:18-04:00  SERVING
+# default                 20211011t235453  0.00           2021-10-11T19:56:14-04:00  SERVING
+# default                 20211011t224634  0.00           2021-10-11T18:47:58-04:00  SERVING
+# default                 20211011t174445  0.00           2021-10-11T13:48:54-04:00  SERVING
+# default                 20210812t202133  0.00           2021-08-12T16:22:14-04:00  SERVING
+# default                 20210810t163607  0.00           2021-08-10T12:37:28-04:00  SERVING
+# default                 20210518t153854  0.00           2021-05-18T11:39:56-04:00  SERVING
+# default                 20210427t170445  0.00           2021-04-27T13:06:07-04:00  SERVING
+# default                 20210420t212953  0.00           2021-04-20T17:30:45-04:00  SERVING
+# default                 20210420t174553  0.00           2021-04-20T13:46:37-04:00  SERVING
+# default                 20210409t180654  0.00           2021-04-09T14:07:38-04:00  SERVING
 
-# Delete service versions after the first 9 with a zero traffic split.
-gcloud --project=${PROJECT_ID} app versions list | \
+# Delete service versions after the most recent 9 with a zero traffic split.
+# NOTE: any service version with a non-zero traffic split is never deleted.
+gcloud --project=${PROJECT_ID} \
+    app versions list --sort-by=SERVICE,~LAST_DEPLOYED | \
     awk '{
        if ($3 == 0) {
          count[$1]+=1
-       };
-       if (count[$1] > 9 && $3 == 0) {
-         print $1, $2
+         if (count[$1] > 9) {
+           print $1, $2
+         }
        }
     }' | \
     while read service version ; do 


### PR DESCRIPTION
AppEngine has a hard limit of 210 service versions across a project. This change adds a small script that deletes all service versions after the first 9 that are non-serving. The number of older versions to preserve is arbitrary; more than 1 to allow rollbacks is the main intention. 9 is conservative number. This change was inspired by an alert in staging about there being too many service versions.

Limitations / caveats:

- The first time this script runs, it will delete many older versions and will take longer than steady state. At the limit, it should delete no more than one per service.
- This script applies to all app engine services but will only run on ETL deployments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1042)
<!-- Reviewable:end -->
