### PR TITLE
Disable v1 deployment

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -113,36 +113,36 @@ steps:
 # TODO: delete once legacy services are retired.
 
 # Use the GCR image as the base for the AppEngine deployment.
-- name: gcr.io/cloud-builders/gcloud
-  id: "Generate Dockerfile for AppEngine deployment"
-  entrypoint: bash
-  args: [
-     '-c', 'echo "FROM gcr.io/$PROJECT_ID/etl:$_DOCKER_TAG" > /workspace/cmd/etl_worker/Dockerfile',
-  ]
-
+#- name: gcr.io/cloud-builders/gcloud
+#  id: "Generate Dockerfile for AppEngine deployment"
+#  entrypoint: bash
+#  args: [
+#     '-c', 'echo "FROM gcr.io/$PROJECT_ID/etl:$_DOCKER_TAG" > /workspace/cmd/etl_worker/Dockerfile',
+#  ]
+#
 # LEGACY PARSER: Deploy to app engine.
-- name: gcr.io/google.com/cloudsdktool/cloud-sdk
-  id: "Deploy etl batch parser to app engine"
-  args: [
-    'gcloud', 'app', 'deploy', '--project=$PROJECT_ID', 'appengine/queue.yaml'
-  ]
-
+# - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+#   id: "Deploy etl batch parser to app engine"
+#   args: [
+#     'gcloud', 'app', 'deploy', '--project=$PROJECT_ID', 'appengine/queue.yaml'
+#   ]
+#
 # Prepare app yaml configuration.
-- name: gcr.io/google.com/cloudsdktool/cloud-sdk
-  id: "Update annotator url environment variable in app-batch.yaml"
-  args: [
-    'bash', '-c',
-    "sed -i -e 's|{{ANNOTATOR_URL}}|$_ANNOTATOR_URL|' cmd/etl_worker/app-batch.yaml"
-  ]
-
-- name: gcr.io/google.com/cloudsdktool/cloud-sdk
-  id: "Deploy etl batch parser to AppEngine"
-  args: [
-    'bash', '-c', 'cd cmd/etl_worker && gcloud --project=$PROJECT_ID app deploy --promote app-batch.yaml'
-  ]
-
-- name: gcr.io/google.com/cloudsdktool/cloud-sdk
-  id: "Delete non-serving appengine versions"
-  args: [
-    'bash', '-c', './delete-appengine-services.sh'
-  ]
+# - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+#   id: "Update annotator url environment variable in app-batch.yaml"
+#   args: [
+#     'bash', '-c',
+#     "sed -i -e 's|{{ANNOTATOR_URL}}|$_ANNOTATOR_URL|' cmd/etl_worker/app-batch.yaml"
+#   ]
+#
+# - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+#   id: "Deploy etl batch parser to AppEngine"
+#   args: [
+#     'bash', '-c', 'cd cmd/etl_worker && gcloud --project=$PROJECT_ID app deploy --promote app-batch.yaml'
+#   ]
+#
+# - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+#   id: "Delete non-serving appengine versions"
+#   args: [
+#     'bash', '-c', './delete-appengine-services.sh'
+#   ]


### PR DESCRIPTION
This change disables steps to deploy the v1 parsers to app engine. This is necessary to deploy updated v2 parsers to the new pipeline without disrupting the v1 parsers until we decide to turn them off.

Part of https://github.com/m-lab/etl/issues/1050

FYI: @robertodauria 