### PR TITLE
Double parser replicas to process historical archive faster with tcpinfo

### DIFF
--- a/k8s/data-processing/deployments/parser.yml
+++ b/k8s/data-processing/deployments/parser.yml
@@ -4,7 +4,7 @@ metadata:
   name: etl-parser
   namespace: default
 spec:
-  replicas: 6
+  replicas: 8
   selector:
     matchLabels:
       # Used to match pre-existing pods that may be affected during updates.

--- a/k8s/data-processing/deployments/parser.yml
+++ b/k8s/data-processing/deployments/parser.yml
@@ -4,7 +4,7 @@ metadata:
   name: etl-parser
   namespace: default
 spec:
-  replicas: 4
+  replicas: 6
   selector:
     matchLabels:
       # Used to match pre-existing pods that may be affected during updates.


### PR DESCRIPTION
The introduction of the tcpinfo v2 parser has [significantly slowed processing of the v2 pipeline][a]. This change increases the replicas from 4 to 8.

[a]: https://grafana.mlab-staging.measurementlab.net/d/UTgnK-jMz/pipeline-overview?orgId=1&from=now-7d&to=now&var-project=mlab-staging&var-PrometheusDS=Prometheus%20(mlab-staging)&var-LegacyDS=Data%20Proc%20(mlab-staging)&var-Gardener2_DS=Data%20Processing%20(mlab-staging)&var-states=Finishing&var-states=Processing&var-states2=complete&refresh=5m&viewPanel=54

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1071)
<!-- Reviewable:end -->
