### PR TITLE
Update Go version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to contain the generate_schema_docs CLI.
 
-FROM golang:1.14.4-alpine3.12 AS build
+FROM golang:1.16.7-alpine3.14 AS build
 RUN apk update
 RUN apk add --virtual build-dependencies build-base gcc wget git linux-headers
 # Build the command.
@@ -9,7 +9,7 @@ WORKDIR /go/src/github.com/m-lab/etl
 RUN go get -v github.com/m-lab/etl/cmd/generate_schema_docs
 
 # Now copy the resulting command into the minimal base image.
-FROM alpine:3.12
+FROM alpine:3.14
 COPY --from=build /go/bin/generate_schema_docs /
 COPY --from=build /go/src/github.com/m-lab/etl/schema/descriptions /schema/descriptions/
 WORKDIR /

--- a/cmd/etl_worker/Dockerfile.k8s
+++ b/cmd/etl_worker/Dockerfile.k8s
@@ -1,4 +1,4 @@
-FROM golang:1.16.7 as builder
+FROM golang:1.15.8 as builder
 
 ARG VERSION
 

--- a/cmd/etl_worker/Dockerfile.k8s
+++ b/cmd/etl_worker/Dockerfile.k8s
@@ -1,4 +1,4 @@
-FROM golang:1.15.8 as builder
+FROM golang:1.16.7 as builder
 
 ARG VERSION
 


### PR DESCRIPTION
A lot the project's dependencies were upgraded when we updated to the latest version of ndt-server #1056.

This has caused the Docker build to fail since it some of the new dependencies require a higher version of Go.
https://hub.docker.com/repository/registry-1.docker.io/measurementlab/generate-schema-docs/builds/5dba9aee-3d0c-41b0-90e3-2166e489bb19.

Upgrading the Go/Alpine versions in the Dockerfile to be the same as ndt-server fixes this issue https://github.com/m-lab/ndt-server/pull/339.
Tested locally with `docker build . -t etl`.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1058)
<!-- Reviewable:end -->
