### PR TITLE
Update generate_schema_docs & parser descriptions

### DIFF
--- a/cmd/generate_schema_docs/main.go
+++ b/cmd/generate_schema_docs/main.go
@@ -152,7 +152,7 @@ func main() {
 	generators := []schemaGenerator{
 		&schema.AnnotationRow{},
 		&schema.HopAnnotation1Row{},
-		&schema.NDT5ResultRow{},
+		&schema.NDT5ResultRowV2{},
 		&schema.NDT7ResultRow{},
 		&schema.TCPRow{},
 		&schema.PTTest{},

--- a/cmd/generate_schema_docs/main_test.go
+++ b/cmd/generate_schema_docs/main_test.go
@@ -35,7 +35,7 @@ func Test_main(t *testing.T) {
 	main() // no crash == working
 
 	files := [4]string{
-		"schema_ndt5resultrow.md",
+		"schema_ndt5resultrowv2.md",
 		"schema_pcaprow.md",
 		"schema_hopannotation1row.md",
 		"schema_scamper1row.md",

--- a/schema/descriptions/Scamper1Row.yaml
+++ b/schema/descriptions/Scamper1Row.yaml
@@ -1,19 +1,5 @@
 raw.Tracelb.Nodes.HopID:
   Description: Daily unique identifier to join traceroute datasets with Hop Annotations.
-# Descriptions of the following fields are provided in toplevel.yaml.
-#id:
-#parser:
-#parser.Version:
-#parser.Time:
-#parser.ArchiveURL:
-#date:
-#raw:
-parser.Filename:
-  Description:
-parser.Priority:
-  Description:
-parser.GitCommit:
-  Description:
 raw.Metadata:
   Description:
 raw.Metadata.UUID:

--- a/schema/descriptions/toplevel.yaml
+++ b/schema/descriptions/toplevel.yaml
@@ -33,6 +33,11 @@ parser.Time:
 parser.ArchiveURL:
   Description: The Google Cloud Storage URL to the archive containing the
     Filename for this row.
+parser.Filename:
+  Description: The name of the filename within the ArchiveURL originally created by the measurement service.
+    Results in the raw record are derived from measurements in this file.
+parser.GitCommit:
+  Description: The git commit of this build of the parser.
 
 server:
   Description: Location information about the M-Lab server that collected the

--- a/schema/descriptions/toplevel.yaml
+++ b/schema/descriptions/toplevel.yaml
@@ -34,7 +34,7 @@ parser.ArchiveURL:
   Description: The Google Cloud Storage URL to the archive containing the
     Filename for this row.
 parser.Filename:
-  Description: The name of the filename within the ArchiveURL originally created by the measurement service.
+  Description: The name of the file within the ArchiveURL originally created by the measurement service.
     Results in the raw record are derived from measurements in this file.
 parser.GitCommit:
   Description: The git commit of this build of the parser.


### PR DESCRIPTION
This change removes support for the older ndt5 schema in favor of the ndt5 v2 schema in `generate_schema_docs`.

With this change, I've removed `parser.*` field definitions from the `Scamper1Row.yaml` and moved them to the `toplevel.yaml` so the descriptions can be shared by all datatypes with a v2 `parser` record.

Part of:
* https://github.com/m-lab/etl/issues/1046

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1065)
<!-- Reviewable:end -->
