### PR TITLE
Update the gardener_addr flag (2 of 2)

### DIFF
--- a/cmd/etl_worker/etl_worker_test.go
+++ b/cmd/etl_worker/etl_worker_test.go
@@ -88,7 +88,7 @@ func TestPollingMode(t *testing.T) {
 	flag.Set("prometheusx.listen-address", ":0")
 	flag.Set("max_workers", "25")
 	flag.Set("gcloud_project", "mlab-testing")
-	flag.Set("gardener_host", "gardener")
+	flag.Set("gardener_addr", "gardener:8080")
 	etl.GitCommit = "123456789ABCDEF"
 	mainCtx, mainCancel = context.WithCancel(context.Background())
 

--- a/k8s/data-processing/deployments/parser.yml
+++ b/k8s/data-processing/deployments/parser.yml
@@ -47,8 +47,8 @@ spec:
         - name: BIGQUERY_DATASET
           value: "{{BIGQUERY_DATASET}}"
 
-        - name: GARDENER_HOST
-          value: "etl-gardener-service.default.svc.cluster.local"
+        - name: GARDENER_ADDR
+          value: "etl-gardener-service.default.svc.cluster.local:8080"
         - name: BATCH_SERVICE
           value: 'true'   # Allow instances to discover they are BATCH instances.
         - name: MAX_WORKERS


### PR DESCRIPTION
This change changes the `-gardener_host` flag to `-gardener_addr` to allow the caller to specify a host:port combination, typical of Go addresses. This change is a complement to https://github.com/m-lab/etl-gardener/pull/371 which allows gardener to specify the serving port. These changes should allow more flexibility in running the gardener and parser in local development modes and normalizing how addresses are specified in the etl pipeline.

This change additionally updates the k8s configuration that depends on the `GARDENER_ADDR` to specify both the address and port for the Gardener service.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1055)
<!-- Reviewable:end -->
