### PR TITLE
Add descriptions of server metadata to ndt5 and ndt7

### DIFF
--- a/schema/descriptions/NDT5ResultRowV2.yaml
+++ b/schema/descriptions/NDT5ResultRowV2.yaml
@@ -63,7 +63,7 @@ Control.ClientMetadata.Value:
 Control.ServerMetadata:
   Description: Authoritative metadata added by the server configuration.
 Control.ServerMetadata.Name:
-  Description: If set, contains the name a single piece of metadata.
+  Description: If set, contains the name of a single piece of metadata.
     This name will be the same for all measurements collected while this
     server was running with this configuration.
 Control.ServerMetadata.Value:

--- a/schema/descriptions/NDT5ResultRowV2.yaml
+++ b/schema/descriptions/NDT5ResultRowV2.yaml
@@ -60,6 +60,16 @@ Control.ClientMetadata.Name:
 Control.ClientMetadata.Value:
   Description: If set, contains a value corresponding to metadata name. For
     example, "Windows 10" or "ndtJS"
+Control.ServerMetadata:
+  Description: Authoritative metadata added by the server configuration.
+Control.ServerMetadata.Name:
+  Description: If set, contains the name a single piece of metadata.
+    This name will be the same for all measurements collected while this
+    server was running with this configuration.
+Control.ServerMetadata.Value:
+  Description: If name is set, contains the text of a server configuration
+    value. This value will be the same for all measurements collected while
+    this server was running with this configuration.
 
 C2S:
   Description: Metadata for Client-to-Server (upload) measurements performed

--- a/schema/descriptions/NDT7ResultRow.yaml
+++ b/schema/descriptions/NDT7ResultRow.yaml
@@ -276,7 +276,7 @@ ClientMetadata.Value:
 ServerMetadata:
   Description: Authoritative metadata added by the server configuration.
 ServerMetadata.Name:
-  Description: If set, contains the name a single piece of metadata.
+  Description: If set, contains the name of a single piece of metadata.
     This name will be the same for all measurements collected while this
     server was running with this configuration.
 ServerMetadata.Value:

--- a/schema/descriptions/NDT7ResultRow.yaml
+++ b/schema/descriptions/NDT7ResultRow.yaml
@@ -272,3 +272,14 @@ ClientMetadata.Name:
 ClientMetadata.Value:
   Description: If set, contains a value corresponding to metadata name. For
     example, "Windows 10" or "ndtJS"
+
+ServerMetadata:
+  Description: Authoritative metadata added by the server configuration.
+ServerMetadata.Name:
+  Description: If set, contains the name a single piece of metadata.
+    This name will be the same for all measurements collected while this
+    server was running with this configuration.
+ServerMetadata.Value:
+  Description: If name is set, contains the text of a server configuration
+    value. This value will be the same for all measurements collected while
+    this server was running with this configuration.


### PR DESCRIPTION
While preparing to update the website documentation for the v2 schema of ndt5, I found that the server metadata fields could use a helpful description. This change adds a description of these fields for ndt5 and ndt7.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1063)
<!-- Reviewable:end -->
