### PR TITLE
Increase v2 / decrease v1 resources

### DIFF
--- a/appengine/queue.yaml
+++ b/appengine/queue.yaml
@@ -94,7 +94,7 @@ queue:
 - name: etl-ndt-batch-0
   target: etl-batch-parser
   # At 10/s, the ndt requests cause a lot of 429s, and crowd out the other queues.
-  rate: 3/s
+  rate: 1/s
   bucket_size: 10
   max_concurrent_requests: 120
   retry_parameters:
@@ -105,7 +105,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-1
   target: etl-batch-parser
-  rate: 3/s
+  rate: 1/s
   bucket_size: 10
   max_concurrent_requests: 120
   retry_parameters:
@@ -115,7 +115,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-2
   target: etl-batch-parser
-  rate: 3/s
+  rate: 1/s
   bucket_size: 10
   max_concurrent_requests: 120
   retry_parameters:
@@ -125,7 +125,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-3
   target: etl-batch-parser
-  rate: 3/s
+  rate: 1/s
   bucket_size: 10
   max_concurrent_requests: 120
   retry_parameters:
@@ -135,7 +135,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-4
   target: etl-batch-parser
-  rate: 3/s
+  rate: 1/s
   bucket_size: 10
   max_concurrent_requests: 120
   retry_parameters:
@@ -145,7 +145,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-5
   target: etl-batch-parser
-  rate: 3/s
+  rate: 1/s
   bucket_size: 10
   max_concurrent_requests: 120
   retry_parameters:
@@ -155,7 +155,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-6
   target: etl-batch-parser
-  rate: 3/s
+  rate: 1/s
   bucket_size: 10
   max_concurrent_requests: 120
   retry_parameters:
@@ -165,7 +165,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-7
   target: etl-batch-parser
-  rate: 3/s
+  rate: 1/s
   bucket_size: 10
   max_concurrent_requests: 120
   retry_parameters:
@@ -175,7 +175,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-8
   target: etl-batch-parser
-  rate: 3/s
+  rate: 1/s
   bucket_size: 10
   max_concurrent_requests: 120
   retry_parameters:
@@ -185,7 +185,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-9
   target: etl-batch-parser
-  rate: 3/s
+  rate: 1/s
   bucket_size: 10
   max_concurrent_requests: 120
   retry_parameters:
@@ -195,7 +195,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-10
   target: etl-batch-parser
-  rate: 3/s
+  rate: 1/s
   bucket_size: 10
   max_concurrent_requests: 120
   retry_parameters:
@@ -205,7 +205,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-11
   target: etl-batch-parser
-  rate: 3/s
+  rate: 1/s
   bucket_size: 10
   max_concurrent_requests: 120
   retry_parameters:
@@ -215,7 +215,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-12
   target: etl-batch-parser
-  rate: 3/s
+  rate: 1/s
   bucket_size: 10
   max_concurrent_requests: 120
   retry_parameters:
@@ -225,7 +225,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-13
   target: etl-batch-parser
-  rate: 3/s
+  rate: 1/s
   bucket_size: 10
   max_concurrent_requests: 120
   retry_parameters:
@@ -235,7 +235,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-14
   target: etl-batch-parser
-  rate: 3/s
+  rate: 1/s
   bucket_size: 10
   max_concurrent_requests: 120
   retry_parameters:
@@ -245,7 +245,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt-batch-15
   target: etl-batch-parser
-  rate: 3/s
+  rate: 1/s
   bucket_size: 10
   max_concurrent_requests: 120
   retry_parameters:
@@ -256,7 +256,7 @@ queue:
 
 - name: etl-sidestream-batch-0
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 20
@@ -269,7 +269,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-1
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 20
@@ -282,7 +282,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-2
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 20
@@ -295,7 +295,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-3
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 20
@@ -308,7 +308,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-4
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 20
@@ -321,7 +321,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-5
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 20
@@ -334,7 +334,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-6
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 20
@@ -347,7 +347,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-7
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 20
@@ -360,7 +360,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-8
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 20
@@ -373,7 +373,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-9
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 20
@@ -386,7 +386,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-10
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 20
@@ -399,7 +399,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-11
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 20
@@ -412,7 +412,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-12
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 20
@@ -425,7 +425,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-13
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 20
@@ -438,7 +438,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-14
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 20
@@ -451,7 +451,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-sidestream-batch-15
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 20
@@ -465,7 +465,7 @@ queue:
 
 - name: etl-traceroute-batch-0
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 20
@@ -478,7 +478,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-traceroute-batch-1
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   max_concurrent_requests: 20
   retry_parameters:
@@ -487,7 +487,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-traceroute-batch-2
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   max_concurrent_requests: 20
   retry_parameters:
@@ -496,7 +496,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-traceroute-batch-3
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   max_concurrent_requests: 20
   retry_parameters:
@@ -505,7 +505,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-traceroute-batch-4
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   max_concurrent_requests: 20
   retry_parameters:
@@ -514,7 +514,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-traceroute-batch-5
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   max_concurrent_requests: 20
   retry_parameters:
@@ -523,7 +523,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-traceroute-batch-6
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   max_concurrent_requests: 20
   retry_parameters:
@@ -532,7 +532,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-traceroute-batch-7
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   max_concurrent_requests: 20
   retry_parameters:
@@ -541,7 +541,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-traceroute-batch-8
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   max_concurrent_requests: 20
   retry_parameters:
@@ -550,7 +550,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-traceroute-batch-9
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   max_concurrent_requests: 20
   retry_parameters:
@@ -559,7 +559,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-traceroute-batch-10
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   max_concurrent_requests: 20
   retry_parameters:
@@ -568,7 +568,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-traceroute-batch-11
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   max_concurrent_requests: 20
   retry_parameters:
@@ -577,7 +577,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-traceroute-batch-12
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   max_concurrent_requests: 20
   retry_parameters:
@@ -586,7 +586,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-traceroute-batch-13
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   max_concurrent_requests: 20
   retry_parameters:
@@ -595,7 +595,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-traceroute-batch-14
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   max_concurrent_requests: 20
   retry_parameters:
@@ -604,7 +604,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-traceroute-batch-15
   target: etl-batch-parser
-  rate: 1/s
+  rate: 30/m
   bucket_size: 10
   max_concurrent_requests: 20
   retry_parameters:
@@ -614,7 +614,7 @@ queue:
 
 - name: etl-disco-batch-0
   target: etl-batch-parser
-  rate: 2/s
+  rate: 1/s
   bucket_size: 10
   # max concurrent is limited, because we will share the pipeline with other experiment types
   max_concurrent_requests: 5
@@ -627,7 +627,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-disco-batch-1
   target: etl-batch-parser
-  rate: 2/s
+  rate: 1/s
   bucket_size: 10
   max_concurrent_requests: 5
   retry_parameters:
@@ -636,7 +636,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-disco-batch-2
   target: etl-batch-parser
-  rate: 2/s
+  rate: 1/s
   bucket_size: 10
   max_concurrent_requests: 5
   retry_parameters:
@@ -645,7 +645,7 @@ queue:
     max_backoff_seconds: 20
 - name: etl-disco-batch-3
   target: etl-batch-parser
-  rate: 2/s
+  rate: 1/s
   bucket_size: 10
   max_concurrent_requests: 5
   retry_parameters:
@@ -656,7 +656,7 @@ queue:
 # TCPINFO batch parsing queues.
 - name: etl-tcpinfo-batch-0
   target: etl-batch-parser
-  rate: 2/s
+  rate: 1/s
   bucket_size: 10
   max_concurrent_requests: 200
   retry_parameters:
@@ -666,7 +666,7 @@ queue:
 
 - name: etl-tcpinfo-batch-1
   target: etl-batch-parser
-  rate: 2/s
+  rate: 1/s
   bucket_size: 10
   max_concurrent_requests: 200
   retry_parameters:
@@ -676,7 +676,7 @@ queue:
 
 - name: etl-tcpinfo-batch-2
   target: etl-batch-parser
-  rate: 2/s
+  rate: 1/s
   bucket_size: 10
   max_concurrent_requests: 200
   retry_parameters:
@@ -686,7 +686,7 @@ queue:
 
 - name: etl-tcpinfo-batch-3
   target: etl-batch-parser
-  rate: 2/s
+  rate: 1/s
   bucket_size: 10
   max_concurrent_requests: 200
   retry_parameters:
@@ -698,7 +698,7 @@ queue:
 - name: etl-ndt5-batch-0
   target: etl-batch-parser
   # At 0.2/sec, this was getting crowded out by ndt.
-  rate: 5/s
+  rate: 2/s
   bucket_size: 10
   max_concurrent_requests: 10
   retry_parameters:
@@ -708,7 +708,7 @@ queue:
     max_doublings: 0
 - name: etl-ndt5-batch-1
   target: etl-batch-parser
-  rate: 5/s
+  rate: 2/s
   bucket_size: 10
   max_concurrent_requests: 10
   retry_parameters:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -120,29 +120,29 @@ steps:
      '-c', 'echo "FROM gcr.io/$PROJECT_ID/etl:$_DOCKER_TAG" > /workspace/cmd/etl_worker/Dockerfile',
   ]
 
-# LEGACY PARSER: Deploy to app engine.
- - name: gcr.io/google.com/cloudsdktool/cloud-sdk
-   id: "Deploy etl batch parser task queue config to app engine"
-   args: [
-     'gcloud', 'app', 'deploy', '--project=$PROJECT_ID', 'appengine/queue.yaml'
-   ]
+ # LEGACY PARSER: Deploy to app engine.
+- name: gcr.io/google.com/cloudsdktool/cloud-sdk
+  id: "Deploy etl batch parser task queue config to app engine"
+  args: [
+     'gcloud', 'app', 'deploy', '--project=$PROJECT_ID', 'appengine/queue.yaml',
+  ]
 
 # Prepare app yaml configuration.
- - name: gcr.io/google.com/cloudsdktool/cloud-sdk
-   id: "Update annotator url environment variable in app-batch.yaml"
-   args: [
+- name: gcr.io/google.com/cloudsdktool/cloud-sdk
+  id: "Update annotator url environment variable in app-batch.yaml"
+  args: [
      'bash', '-c',
-     "sed -i -e 's|{{ANNOTATOR_URL}}|$_ANNOTATOR_URL|' cmd/etl_worker/app-batch.yaml"
-   ]
+     "sed -i -e 's|{{ANNOTATOR_URL}}|$_ANNOTATOR_URL|' cmd/etl_worker/app-batch.yaml",
+  ]
 
- - name: gcr.io/google.com/cloudsdktool/cloud-sdk
-   id: "Deploy etl batch parser to AppEngine"
-   args: [
-     'bash', '-c', 'cd cmd/etl_worker && gcloud --project=$PROJECT_ID app deploy --promote app-batch.yaml'
-   ]
+- name: gcr.io/google.com/cloudsdktool/cloud-sdk
+  id: "Deploy etl batch parser to AppEngine"
+  args: [
+     'bash', '-c', 'cd cmd/etl_worker && gcloud --project=$PROJECT_ID app deploy --promote app-batch.yaml',
+  ]
 
- - name: gcr.io/google.com/cloudsdktool/cloud-sdk
-   id: "Delete non-serving appengine versions"
-   args: [
+- name: gcr.io/google.com/cloudsdktool/cloud-sdk
+  id: "Delete non-serving appengine versions"
+  args: [
      'bash', '-c', './delete-appengine-services.sh'
-   ]
+  ]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -113,36 +113,36 @@ steps:
 # TODO: delete once legacy services are retired.
 
 # Use the GCR image as the base for the AppEngine deployment.
-#- name: gcr.io/cloud-builders/gcloud
-#  id: "Generate Dockerfile for AppEngine deployment"
-#  entrypoint: bash
-#  args: [
-#     '-c', 'echo "FROM gcr.io/$PROJECT_ID/etl:$_DOCKER_TAG" > /workspace/cmd/etl_worker/Dockerfile',
-#  ]
-#
+- name: gcr.io/cloud-builders/gcloud
+  id: "Generate Dockerfile for AppEngine deployment"
+  entrypoint: bash
+  args: [
+     '-c', 'echo "FROM gcr.io/$PROJECT_ID/etl:$_DOCKER_TAG" > /workspace/cmd/etl_worker/Dockerfile',
+  ]
+
 # LEGACY PARSER: Deploy to app engine.
-# - name: gcr.io/google.com/cloudsdktool/cloud-sdk
-#   id: "Deploy etl batch parser to app engine"
-#   args: [
-#     'gcloud', 'app', 'deploy', '--project=$PROJECT_ID', 'appengine/queue.yaml'
-#   ]
-#
+ - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+   id: "Deploy etl batch parser task queue config to app engine"
+   args: [
+     'gcloud', 'app', 'deploy', '--project=$PROJECT_ID', 'appengine/queue.yaml'
+   ]
+
 # Prepare app yaml configuration.
-# - name: gcr.io/google.com/cloudsdktool/cloud-sdk
-#   id: "Update annotator url environment variable in app-batch.yaml"
-#   args: [
-#     'bash', '-c',
-#     "sed -i -e 's|{{ANNOTATOR_URL}}|$_ANNOTATOR_URL|' cmd/etl_worker/app-batch.yaml"
-#   ]
-#
-# - name: gcr.io/google.com/cloudsdktool/cloud-sdk
-#   id: "Deploy etl batch parser to AppEngine"
-#   args: [
-#     'bash', '-c', 'cd cmd/etl_worker && gcloud --project=$PROJECT_ID app deploy --promote app-batch.yaml'
-#   ]
-#
-# - name: gcr.io/google.com/cloudsdktool/cloud-sdk
-#   id: "Delete non-serving appengine versions"
-#   args: [
-#     'bash', '-c', './delete-appengine-services.sh'
-#   ]
+ - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+   id: "Update annotator url environment variable in app-batch.yaml"
+   args: [
+     'bash', '-c',
+     "sed -i -e 's|{{ANNOTATOR_URL}}|$_ANNOTATOR_URL|' cmd/etl_worker/app-batch.yaml"
+   ]
+
+ - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+   id: "Deploy etl batch parser to AppEngine"
+   args: [
+     'bash', '-c', 'cd cmd/etl_worker && gcloud --project=$PROJECT_ID app deploy --promote app-batch.yaml'
+   ]
+
+ - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+   id: "Delete non-serving appengine versions"
+   args: [
+     'bash', '-c', './delete-appengine-services.sh'
+   ]

--- a/cmd/etl_worker/app-batch.yaml
+++ b/cmd/etl_worker/app-batch.yaml
@@ -27,7 +27,7 @@ automatic_scaling:
   # * for low capacity: 4, 12
   # * for high capacity: 20, 80
   min_num_instances: 20
-  max_num_instances: 80
+  max_num_instances: 40
   # Very long cool down period, to reduce the likelihood of tasks being truncated.
   cool_down_period_sec: 1800
   # We don't care much about latency, so a high utilization is desireable.

--- a/k8s/data-processing/deployments/parser.yml
+++ b/k8s/data-processing/deployments/parser.yml
@@ -4,7 +4,7 @@ metadata:
   name: etl-parser
   namespace: default
 spec:
-  replicas: 4
+  replicas: 6
   selector:
     matchLabels:
       # Used to match pre-existing pods that may be affected during updates.


### PR DESCRIPTION
The introduction of the tcpinfo v2 parser has [significantly slowed processing of the v2 pipeline][a]. This change increases the replicas from 4 to 6.

[a]: https://grafana.mlab-staging.measurementlab.net/d/UTgnK-jMz/pipeline-overview?orgId=1&from=now-7d&to=now&var-project=mlab-staging&var-PrometheusDS=Prometheus%20(mlab-staging)&var-LegacyDS=Data%20Proc%20(mlab-staging)&var-Gardener2_DS=Data%20Processing%20(mlab-staging)&var-states=Finishing&var-states=Processing&var-states2=complete&refresh=5m&viewPanel=54


This change also reduces the max number of batch pipeline instances from 80 to 40 and decreases the task queue rates by at least 50%. Typically, we would reduce v1 gardener throughput by updating the ["NUM_QUEUES"][nq] setting in the k8s config for those deployments, but we no longer deploy the v1 gardener system. By reducing the queue rates, we should accomplish the equivalent result. (but v1 gardener was notoriously difficult to performance tune).

[nq]: https://github.com/m-lab/etl-gardener/blob/master/k8s/data-processing-cluster/deployments/etl-gardener-ndt.yml#L62

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1070)
<!-- Reviewable:end -->
