### PR TITLE
Export NullAnnotator for v2 parsers

### DIFF
--- a/factory/factory.go
+++ b/factory/factory.go
@@ -7,6 +7,7 @@ import (
 	v2 "github.com/m-lab/annotation-service/api/v2"
 
 	"github.com/m-lab/etl/etl"
+	"github.com/m-lab/etl/parser"
 	"github.com/m-lab/etl/row"
 )
 
@@ -59,7 +60,7 @@ type defaultAnnotatorFactory struct{}
 
 // Get implements AnnotatorFactory.Get
 func (ann *defaultAnnotatorFactory) Get(ctx context.Context, dp etl.DataPath) (v2.Annotator, etl.ProcessingError) {
-	return v2.GetAnnotator(etl.BatchAnnotatorURL), nil
+	return &parser.NullAnnotator{}, nil
 }
 
 // DefaultAnnotatorFactory returns the annotation service annotator.

--- a/parser/annotation.go
+++ b/parser/annotation.go
@@ -30,8 +30,11 @@ type AnnotationParser struct {
 	suffix string
 }
 
+// NullAnnotator mimicks the annotation-service API, and always returns an empty
+// result without any network connections.
 type NullAnnotator struct{}
 
+// GetAnnotations always returns an empty annotation result.
 func (ann *NullAnnotator) GetAnnotations(ctx context.Context, date time.Time, ips []string, info ...string) (*v2as.Response, error) {
 	return &v2as.Response{AnnotatorDate: time.Now(), Annotations: make(map[string]*api.Annotations, 0)}, nil
 }

--- a/parser/annotation.go
+++ b/parser/annotation.go
@@ -30,9 +30,9 @@ type AnnotationParser struct {
 	suffix string
 }
 
-type nullAnnotator struct{}
+type NullAnnotator struct{}
 
-func (ann *nullAnnotator) GetAnnotations(ctx context.Context, date time.Time, ips []string, info ...string) (*v2as.Response, error) {
+func (ann *NullAnnotator) GetAnnotations(ctx context.Context, date time.Time, ips []string, info ...string) (*v2as.Response, error) {
 	return &v2as.Response{AnnotatorDate: time.Now(), Annotations: make(map[string]*api.Annotations, 0)}, nil
 }
 
@@ -40,7 +40,7 @@ func (ann *nullAnnotator) GetAnnotations(ctx context.Context, date time.Time, ip
 func NewAnnotationParser(sink row.Sink, label, suffix string, ann v2as.Annotator) etl.Parser {
 	bufSize := etl.ANNOTATION.BQBufferSize()
 	if ann == nil {
-		ann = &nullAnnotator{}
+		ann = &NullAnnotator{}
 	}
 
 	return &AnnotationParser{

--- a/parser/hopannotation1.go
+++ b/parser/hopannotation1.go
@@ -30,7 +30,7 @@ type HopAnnotation1Parser struct {
 func NewHopAnnotation1Parser(sink row.Sink, table, suffix string, ann v2as.Annotator) etl.Parser {
 	bufSize := etl.HOPANNOTATION1.BQBufferSize()
 	if ann == nil {
-		ann = v2as.GetAnnotator(etl.BatchAnnotatorURL)
+		ann = &NullAnnotator{}
 	}
 
 	return &HopAnnotation1Parser{

--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -153,7 +153,7 @@ func NewNDTParser(ins etl.Inserter, annotator ...v2as.Annotator) *NDTParser {
 	if len(annotator) > 0 && annotator[0] != nil {
 		ann = annotator[0]
 	} else {
-		ann = v2as.GetAnnotator(etl.BatchAnnotatorURL)
+		ann = &NullAnnotator{}
 	}
 
 	return &NDTParser{Base: *NewBase(ins, bufSize, ann)}

--- a/parser/ndt5_result.go
+++ b/parser/ndt5_result.go
@@ -35,7 +35,7 @@ type NDT5ResultParser struct {
 func NewNDT5ResultParser(sink row.Sink, label, suffix string, ann v2as.Annotator) etl.Parser {
 	bufSize := etl.NDT5.BQBufferSize()
 	if ann == nil {
-		ann = &nullAnnotator{}
+		ann = &NullAnnotator{}
 	}
 
 	return &NDT5ResultParser{

--- a/parser/ndt7_result.go
+++ b/parser/ndt7_result.go
@@ -35,7 +35,7 @@ type NDT7ResultParser struct {
 func NewNDT7ResultParser(sink row.Sink, table, suffix string, ann v2as.Annotator) etl.Parser {
 	bufSize := etl.NDT7.BQBufferSize()
 	if ann == nil {
-		ann = v2as.GetAnnotator(etl.BatchAnnotatorURL)
+		ann = &NullAnnotator{}
 	}
 
 	return &NDT7ResultParser{

--- a/parser/pcap.go
+++ b/parser/pcap.go
@@ -128,7 +128,7 @@ type PCAPParser struct {
 func NewPCAPParser(sink row.Sink, table, suffix string, ann v2as.Annotator) etl.Parser {
 	bufSize := etl.PCAP.BQBufferSize()
 	if ann == nil {
-		ann = v2as.GetAnnotator(etl.BatchAnnotatorURL)
+		ann = &NullAnnotator{}
 	}
 
 	return &PCAPParser{

--- a/parser/pt.go
+++ b/parser/pt.go
@@ -368,7 +368,7 @@ func NewPTParser(ins etl.Inserter, ann ...v2as.Annotator) *PTParser {
 	if len(ann) > 0 && ann[0] != nil {
 		annotator = ann[0]
 	} else {
-		annotator = v2as.GetAnnotator(etl.BatchAnnotatorURL)
+		annotator = &NullAnnotator{}
 	}
 	return &PTParser{Base: *NewBase(ins, bufSize, annotator)}
 }

--- a/parser/scamper1.go
+++ b/parser/scamper1.go
@@ -34,7 +34,7 @@ type Scamper1Parser struct {
 func NewScamper1Parser(sink row.Sink, table, suffix string, ann v2as.Annotator) etl.Parser {
 	bufSize := etl.SCAMPER1.BQBufferSize()
 	if ann == nil {
-		ann = v2as.GetAnnotator(etl.BatchAnnotatorURL)
+		ann = &NullAnnotator{}
 	}
 
 	return &Scamper1Parser{

--- a/parser/ss.go
+++ b/parser/ss.go
@@ -36,7 +36,7 @@ func NewSSParser(ins etl.Inserter, ann v2as.Annotator) *SSParser {
 // TODO get rid of this hack.
 func NewDefaultSSParser(ins etl.Inserter) *SSParser {
 	bufSize := etl.SS.BQBufferSize()
-	return &SSParser{*NewBase(ins, bufSize, v2as.GetAnnotator(etl.BatchAnnotatorURL))}
+	return &SSParser{*NewBase(ins, bufSize, &NullAnnotator{})}
 }
 
 // ExtractLogtimeFromFilename extracts the log time.

--- a/parser/switch.go
+++ b/parser/switch.go
@@ -44,7 +44,7 @@ type SwitchParser struct {
 func NewSwitchParser(sink row.Sink, table, suffix string, ann v2as.Annotator) etl.Parser {
 	bufSize := etl.SW.BQBufferSize()
 	if ann == nil {
-		ann = v2as.GetAnnotator(etl.BatchAnnotatorURL)
+		ann = &NullAnnotator{}
 	}
 
 	return &SwitchParser{

--- a/parser/tcpinfo.go
+++ b/parser/tcpinfo.go
@@ -208,7 +208,7 @@ func (p *TCPInfoParser) ParseAndInsert(meta map[string]bigquery.Value, testName 
 func NewTCPInfoParser(sink row.Sink, table, suffix string, ann v2as.Annotator) *TCPInfoParser {
 	bufSize := etl.TCPINFO.BQBufferSize()
 	if ann == nil {
-		ann = &nullAnnotator{}
+		ann = &NullAnnotator{}
 	}
 
 	return &TCPInfoParser{


### PR DESCRIPTION
This change eliminates dependency on the annotation-service annotator by replacing changing the `DefaultAnnotatorFactory` to unconditionally return a `NullAnnotator` instance, now exported from the `parser` package.

Ultimately, the annotation call outs can be removed from the source entirely.

This change is part of:
* https://github.com/m-lab/etl/issues/1074

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1078)
<!-- Reviewable:end -->
