### PR TITLE
Remove live v1 annotation logic from data pipeline

### DIFF
--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -228,7 +228,6 @@ func toRunnable(obj *gcs.ObjectAttrs) active.Runnable {
 	}
 
 	taskFactory := worker.StandardTaskFactory{
-		// Annotator: factory.DefaultAnnotatorFactory(),
 		Sink:   sink,
 		Source: storage.GCSSourceFactory(c),
 	}

--- a/cmd/etl_worker/etl_worker.go
+++ b/cmd/etl_worker/etl_worker.go
@@ -228,9 +228,9 @@ func toRunnable(obj *gcs.ObjectAttrs) active.Runnable {
 	}
 
 	taskFactory := worker.StandardTaskFactory{
-		Annotator: factory.DefaultAnnotatorFactory(),
-		Sink:      sink,
-		Source:    storage.GCSSourceFactory(c),
+		// Annotator: factory.DefaultAnnotatorFactory(),
+		Sink:   sink,
+		Source: storage.GCSSourceFactory(c),
 	}
 	return &runnable{&taskFactory, *obj}
 }

--- a/parser/annotation.go
+++ b/parser/annotation.go
@@ -40,14 +40,10 @@ func (ann *NullAnnotator) GetAnnotations(ctx context.Context, date time.Time, ip
 }
 
 // NewAnnotationParser creates a new parser for annotation data.
-func NewAnnotationParser(sink row.Sink, label, suffix string, ann v2as.Annotator) etl.Parser {
+func NewAnnotationParser(sink row.Sink, label, suffix string) etl.Parser {
 	bufSize := etl.ANNOTATION.BQBufferSize()
-	if ann == nil {
-		ann = &NullAnnotator{}
-	}
-
 	return &AnnotationParser{
-		Base:   row.NewBase(label, sink, bufSize, ann),
+		Base:   row.NewBase(label, sink, bufSize),
 		table:  label,
 		suffix: suffix,
 	}

--- a/parser/annotation_test.go
+++ b/parser/annotation_test.go
@@ -36,7 +36,7 @@ func TestAnnotationParser_ParseAndInsert(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ins := newInMemorySink()
-			n := parser.NewAnnotationParser(ins, "test", "_suffix", &fakeAnnotator{})
+			n := parser.NewAnnotationParser(ins, "test", "_suffix")
 
 			data, err := ioutil.ReadFile("testdata/Annotation/" + tt.file)
 			rtx.Must(err, "failed to read test file")

--- a/parser/base.go
+++ b/parser/base.go
@@ -4,26 +4,19 @@ package parser
 // Probably should have Base implement Parser.
 
 import (
-	"context"
 	"errors"
 	"log"
 	"reflect"
-	"time"
-
-	"github.com/prometheus/client_golang/prometheus"
-
-	v2as "github.com/m-lab/annotation-service/api/v2"
 
 	"github.com/m-lab/etl/etl"
-	"github.com/m-lab/etl/metrics"
 	"github.com/m-lab/etl/row"
 )
 
 // Errors that may be returned by BaseRowBuffer functions.
 var (
-	ErrAnnotationError = errors.New("Annotation error")
+	ErrAnnotationError = errors.New("annotation error")
 	ErrNotAnnotatable  = errors.New("object does not implement Annotatable")
-	ErrRowNotPointer   = errors.New("Row should be a pointer type")
+	ErrRowNotPointer   = errors.New("row should be a pointer type")
 )
 
 // RowBuffer provides all basic functionality generally needed for buffering, annotating, and inserting
@@ -31,7 +24,6 @@ var (
 type RowBuffer struct {
 	bufferSize int
 	rows       []interface{} // Actually these are Annotatable, but we cast them later.
-	ann        v2as.Annotator
 }
 
 // AddRow simply inserts a row into the buffer.  Returns error if buffer is full.
@@ -61,140 +53,6 @@ func (buf *RowBuffer) TakeRows() []interface{} {
 	return res
 }
 
-// TODO update this to use local cache of high quality annotations.
-// label is used to label metrics and errors in GetAnnotations
-func (buf *RowBuffer) annotateServers(label string) error {
-	serverIPs := make(map[string]struct{})
-	logTime := time.Time{}
-	for i := range buf.rows {
-		r, ok := buf.rows[i].(row.Annotatable)
-		if !ok {
-			return ErrNotAnnotatable
-		}
-
-		// Only ask for the IP if it is non-empty.
-		ip := r.GetServerIP()
-		if ip != "" {
-			serverIPs[ip] = struct{}{}
-		}
-
-		if (logTime == time.Time{}) {
-			logTime = r.GetLogTime()
-		}
-	}
-
-	ipSlice := make([]string, 0, len(buf.rows))
-	for ip := range serverIPs {
-		ipSlice = append(ipSlice, ip)
-	}
-	if len(ipSlice) == 0 {
-		return nil
-	}
-	response, err := buf.ann.GetAnnotations(context.Background(), logTime, ipSlice, label)
-	if err != nil {
-		log.Println("error in server GetAnnotations: ", err)
-		metrics.AnnotationErrorCount.With(prometheus.
-			Labels{"source": "Server IP: RPC err in GetAnnotations."}).Inc()
-		return err
-	}
-	annMap := response.Annotations
-	if annMap == nil {
-		log.Println("empty server annotation response")
-		metrics.AnnotationErrorCount.With(prometheus.
-			Labels{"source": "Server IP: empty response"}).Inc()
-		return ErrAnnotationError
-	}
-
-	for i := range buf.rows {
-		r, ok := buf.rows[i].(row.Annotatable)
-		if !ok {
-			err = ErrNotAnnotatable
-		} else {
-			ip := r.GetServerIP()
-			if ip != "" {
-				ann, ok := annMap[ip]
-				if ok {
-					r.AnnotateServer(ann)
-				}
-			}
-		}
-	}
-
-	return err
-}
-
-// label is used to label metrics and errors in GetAnnotations
-func (buf *RowBuffer) annotateClients(label string) error {
-	ipSlice := make([]string, 0, 2*len(buf.rows)) // This may be inadequate, but its a reasonable start.
-	logTime := time.Time{}
-	for i := range buf.rows {
-		r, ok := buf.rows[i].(row.Annotatable)
-		if !ok {
-			return ErrNotAnnotatable
-		}
-		ipSlice = append(ipSlice, r.GetClientIPs()...)
-		if (logTime == time.Time{}) {
-			logTime = r.GetLogTime()
-		}
-	}
-
-	response, err := buf.ann.GetAnnotations(context.Background(), logTime, ipSlice, label)
-	if err != nil {
-		log.Println("error in client GetAnnotations: ", err)
-		metrics.AnnotationErrorCount.With(prometheus.
-			Labels{"source": "Client IP: RPC err in GetAnnotations."}).Inc()
-		return err
-	}
-	annMap := response.Annotations
-	if annMap == nil {
-		log.Println("empty client annotation response")
-		metrics.AnnotationErrorCount.With(prometheus.
-			Labels{"source": "Client IP: empty response"}).Inc()
-		return ErrAnnotationError
-	}
-
-	for i := range buf.rows {
-		r, ok := buf.rows[i].(row.Annotatable)
-		if !ok {
-			err = ErrNotAnnotatable
-		} else {
-			// Will not error because we check for nil annMap above.
-			r.AnnotateClients(annMap)
-		}
-	}
-
-	return err
-}
-
-// Annotate fetches annotations for all rows in the buffer.
-// Not thread-safe.  Should only be called by owning thread.
-// TODO should convert this to operate on the rows, instead of the buffer.
-// Then we can do it after TakeRows().
-func (buf *RowBuffer) Annotate(metricLabel string) error {
-	return nil
-	metrics.WorkerState.WithLabelValues(metricLabel, "annotate").Inc()
-	defer metrics.WorkerState.WithLabelValues(metricLabel, "annotate").Dec()
-	if len(buf.rows) == 0 {
-		return nil
-	}
-	start := time.Now()
-	defer metrics.AnnotationTimeSummary.With(prometheus.Labels{"test_type": metricLabel}).Observe(float64(time.Since(start).Nanoseconds()))
-
-	// TODO Consider doing these in parallel?
-	clientErr := buf.annotateClients(metricLabel)
-	serverErr := buf.annotateServers(metricLabel)
-
-	if clientErr != nil {
-		return clientErr
-	}
-
-	if serverErr != nil {
-		return serverErr
-	}
-
-	return nil
-}
-
 // Base provides common parser functionality.
 type Base struct {
 	etl.Inserter
@@ -222,31 +80,3 @@ func (pb *Base) Flush() error {
 	pb.Put(rows)
 	return pb.Inserter.Flush()
 }
-
-/*
-// AnnotateAndFlush annotates the rows in the buffer, and synchronously
-// pushes them through Inserter.
-func (pb *Base) AnnotateAndFlush(metricLabel string) error {
-	annErr := pb.Annotate(metricLabel)
-	flushErr := pb.Flush()
-
-	if flushErr != nil {
-		return flushErr
-	}
-	return annErr
-}
-
-// AnnotateAndPutAsync annotates the rows in the buffer (synchronously),
-// and asynchronously pushes them to the Inserter.
-func (pb *Base) AnnotateAndPutAsync(metricLabel string) error {
-	annErr := pb.Annotate(metricLabel)
-	rows := pb.TakeRows()
-	pb.PutAsync(rows)
-	return annErr
-}
-*/
-/*func (pb *Base) PutAsync() {
-	rows := pb.TakeRows()
-	pb.Inserter.PutAsync(rows)
-}
-*/

--- a/parser/base.go
+++ b/parser/base.go
@@ -171,6 +171,7 @@ func (buf *RowBuffer) annotateClients(label string) error {
 // TODO should convert this to operate on the rows, instead of the buffer.
 // Then we can do it after TakeRows().
 func (buf *RowBuffer) Annotate(metricLabel string) error {
+	return nil
 	metrics.WorkerState.WithLabelValues(metricLabel, "annotate").Inc()
 	defer metrics.WorkerState.WithLabelValues(metricLabel, "annotate").Dec()
 	if len(buf.rows) == 0 {
@@ -201,8 +202,11 @@ type Base struct {
 }
 
 // NewBase creates a new parser.Base.  This will generally be embedded in a type specific parser.
-func NewBase(ins etl.Inserter, bufSize int, ann v2as.Annotator) *Base {
-	buf := RowBuffer{bufSize, make([]interface{}, 0, bufSize), ann}
+func NewBase(ins etl.Inserter, bufSize int) *Base {
+	buf := RowBuffer{
+		bufferSize: bufSize,
+		rows:       make([]interface{}, 0, bufSize),
+	}
 	return &Base{ins, buf}
 }
 
@@ -219,6 +223,7 @@ func (pb *Base) Flush() error {
 	return pb.Inserter.Flush()
 }
 
+/*
 // AnnotateAndFlush annotates the rows in the buffer, and synchronously
 // pushes them through Inserter.
 func (pb *Base) AnnotateAndFlush(metricLabel string) error {
@@ -239,3 +244,9 @@ func (pb *Base) AnnotateAndPutAsync(metricLabel string) error {
 	pb.PutAsync(rows)
 	return annErr
 }
+*/
+/*func (pb *Base) PutAsync() {
+	rows := pb.TakeRows()
+	pb.Inserter.PutAsync(rows)
+}
+*/

--- a/parser/base_test.go
+++ b/parser/base_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/m-lab/annotation-service/api"
-	v2as "github.com/m-lab/annotation-service/api/v2"
 
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/parser"
@@ -75,7 +74,7 @@ func TestBase(t *testing.T) {
 		ts.Close()
 	}()
 
-	b := parser.NewBase(ins, 10, v2as.GetAnnotator(ts.URL))
+	b := parser.NewBase(ins, 10)
 
 	err := b.AddRow(&Row{"1.2.3.4", "4.3.2.1", nil, nil})
 	if err != nil {
@@ -88,13 +87,15 @@ func TestBase(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = b.Annotate("tablename")
-	if err != nil {
-		t.Error(err)
-	}
-	if callCount != 2 {
-		t.Error("Callcount should be 2:", callCount)
-	}
+	/*
+		err = b.Annotate("tablename")
+		if err != nil {
+			t.Error(err)
+		}
+		if callCount != 2 {
+			t.Error("Callcount should be 2:", callCount)
+		}
+	*/
 	b.Flush()
 	if ins.Committed() != 2 {
 		t.Fatalf("Expected %d, Got %d.", 2, ins.Committed())
@@ -103,13 +104,15 @@ func TestBase(t *testing.T) {
 	if len(ins.data) < 1 {
 		t.Fatal("Should have at least one inserted row")
 	}
-	inserted := ins.data[0].(*Row)
-	if inserted.clientAnn == nil || inserted.clientAnn.Geo.PostalCode != "10583" {
-		t.Error("Failed client annotation")
-	}
-	if inserted.serverAnn == nil || inserted.serverAnn.Geo.PostalCode != "10584" {
-		t.Error("Failed server annotation")
-	}
+	/*
+		inserted := ins.data[0].(*Row)
+		if inserted.clientAnn == nil || inserted.clientAnn.Geo.PostalCode != "10583" {
+			t.Error("Failed client annotation")
+		}
+		if inserted.serverAnn == nil || inserted.serverAnn.Geo.PostalCode != "10584" {
+			t.Error("Failed server annotation")
+		}
+	*/
 
 	err = b.AddRow(&BadRow{})
 	if err != parser.ErrNotAnnotatable {
@@ -140,7 +143,7 @@ func TestAsyncPut(t *testing.T) {
 		ts.Close()
 	}()
 
-	b := parser.NewBase(ins, 1, v2as.GetAnnotator(ts.URL))
+	b := parser.NewBase(ins, 1)
 
 	err := b.AddRow(&Row{"1.2.3.4", "4.3.2.1", nil, nil})
 	if err != nil {
@@ -156,11 +159,7 @@ func TestAsyncPut(t *testing.T) {
 		t.Error("Should be full buffer error:", err)
 	}
 
-	err = b.AnnotateAndPutAsync("foobar")
-	if err != nil {
-		t.Error(err)
-	}
-
+	b.PutAsync(b.TakeRows())
 	b.Inserter.Flush() // To synchronize after the PutAsync.
 
 	if ins.Committed() != 1 {
@@ -170,13 +169,15 @@ func TestAsyncPut(t *testing.T) {
 	if len(ins.data) < 1 {
 		t.Fatal("Should have at least one inserted row")
 	}
-	inserted := ins.data[0].(*Row)
-	if inserted.clientAnn == nil || inserted.clientAnn.Geo.PostalCode != "10583" {
-		t.Error("Failed client annotation")
-	}
-	if inserted.serverAnn == nil || inserted.serverAnn.Geo.PostalCode != "10584" {
-		t.Error("Failed server annotation")
-	}
+	/*
+		inserted := ins.data[0].(*Row)
+		if inserted.clientAnn == nil || inserted.clientAnn.Geo.PostalCode != "10583" {
+			t.Error("Failed client annotation")
+		}
+		if inserted.serverAnn == nil || inserted.serverAnn.Geo.PostalCode != "10584" {
+			t.Error("Failed server annotation")
+		}
+	*/
 }
 
 func TestEmptyAnnotations(t *testing.T) {
@@ -195,19 +196,21 @@ func TestEmptyAnnotations(t *testing.T) {
 		ts.Close()
 	}()
 
-	b := parser.NewBase(ins, 10, v2as.GetAnnotator(ts.URL))
+	b := parser.NewBase(ins, 10)
 
 	err := b.AddRow(&Row{"1.2.3.4", "4.3.2.1", nil, nil})
 	if err != nil {
 		t.Error(err)
 	}
-	err = b.Annotate("tablename")
-	if err != nil {
-		t.Error(err)
-	}
-	if callCount != 2 {
-		t.Error("Callcount should be 2:", callCount)
-	}
+	/*
+		err = b.Annotate("tablename")
+		if err != nil {
+			t.Error(err)
+		}
+		if callCount != 2 {
+			t.Error("Callcount should be 2:", callCount)
+		}
+	*/
 	b.Flush()
 	if ins.Committed() != 1 {
 		t.Fatalf("Expected %d, Got %d.", 1, ins.Committed())

--- a/parser/hopannotation1.go
+++ b/parser/hopannotation1.go
@@ -7,7 +7,6 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/civil"
-	v2as "github.com/m-lab/annotation-service/api/v2"
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/metrics"
 	"github.com/m-lab/etl/row"
@@ -27,14 +26,10 @@ type HopAnnotation1Parser struct {
 }
 
 // NewHopAnnotation1Parser returns a new parser for the HopAnnotation1 archives.
-func NewHopAnnotation1Parser(sink row.Sink, table, suffix string, ann v2as.Annotator) etl.Parser {
+func NewHopAnnotation1Parser(sink row.Sink, table, suffix string) etl.Parser {
 	bufSize := etl.HOPANNOTATION1.BQBufferSize()
-	if ann == nil {
-		ann = &NullAnnotator{}
-	}
-
 	return &HopAnnotation1Parser{
-		Base:   row.NewBase(table, sink, bufSize, ann),
+		Base:   row.NewBase(table, sink, bufSize),
 		table:  table,
 		suffix: suffix,
 	}

--- a/parser/hopannotation1_test.go
+++ b/parser/hopannotation1_test.go
@@ -24,7 +24,7 @@ const (
 
 func TestHopAnnotation1Parser_ParseAndInsert(t *testing.T) {
 	ins := newInMemorySink()
-	n := parser.NewHopAnnotation1Parser(ins, "test", "_suffix", &fakeAnnotator{})
+	n := parser.NewHopAnnotation1Parser(ins, "test", "_suffix")
 
 	data, err := ioutil.ReadFile(path.Join("testdata/HopAnnotation1/", hopAnnotation1Filename))
 	rtx.Must(err, "failed to load test file")

--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -147,17 +147,8 @@ type NDTParser struct {
 // NewNDTParser returns a new NDT parser.
 // Caller may include an annotator.  If not provided, the default annotator is used.
 // TODO - clean up the vararg annotator hack once it is standard in all parsers.
-func NewNDTParser(ins etl.Inserter, annotator ...v2as.Annotator) *NDTParser {
+func NewNDTParser(ins etl.Inserter) *NDTParser {
 	bufSize := etl.NDT.BQBufferSize()
-	/*
-		var ann v2as.Annotator
-		if len(annotator) > 0 && annotator[0] != nil {
-			ann = annotator[0]
-		} else {
-			ann = &NullAnnotator{}
-		}
-	*/
-
 	return &NDTParser{Base: *NewBase(ins, bufSize)}
 }
 
@@ -181,7 +172,7 @@ func (n *NDTParser) Flush() error {
 		n.processGroup()
 	}
 
-	return n.Base.Flush() // (n.TableBase())
+	return n.Base.Flush()
 }
 
 // TableName returns the base of the bq table inserter target.

--- a/parser/ndt.go
+++ b/parser/ndt.go
@@ -145,8 +145,6 @@ type NDTParser struct {
 }
 
 // NewNDTParser returns a new NDT parser.
-// Caller may include an annotator.  If not provided, the default annotator is used.
-// TODO - clean up the vararg annotator hack once it is standard in all parsers.
 func NewNDTParser(ins etl.Inserter) *NDTParser {
 	bufSize := etl.NDT.BQBufferSize()
 	return &NDTParser{Base: *NewBase(ins, bufSize)}
@@ -614,7 +612,6 @@ func (n *NDTParser) getAndInsertValues(test *fileInfoAndData, testType string) {
 	ndtTest := NDTTest{results}
 	err = n.Base.AddRow(ndtTest)
 	if err == etl.ErrBufferFull {
-		// Ignore annotation errors.  They are counted and logged elsewhere.
 		n.PutAsync(n.TakeRows())
 		err = n.Base.AddRow(ndtTest)
 	}

--- a/parser/ndt5_result.go
+++ b/parser/ndt5_result.go
@@ -12,8 +12,6 @@ import (
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/civil"
 
-	v2as "github.com/m-lab/annotation-service/api/v2"
-
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/metrics"
 	"github.com/m-lab/etl/row"
@@ -32,14 +30,10 @@ type NDT5ResultParser struct {
 }
 
 // NewNDT5ResultParser returns a parser for NDT5Result archives.
-func NewNDT5ResultParser(sink row.Sink, label, suffix string, ann v2as.Annotator) etl.Parser {
+func NewNDT5ResultParser(sink row.Sink, label, suffix string) etl.Parser {
 	bufSize := etl.NDT5.BQBufferSize()
-	if ann == nil {
-		ann = &NullAnnotator{}
-	}
-
 	return &NDT5ResultParser{
-		Base:   row.NewBase(label, sink, bufSize, ann),
+		Base:   row.NewBase(label, sink, bufSize),
 		table:  label,
 		suffix: suffix,
 	}

--- a/parser/ndt5_result_test.go
+++ b/parser/ndt5_result_test.go
@@ -39,7 +39,7 @@ func TestNDT5ResultParser_ParseAndInsert(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ins := newInMemorySink()
-			n := parser.NewNDT5ResultParser(ins, "test", "_suffix", &fakeAnnotator{})
+			n := parser.NewNDT5ResultParser(ins, "test", "_suffix")
 
 			resultData, err := ioutil.ReadFile(`testdata/NDT5Result/` + tt.testName)
 			if err != nil {

--- a/parser/ndt7_result.go
+++ b/parser/ndt7_result.go
@@ -11,7 +11,6 @@ import (
 	"cloud.google.com/go/bigquery"
 
 	"cloud.google.com/go/civil"
-	v2as "github.com/m-lab/annotation-service/api/v2"
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/metrics"
 	"github.com/m-lab/etl/row"
@@ -32,14 +31,10 @@ type NDT7ResultParser struct {
 }
 
 // NewNDT7ResultParser returns a parser for NDT7Result archives.
-func NewNDT7ResultParser(sink row.Sink, table, suffix string, ann v2as.Annotator) etl.Parser {
+func NewNDT7ResultParser(sink row.Sink, table, suffix string) etl.Parser {
 	bufSize := etl.NDT7.BQBufferSize()
-	if ann == nil {
-		ann = &NullAnnotator{}
-	}
-
 	return &NDT7ResultParser{
-		Base:   row.NewBase(table, sink, bufSize, ann),
+		Base:   row.NewBase(table, sink, bufSize),
 		table:  table,
 		suffix: suffix,
 	}

--- a/parser/ndt7_result_test.go
+++ b/parser/ndt7_result_test.go
@@ -32,7 +32,7 @@ func TestNDT7ResultParser_ParseAndInsert(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ins := newInMemorySink()
-			n := parser.NewNDT7ResultParser(ins, "test", "_suffix", &fakeAnnotator{})
+			n := parser.NewNDT7ResultParser(ins, "test", "_suffix")
 
 			resultData, err := ioutil.ReadFile(`testdata/NDT7Result/` + tt.testName)
 			if err != nil {

--- a/parser/ndt_test.go
+++ b/parser/ndt_test.go
@@ -3,8 +3,6 @@ package parser_test
 import (
 	"fmt"
 	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"cloud.google.com/go/bigquery"
@@ -111,18 +109,7 @@ func TestNDTParser(t *testing.T) {
 	// Load test data.
 	ins := newInMemoryInserter()
 
-	// Completely fake annotation data.
-	responseJSON := `{"AnnotatorDate":"2018-12-05T00:00:00Z",
-		"Annotations":{
-		   "45.56.98.222":{"Geo":{"postal_code":"45569", "latitude": 1.0, "longitude": 2.0}, "Network":{"ASName":"Fake Client ISP", "ASNumber": 123, "Systems":[{"ASNs":[123]}]}},
-		   "213.208.152.37":{"Geo":{"postal_code":"21320", "latitude": 3.0, "longitude": 4.0}, "Network":{"ASName":"Fake Server ISP", "ASNumber": 456, "CIDR": "213.208.152.0/26", "Systems":[{"ASNs":[456]}]}}
-	   }}`
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, responseJSON)
-	}))
-	defer ts.Close()
-
-	n := parser.NewNDTParser(ins) // , v2as.GetAnnotator(ts.URL))
+	n := parser.NewNDTParser(ins)
 
 	// TODO(prod) - why are so many of the tests to this endpoint and a few others?
 	// A: because this is EB, which runs all the health tests.
@@ -184,42 +171,6 @@ func TestNDTParser(t *testing.T) {
 		"id": "nYjSCZhB0EfQPChl2tT8Fg",
 		"connection_spec": schema.Web100ValueMap{
 			"server_hostname": "mlab3.vie01.measurement-lab.org",
-			/*
-				"client": schema.Web100ValueMap{
-					"network": schema.Web100ValueMap{"asn": int64(123)},
-				},
-				"server": schema.Web100ValueMap{
-					"network":   schema.Web100ValueMap{"asn": int64(456)},
-					"iata_code": "VIE",
-				},
-			*/
-			/*
-				"ClientX": schema.Web100ValueMap{
-					"Network": schema.Web100ValueMap{
-						"ASName":   "Fake Client ISP",
-						"ASNumber": int64(123),
-						"Missing":  false,
-					},
-					"Geo": schema.Web100ValueMap{
-						"Latitude":  1.0,
-						"Longitude": 2.0,
-					},
-				},
-				"ServerX": schema.Web100ValueMap{
-					"Site":    "vie01",
-					"Machine": "mlab3",
-					"Network": schema.Web100ValueMap{
-						"ASName":   "Fake Server ISP",
-						"ASNumber": int64(456),
-						"CIDR":     "213.208.152.0/26",
-						"Missing":  false,
-					},
-					"Geo": schema.Web100ValueMap{
-						"Latitude":  3.0,
-						"Longitude": 4.0,
-					},
-				},
-			*/
 		},
 		"web100_log_entry": schema.Web100ValueMap{
 			"version": "2.5.27 201001301335 net100",

--- a/parser/ndt_test.go
+++ b/parser/ndt_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/go-test/deep"
 	"github.com/kr/pretty"
 
-	v2as "github.com/m-lab/annotation-service/api/v2"
-
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/parser"
 	"github.com/m-lab/etl/row"
@@ -124,7 +122,7 @@ func TestNDTParser(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	n := parser.NewNDTParser(ins, v2as.GetAnnotator(ts.URL))
+	n := parser.NewNDTParser(ins) // , v2as.GetAnnotator(ts.URL))
 
 	// TODO(prod) - why are so many of the tests to this endpoint and a few others?
 	// A: because this is EB, which runs all the health tests.
@@ -186,38 +184,42 @@ func TestNDTParser(t *testing.T) {
 		"id": "nYjSCZhB0EfQPChl2tT8Fg",
 		"connection_spec": schema.Web100ValueMap{
 			"server_hostname": "mlab3.vie01.measurement-lab.org",
-			"client": schema.Web100ValueMap{
-				"network": schema.Web100ValueMap{"asn": int64(123)},
-			},
-			"server": schema.Web100ValueMap{
-				"network":   schema.Web100ValueMap{"asn": int64(456)},
-				"iata_code": "VIE",
-			},
-			"ClientX": schema.Web100ValueMap{
-				"Network": schema.Web100ValueMap{
-					"ASName":   "Fake Client ISP",
-					"ASNumber": int64(123),
-					"Missing":  false,
+			/*
+				"client": schema.Web100ValueMap{
+					"network": schema.Web100ValueMap{"asn": int64(123)},
 				},
-				"Geo": schema.Web100ValueMap{
-					"Latitude":  1.0,
-					"Longitude": 2.0,
+				"server": schema.Web100ValueMap{
+					"network":   schema.Web100ValueMap{"asn": int64(456)},
+					"iata_code": "VIE",
 				},
-			},
-			"ServerX": schema.Web100ValueMap{
-				"Site":    "vie01",
-				"Machine": "mlab3",
-				"Network": schema.Web100ValueMap{
-					"ASName":   "Fake Server ISP",
-					"ASNumber": int64(456),
-					"CIDR":     "213.208.152.0/26",
-					"Missing":  false,
+			*/
+			/*
+				"ClientX": schema.Web100ValueMap{
+					"Network": schema.Web100ValueMap{
+						"ASName":   "Fake Client ISP",
+						"ASNumber": int64(123),
+						"Missing":  false,
+					},
+					"Geo": schema.Web100ValueMap{
+						"Latitude":  1.0,
+						"Longitude": 2.0,
+					},
 				},
-				"Geo": schema.Web100ValueMap{
-					"Latitude":  3.0,
-					"Longitude": 4.0,
+				"ServerX": schema.Web100ValueMap{
+					"Site":    "vie01",
+					"Machine": "mlab3",
+					"Network": schema.Web100ValueMap{
+						"ASName":   "Fake Server ISP",
+						"ASNumber": int64(456),
+						"CIDR":     "213.208.152.0/26",
+						"Missing":  false,
+					},
+					"Geo": schema.Web100ValueMap{
+						"Latitude":  3.0,
+						"Longitude": 4.0,
+					},
 				},
-			},
+			*/
 		},
 		"web100_log_entry": schema.Web100ValueMap{
 			"version": "2.5.27 201001301335 net100",

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -86,8 +86,8 @@ func GetHopID(cycleStartTime float64, hostname string, address string) string {
 	return fmt.Sprintf("%s_%s_%s", date, hostname, address)
 }
 
-// NewSinkParser creates an appropriate parser for a given data type.
-// Eventually all datatypes will use this instead of NewParser.
+// NewSinkParser creates a parser for the given data type.
+// NewSinkParser should only support datatypes that use "standard column" schemas.
 func NewSinkParser(dt etl.DataType, sink row.Sink, table string) etl.Parser {
 	switch dt {
 	case etl.ANNOTATION:

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -11,8 +11,6 @@ import (
 
 	"cloud.google.com/go/bigquery"
 
-	"github.com/m-lab/annotation-service/api/v2"
-
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/metrics"
 	"github.com/m-lab/etl/row"
@@ -90,39 +88,24 @@ func GetHopID(cycleStartTime float64, hostname string, address string) string {
 
 // NewSinkParser creates an appropriate parser for a given data type.
 // Eventually all datatypes will use this instead of NewParser.
-func NewSinkParser(dt etl.DataType, sink row.Sink, table string, ann api.Annotator) etl.Parser {
+func NewSinkParser(dt etl.DataType, sink row.Sink, table string) etl.Parser {
 	switch dt {
 	case etl.ANNOTATION:
-		return NewAnnotationParser(sink, table, "", ann)
+		return NewAnnotationParser(sink, table, "")
 	case etl.HOPANNOTATION1:
-		return NewHopAnnotation1Parser(sink, table, "", ann)
+		return NewHopAnnotation1Parser(sink, table, "")
 	case etl.NDT5:
-		return NewNDT5ResultParser(sink, table, "", ann)
+		return NewNDT5ResultParser(sink, table, "")
 	case etl.NDT7:
-		return NewNDT7ResultParser(sink, table, "", ann)
+		return NewNDT7ResultParser(sink, table, "")
 	case etl.TCPINFO:
-		return NewTCPInfoParser(sink, table, "", ann)
+		return NewTCPInfoParser(sink, table, "")
 	case etl.PCAP:
-		return NewPCAPParser(sink, table, "", ann)
+		return NewPCAPParser(sink, table, "")
 	case etl.SCAMPER1:
-		return NewScamper1Parser(sink, table, "", ann)
+		return NewScamper1Parser(sink, table, "")
 	case etl.SW:
-		return NewSwitchParser(sink, table, "", ann)
-	default:
-		return nil
-	}
-}
-
-// NewParser creates an appropriate parser for a given data type.
-// DEPRECATED - parsers should migrate to use NewSinkParser.
-func NewParser(dt etl.DataType, ins etl.Inserter) etl.Parser {
-	switch dt {
-	case etl.NDT:
-		return NewNDTParser(ins)
-	case etl.SS:
-		return NewDefaultSSParser(ins) // TODO fix this hack.
-	case etl.PT:
-		return NewPTParser(ins)
+		return NewSwitchParser(sink, table, "")
 	default:
 		return nil
 	}

--- a/parser/pcap.go
+++ b/parser/pcap.go
@@ -14,7 +14,6 @@ import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcapgo"
-	v2as "github.com/m-lab/annotation-service/api/v2"
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/metrics"
 	"github.com/m-lab/etl/row"
@@ -125,14 +124,10 @@ type PCAPParser struct {
 }
 
 // NewPCAPParser returns a new parser for PCAP archives.
-func NewPCAPParser(sink row.Sink, table, suffix string, ann v2as.Annotator) etl.Parser {
+func NewPCAPParser(sink row.Sink, table, suffix string) etl.Parser {
 	bufSize := etl.PCAP.BQBufferSize()
-	if ann == nil {
-		ann = &NullAnnotator{}
-	}
-
 	return &PCAPParser{
-		Base:   row.NewBase(table, sink, bufSize, ann),
+		Base:   row.NewBase(table, sink, bufSize),
 		table:  table,
 		suffix: suffix,
 	}

--- a/parser/pcap_test.go
+++ b/parser/pcap_test.go
@@ -24,7 +24,7 @@ const (
 
 func TestPCAPParser_ParseAndInsert(t *testing.T) {
 	ins := newInMemorySink()
-	n := parser.NewPCAPParser(ins, "test", "_suffix", &fakeAnnotator{})
+	n := parser.NewPCAPParser(ins, "test", "_suffix")
 
 	data, err := ioutil.ReadFile(path.Join("testdata/PCAP/", pcapFilename))
 	rtx.Must(err, "failed to load test file")

--- a/parser/pt.go
+++ b/parser/pt.go
@@ -17,7 +17,6 @@ import (
 	"cloud.google.com/go/bigquery"
 
 	"github.com/google/go-jsonnet"
-	v2as "github.com/m-lab/annotation-service/api/v2"
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/metrics"
 	"github.com/m-lab/etl/schema"
@@ -362,16 +361,8 @@ const IPv4_AF int32 = 2
 const IPv6_AF int32 = 10
 const PTBufferSize int = 2
 
-func NewPTParser(ins etl.Inserter, ann ...v2as.Annotator) *PTParser {
+func NewPTParser(ins etl.Inserter) *PTParser {
 	bufSize := etl.PT.BQBufferSize()
-	/*
-		var annotator v2as.Annotator
-		if len(ann) > 0 && ann[0] != nil {
-			annotator = ann[0]
-		} else {
-			annotator = &NullAnnotator{}
-		}
-	*/
 	return &PTParser{Base: *NewBase(ins, bufSize)}
 }
 
@@ -525,7 +516,6 @@ func (pt *PTParser) InsertOneTest(oneTest cachedPTData) {
 	err := pt.AddRow(&ptTest)
 	if err == etl.ErrBufferFull {
 		// Flush asynchronously, to improve throughput.
-		pt.Annotate(pt.TableName())
 		pt.PutAsync(pt.TakeRows())
 		pt.AddRow(&ptTest)
 	}
@@ -543,7 +533,6 @@ func (pt *PTParser) ProcessLastTests() error {
 
 func (pt *PTParser) Flush() error {
 	pt.ProcessLastTests()
-	pt.Annotate(pt.TableName())
 	pt.Put(pt.TakeRows())
 	return pt.Inserter.Flush()
 }
@@ -614,7 +603,6 @@ func (pt *PTParser) ParseAndInsert(meta map[string]bigquery.Value, testName stri
 			err := pt.AddRow(&ptTest)
 			if err == etl.ErrBufferFull {
 				// Flush asynchronously, to improve throughput.
-				pt.Annotate(pt.TableName())
 				pt.PutAsync(pt.TakeRows())
 				pt.AddRow(&ptTest)
 			}

--- a/parser/pt.go
+++ b/parser/pt.go
@@ -364,13 +364,15 @@ const PTBufferSize int = 2
 
 func NewPTParser(ins etl.Inserter, ann ...v2as.Annotator) *PTParser {
 	bufSize := etl.PT.BQBufferSize()
-	var annotator v2as.Annotator
-	if len(ann) > 0 && ann[0] != nil {
-		annotator = ann[0]
-	} else {
-		annotator = &NullAnnotator{}
-	}
-	return &PTParser{Base: *NewBase(ins, bufSize, annotator)}
+	/*
+		var annotator v2as.Annotator
+		if len(ann) > 0 && ann[0] != nil {
+			annotator = ann[0]
+		} else {
+			annotator = &NullAnnotator{}
+		}
+	*/
+	return &PTParser{Base: *NewBase(ins, bufSize)}
 }
 
 // ProcessAllNodes take the array of the Nodes, and generate one ScamperHop entry from each node.

--- a/parser/pt_test.go
+++ b/parser/pt_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
-	"github.com/m-lab/annotation-service/api"
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/parser"
 	"github.com/m-lab/etl/schema"
@@ -257,38 +256,8 @@ func TestParseLegacyFormatData(t *testing.T) {
 }
 
 func TestParseJSONL(t *testing.T) {
-	m := map[string]*api.Annotations{
-		"91.213.30.229": &api.Annotations{
-			Geo: &api.GeolocationIP{
-				ContinentCode: "NA",
-				CountryCode:   "US",
-				Latitude:      1.0,
-				Longitude:     2.0,
-			},
-			Network: &api.ASData{
-				ASNumber: 1234,
-				Systems: []api.System{
-					{ASNs: []uint32{1234}},
-				},
-			},
-		},
-		"91.169.126.135": &api.Annotations{
-			Geo: &api.GeolocationIP{
-				ContinentCode: "EU",
-				CountryCode:   "DE",
-				Latitude:      3.0,
-				Longitude:     4.0,
-			},
-			Network: &api.ASData{
-				ASNumber: 4321,
-				Systems: []api.System{
-					{ASNs: []uint32{4321}},
-				},
-			},
-		},
-	}
 	ins := newInMemoryInserter()
-	pt := parser.NewPTParser(ins, newFakeAnnotator(m))
+	pt := parser.NewPTParser(ins)
 
 	filename := "testdata/PT/20190927T070859Z_ndt-qtfh8_1565996043_0000000000003B64.jsonl"
 	rawData, err := ioutil.ReadFile(filename)
@@ -323,20 +292,6 @@ func TestParseJSONL(t *testing.T) {
 	if ptTest.UUID != "ndt-qtfh8_1565996043_0000000000003B64" {
 		t.Fatalf("Wrong UUID; got %q, want %q", ptTest.UUID, "ndt-qtfh8_1565996043_0000000000003B64")
 	}
-
-	/*
-		// Verify the client and server annotations match.
-		cx := v2.ConvertAnnotationsToClientAnnotations(m["91.169.126.135"])
-		if diff := deep.Equal(&ptTest.ClientX, cx); diff != nil {
-			t.Errorf("ClientX annotation does not match; %#v", diff)
-		}
-		sx := v2.ConvertAnnotationsToServerAnnotations(m["91.213.30.229"])
-		sx.Site = "nuq07"
-		sx.Machine = "mlab2"
-		if diff := deep.Equal(&ptTest.ServerX, sx); diff != nil {
-			t.Errorf("ServerX annotation does not match; %#v", diff)
-		}
-	*/
 }
 
 func TestParse(t *testing.T) {
@@ -398,37 +353,7 @@ func TestParse(t *testing.T) {
 
 func TestAnnotateAndPutAsync(t *testing.T) {
 	ins := newInMemoryInserter()
-	m := map[string]*api.Annotations{
-		"172.17.94.34": &api.Annotations{
-			Geo: &api.GeolocationIP{
-				ContinentCode: "NA",
-				CountryCode:   "US",
-				Latitude:      1.0,
-				Longitude:     2.0,
-			},
-			Network: &api.ASData{
-				ASNumber: 1234,
-				Systems: []api.System{
-					{ASNs: []uint32{1234}},
-				},
-			},
-		},
-		"74.125.224.100": &api.Annotations{
-			Geo: &api.GeolocationIP{
-				ContinentCode: "EU",
-				CountryCode:   "DE",
-				Latitude:      3.0,
-				Longitude:     4.0,
-			},
-			Network: &api.ASData{
-				ASNumber: 4321,
-				Systems: []api.System{
-					{ASNs: []uint32{4321}},
-				},
-			},
-		},
-	}
-	pt := parser.NewPTParser(ins, newFakeAnnotator(m))
+	pt := parser.NewPTParser(ins)
 	rawData, err := ioutil.ReadFile("testdata/PT/20170320T23:53:10Z-172.17.94.34-33456-74.125.224.100-33457.paris")
 	if err != nil {
 		t.Fatalf("cannot read testdata.")
@@ -454,57 +379,11 @@ func TestAnnotateAndPutAsync(t *testing.T) {
 	if ptTest.Parseinfo.TaskFileName != url {
 		t.Fatalf("Wrong TaskFilenName; got %q, want %q", ptTest.Parseinfo.TaskFileName, url)
 	}
-
-	/*
-		// Verify the client and server annotations match.
-		cx := v2.ConvertAnnotationsToClientAnnotations(m["74.125.224.100"])
-		if diff := deep.Equal(&ptTest.ClientX, cx); diff != nil {
-			t.Errorf("ClientX annotation does not match; %#v", diff)
-		}
-		sx := v2.ConvertAnnotationsToServerAnnotations(m["172.17.94.34"])
-		sx.Site = "nuq07"
-		sx.Machine = "mlab4"
-		if diff := deep.Equal(&ptTest.ServerX, sx); diff != nil {
-			t.Errorf("ServerX annotation does not match; %#v", diff)
-		}
-	*/
 }
 
 func TestParseAndInsert(t *testing.T) {
-
-	m := map[string]*api.Annotations{
-		"2.80.132.33": &api.Annotations{
-			Geo: &api.GeolocationIP{
-				ContinentCode: "NA",
-				CountryCode:   "US",
-				Latitude:      1.0,
-				Longitude:     2.0,
-			},
-			Network: &api.ASData{
-				ASNumber: 1234,
-				Systems: []api.System{
-					{ASNs: []uint32{1234}},
-				},
-			},
-		},
-		"91.239.96.102": &api.Annotations{
-			Geo: &api.GeolocationIP{
-				ContinentCode: "NA",
-				CountryCode:   "US",
-				Latitude:      1.0,
-				Longitude:     2.0,
-			},
-			Network: &api.ASData{
-				ASNumber: 1234,
-				Systems: []api.System{
-					{ASNs: []uint32{1234}},
-				},
-			},
-		},
-	}
-
 	ins := newInMemoryInserter()
-	pt := parser.NewPTParser(ins, newFakeAnnotator(m))
+	pt := parser.NewPTParser(ins)
 	rawData, err := ioutil.ReadFile("testdata/PT/20130524T00:04:44Z_ALL5729.paris")
 	if err != nil {
 		t.Fatalf("cannot read testdata.")
@@ -533,21 +412,6 @@ func TestParseAndInsert(t *testing.T) {
 	if ins.data[0].(*schema.PTTest).UUID != "R9_wGx1-cSmqtSAt5aQtNg" {
 		t.Fatalf("UUID is wrong; got %q, want %q", ins.data[0].(*schema.PTTest).UUID, "R9_wGx1-cSmqtSAt5aQtNg")
 	}
-	/*
-		p := ins.data[0].(*schema.PTTest)
-
-		// Verify the client and server annotations match.
-		cx := v2.ConvertAnnotationsToClientAnnotations(m["91.239.96.102"])
-		if diff := deep.Equal(&p.ClientX, cx); diff != nil {
-			t.Errorf("ClientX annotation does not match; %#v", diff)
-		}
-		sx := v2.ConvertAnnotationsToServerAnnotations(m["2.80.132.33"])
-		sx.Site = "akl01"
-		sx.Machine = "mlab3"
-		if diff := deep.Equal(&p.ServerX, sx); diff != nil {
-			t.Errorf("ServerX annotation does not match; %#v", diff)
-		}
-	*/
 }
 
 func TestProcessLastTests(t *testing.T) {

--- a/parser/pt_test.go
+++ b/parser/pt_test.go
@@ -9,9 +9,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
-	"github.com/go-test/deep"
 	"github.com/m-lab/annotation-service/api"
-	v2 "github.com/m-lab/annotation-service/api/v2"
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/parser"
 	"github.com/m-lab/etl/schema"
@@ -326,17 +324,19 @@ func TestParseJSONL(t *testing.T) {
 		t.Fatalf("Wrong UUID; got %q, want %q", ptTest.UUID, "ndt-qtfh8_1565996043_0000000000003B64")
 	}
 
-	// Verify the client and server annotations match.
-	cx := v2.ConvertAnnotationsToClientAnnotations(m["91.169.126.135"])
-	if diff := deep.Equal(&ptTest.ClientX, cx); diff != nil {
-		t.Errorf("ClientX annotation does not match; %#v", diff)
-	}
-	sx := v2.ConvertAnnotationsToServerAnnotations(m["91.213.30.229"])
-	sx.Site = "nuq07"
-	sx.Machine = "mlab2"
-	if diff := deep.Equal(&ptTest.ServerX, sx); diff != nil {
-		t.Errorf("ServerX annotation does not match; %#v", diff)
-	}
+	/*
+		// Verify the client and server annotations match.
+		cx := v2.ConvertAnnotationsToClientAnnotations(m["91.169.126.135"])
+		if diff := deep.Equal(&ptTest.ClientX, cx); diff != nil {
+			t.Errorf("ClientX annotation does not match; %#v", diff)
+		}
+		sx := v2.ConvertAnnotationsToServerAnnotations(m["91.213.30.229"])
+		sx.Site = "nuq07"
+		sx.Machine = "mlab2"
+		if diff := deep.Equal(&ptTest.ServerX, sx); diff != nil {
+			t.Errorf("ServerX annotation does not match; %#v", diff)
+		}
+	*/
 }
 
 func TestParse(t *testing.T) {
@@ -444,7 +444,7 @@ func TestAnnotateAndPutAsync(t *testing.T) {
 		fmt.Println(pt.NumRowsForTest())
 		t.Fatalf("Number of rows in PT table is wrong.")
 	}
-	pt.AnnotateAndPutAsync("traceroute")
+	pt.PutAsync(pt.TakeRows())
 
 	if len(ins.data) != 1 {
 		fmt.Println(len(ins.data))
@@ -455,17 +455,19 @@ func TestAnnotateAndPutAsync(t *testing.T) {
 		t.Fatalf("Wrong TaskFilenName; got %q, want %q", ptTest.Parseinfo.TaskFileName, url)
 	}
 
-	// Verify the client and server annotations match.
-	cx := v2.ConvertAnnotationsToClientAnnotations(m["74.125.224.100"])
-	if diff := deep.Equal(&ptTest.ClientX, cx); diff != nil {
-		t.Errorf("ClientX annotation does not match; %#v", diff)
-	}
-	sx := v2.ConvertAnnotationsToServerAnnotations(m["172.17.94.34"])
-	sx.Site = "nuq07"
-	sx.Machine = "mlab4"
-	if diff := deep.Equal(&ptTest.ServerX, sx); diff != nil {
-		t.Errorf("ServerX annotation does not match; %#v", diff)
-	}
+	/*
+		// Verify the client and server annotations match.
+		cx := v2.ConvertAnnotationsToClientAnnotations(m["74.125.224.100"])
+		if diff := deep.Equal(&ptTest.ClientX, cx); diff != nil {
+			t.Errorf("ClientX annotation does not match; %#v", diff)
+		}
+		sx := v2.ConvertAnnotationsToServerAnnotations(m["172.17.94.34"])
+		sx.Site = "nuq07"
+		sx.Machine = "mlab4"
+		if diff := deep.Equal(&ptTest.ServerX, sx); diff != nil {
+			t.Errorf("ServerX annotation does not match; %#v", diff)
+		}
+	*/
 }
 
 func TestParseAndInsert(t *testing.T) {
@@ -531,19 +533,21 @@ func TestParseAndInsert(t *testing.T) {
 	if ins.data[0].(*schema.PTTest).UUID != "R9_wGx1-cSmqtSAt5aQtNg" {
 		t.Fatalf("UUID is wrong; got %q, want %q", ins.data[0].(*schema.PTTest).UUID, "R9_wGx1-cSmqtSAt5aQtNg")
 	}
-	p := ins.data[0].(*schema.PTTest)
+	/*
+		p := ins.data[0].(*schema.PTTest)
 
-	// Verify the client and server annotations match.
-	cx := v2.ConvertAnnotationsToClientAnnotations(m["91.239.96.102"])
-	if diff := deep.Equal(&p.ClientX, cx); diff != nil {
-		t.Errorf("ClientX annotation does not match; %#v", diff)
-	}
-	sx := v2.ConvertAnnotationsToServerAnnotations(m["2.80.132.33"])
-	sx.Site = "akl01"
-	sx.Machine = "mlab3"
-	if diff := deep.Equal(&p.ServerX, sx); diff != nil {
-		t.Errorf("ServerX annotation does not match; %#v", diff)
-	}
+		// Verify the client and server annotations match.
+		cx := v2.ConvertAnnotationsToClientAnnotations(m["91.239.96.102"])
+		if diff := deep.Equal(&p.ClientX, cx); diff != nil {
+			t.Errorf("ClientX annotation does not match; %#v", diff)
+		}
+		sx := v2.ConvertAnnotationsToServerAnnotations(m["2.80.132.33"])
+		sx.Site = "akl01"
+		sx.Machine = "mlab3"
+		if diff := deep.Equal(&p.ServerX, sx); diff != nil {
+			t.Errorf("ServerX annotation does not match; %#v", diff)
+		}
+	*/
 }
 
 func TestProcessLastTests(t *testing.T) {

--- a/parser/scamper1.go
+++ b/parser/scamper1.go
@@ -7,7 +7,6 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/civil"
-	v2as "github.com/m-lab/annotation-service/api/v2"
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/metrics"
 	"github.com/m-lab/etl/row"
@@ -31,14 +30,10 @@ type Scamper1Parser struct {
 }
 
 // NewScamper1Parser returns a new parser for the scamper1 archives.
-func NewScamper1Parser(sink row.Sink, table, suffix string, ann v2as.Annotator) etl.Parser {
+func NewScamper1Parser(sink row.Sink, table, suffix string) etl.Parser {
 	bufSize := etl.SCAMPER1.BQBufferSize()
-	if ann == nil {
-		ann = &NullAnnotator{}
-	}
-
 	return &Scamper1Parser{
-		Base:   row.NewBase(table, sink, bufSize, ann),
+		Base:   row.NewBase(table, sink, bufSize),
 		table:  table,
 		suffix: suffix,
 	}

--- a/parser/scamper1_test.go
+++ b/parser/scamper1_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestScamper1Parser_ParseAndInsert(t *testing.T) {
 	ins := newInMemorySink()
-	n := parser.NewScamper1Parser(ins, "test", "_suffix", &fakeAnnotator{})
+	n := parser.NewScamper1Parser(ins, "test", "_suffix")
 
 	file := "valid.jsonl"
 	data, err := ioutil.ReadFile(path.Join("testdata/Scamper1/", file))
@@ -51,7 +51,7 @@ func TestScamper1Parser_ParseAndInsert(t *testing.T) {
 
 func TestScamper1Parser_ParserAndInsertError(t *testing.T) {
 	ins := newInMemorySink()
-	n := parser.NewScamper1Parser(ins, "test", "_suffix", &fakeAnnotator{})
+	n := parser.NewScamper1Parser(ins, "test", "_suffix")
 
 	file := "badformat.jsonl"
 	data, err := ioutil.ReadFile(path.Join("testdata/Scamper1/", file))

--- a/parser/ss.go
+++ b/parser/ss.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"time"
 
-	v2as "github.com/m-lab/annotation-service/api/v2"
-
 	"cloud.google.com/go/bigquery"
 
 	"github.com/m-lab/etl/etl"
@@ -28,7 +26,7 @@ type SSParser struct {
 }
 
 // NewSSParser creates a new sidestream parser.
-func NewSSParser(ins etl.Inserter, ann v2as.Annotator) *SSParser {
+func NewSSParser(ins etl.Inserter) *SSParser {
 	bufSize := etl.SS.BQBufferSize()
 	return &SSParser{*NewBase(ins, bufSize)}
 }
@@ -302,7 +300,6 @@ func (ss *SSParser) ParseAndInsert(meta map[string]bigquery.Value, testName stri
 		// Add row to buffer, possibly flushing buffer if it is full.
 		err = ss.AddRow(&ssTest)
 		if err == etl.ErrBufferFull {
-			ss.Annotate(ss.TableBase())
 			// Flush asynchronously, to improve throughput.
 			ss.PutAsync(ss.TakeRows())
 			err = ss.AddRow(&ssTest)

--- a/parser/ss.go
+++ b/parser/ss.go
@@ -30,13 +30,13 @@ type SSParser struct {
 // NewSSParser creates a new sidestream parser.
 func NewSSParser(ins etl.Inserter, ann v2as.Annotator) *SSParser {
 	bufSize := etl.SS.BQBufferSize()
-	return &SSParser{*NewBase(ins, bufSize, ann)}
+	return &SSParser{*NewBase(ins, bufSize)}
 }
 
 // TODO get rid of this hack.
 func NewDefaultSSParser(ins etl.Inserter) *SSParser {
 	bufSize := etl.SS.BQBufferSize()
-	return &SSParser{*NewBase(ins, bufSize, &NullAnnotator{})}
+	return &SSParser{*NewBase(ins, bufSize)}
 }
 
 // ExtractLogtimeFromFilename extracts the log time.

--- a/parser/ss_test.go
+++ b/parser/ss_test.go
@@ -8,14 +8,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/m-lab/uuid-annotator/annotator"
+
 	"cloud.google.com/go/bigquery"
 	"github.com/go-test/deep"
 
-	"github.com/m-lab/annotation-service/api"
 	v2as "github.com/m-lab/annotation-service/api/v2"
 	"github.com/m-lab/etl/parser"
 	"github.com/m-lab/etl/schema"
-	"github.com/m-lab/uuid-annotator/annotator"
 )
 
 func TestExtractLogtimeFromFilename(t *testing.T) {
@@ -115,12 +115,14 @@ func TestSSInserter(t *testing.T) {
 		t.Fatal("Should have at least one inserted row")
 	}
 
-	for _, r := range ins.data {
-		row, _ := r.(*schema.SS)
-		if row.Web100_log_entry.Connection_spec.Remote_geolocation.PostalCode == "" {
-			t.Error(row.Web100_log_entry.Connection_spec.Remote_ip, "missing PostalCode")
+	/*
+		for _, r := range ins.data {
+			row, _ := r.(*schema.SS)
+			if row.Web100_log_entry.Connection_spec.Remote_geolocation.PostalCode == "" {
+				t.Error(row.Web100_log_entry.Connection_spec.Remote_ip, "missing PostalCode")
+			}
 		}
-	}
+	*/
 	inserted := ins.data[0].(*schema.SS)
 	if inserted.ParseTime.After(time.Now()) {
 		t.Error("Should have inserted parse_time")
@@ -146,45 +148,52 @@ func TestSSInserter(t *testing.T) {
 		Local_port:  41131,
 		Remote_ip:   "5.228.253.100",
 		Remote_port: 52290,
-		Local_geolocation: api.GeolocationIP{
-			PostalCode: "21320",
-			Latitude:   3,
-			Longitude:  4,
-		},
-		Remote_geolocation: api.GeolocationIP{
-			PostalCode: "52282",
-			Latitude:   1,
-			Longitude:  2,
-		},
 		ServerX: annotator.ServerAnnotations{
 			Site:    "ord03",
 			Machine: "mlab1",
-			Geo: &annotator.Geolocation{
-				PostalCode: "21320",
-				Latitude:   3.0,
-				Longitude:  4.0,
-			},
-			Network: &annotator.Network{
-				CIDR:     "213.248.112.64/26",
-				ASNumber: 456,
-				ASName:   "Fake Server ISP",
-				Systems: []annotator.System{
-					{ASNs: []uint32{456}},
-				},
-			},
 		},
-		ClientX: annotator.ClientAnnotations{
-			Geo: &annotator.Geolocation{
+
+		/*
+			Local_geolocation: api.GeolocationIP{
+				PostalCode: "21320",
+				Latitude:   3,
+				Longitude:  4,
+			},
+			Remote_geolocation: api.GeolocationIP{
 				PostalCode: "52282",
 				Latitude:   1,
 				Longitude:  2,
 			},
-			Network: &annotator.Network{
-				Systems: []annotator.System{
-					{ASNs: []uint32{456}},
+			ServerX: annotator.ServerAnnotations{
+				Site:    "ord03",
+				Machine: "mlab1",
+				Geo: &annotator.Geolocation{
+					PostalCode: "21320",
+					Latitude:   3.0,
+					Longitude:  4.0,
+				},
+				Network: &annotator.Network{
+					CIDR:     "213.248.112.64/26",
+					ASNumber: 456,
+					ASName:   "Fake Server ISP",
+					Systems: []annotator.System{
+						{ASNs: []uint32{456}},
+					},
 				},
 			},
-		},
+			ClientX: annotator.ClientAnnotations{
+				Geo: &annotator.Geolocation{
+					PostalCode: "52282",
+					Latitude:   1,
+					Longitude:  2,
+				},
+				Network: &annotator.Network{
+					Systems: []annotator.System{
+						{ASNs: []uint32{456}},
+					},
+				},
+			},
+		*/
 	}
 
 	if diff := deep.Equal(inserted.Web100_log_entry.Connection_spec, expectedSpec); diff != nil {

--- a/parser/ss_test.go
+++ b/parser/ss_test.go
@@ -3,8 +3,6 @@ package parser_test
 import (
 	"fmt"
 	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -13,7 +11,6 @@ import (
 	"cloud.google.com/go/bigquery"
 	"github.com/go-test/deep"
 
-	v2as "github.com/m-lab/annotation-service/api/v2"
 	"github.com/m-lab/etl/parser"
 	"github.com/m-lab/etl/schema"
 )
@@ -71,21 +68,7 @@ func TestParseOneLine(t *testing.T) {
 
 func TestSSInserter(t *testing.T) {
 	ins := &inMemoryInserter{}
-	// Completely fake annotation data.
-	responseJSON := `{"AnnotatorDate":"2018-12-05T00:00:00Z",
-		"Annotations":{"5.228.253.100":{"Geo":{"postal_code":"52282", "latitude": 1.0, "longitude": 2.0}, "Network":{"Systems":[{"ASNs":[456]}]}},
-				   "178.141.112.12":{"Geo":{"postal_code":"17814"}, "Network":{"Systems":[{"ASNs":[456]}]}},
-				   "193.169.96.33":{"Geo":{"postal_code":"19316"}, "Network":{"Systems":[{"ASNs":[456]}]}},
-				   "178.141.112.12":{"Geo":{"postal_code":"17814"}, "Network":{"Systems":[{"ASNs":[456]}]}},
-				   "45.56.98.222":{"Geo":{"postal_code":"45569"}, "Network":{"Systems":[{"ASNs":[456]}]}},
-		           "213.248.112.75":{"Geo":{"postal_code":"21320", "latitude": 3.0, "longitude": 4.0}, "Network":{"ASName":"Fake Server ISP", "ASNumber": 456, "CIDR": "213.248.112.64/26", "Systems":[{"ASNs":[456]}]}}
-				   }}`
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, responseJSON)
-	}))
-	defer ts.Close()
-
-	p := parser.NewSSParser(ins, v2as.GetAnnotator(ts.URL))
+	p := parser.NewSSParser(ins)
 	filename := "testdata/sidestream/20170203T00:00:00Z_ALL0.web100"
 	rawData, err := ioutil.ReadFile(filename)
 	if err != nil {
@@ -99,10 +82,7 @@ func TestSSInserter(t *testing.T) {
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	err = p.Annotate(p.TableName())
-	if err != nil {
-		t.Error(err)
-	}
+
 	err = p.Flush()
 	if err != nil {
 		t.Error(err)
@@ -115,14 +95,6 @@ func TestSSInserter(t *testing.T) {
 		t.Fatal("Should have at least one inserted row")
 	}
 
-	/*
-		for _, r := range ins.data {
-			row, _ := r.(*schema.SS)
-			if row.Web100_log_entry.Connection_spec.Remote_geolocation.PostalCode == "" {
-				t.Error(row.Web100_log_entry.Connection_spec.Remote_ip, "missing PostalCode")
-			}
-		}
-	*/
 	inserted := ins.data[0].(*schema.SS)
 	if inserted.ParseTime.After(time.Now()) {
 		t.Error("Should have inserted parse_time")
@@ -152,48 +124,6 @@ func TestSSInserter(t *testing.T) {
 			Site:    "ord03",
 			Machine: "mlab1",
 		},
-
-		/*
-			Local_geolocation: api.GeolocationIP{
-				PostalCode: "21320",
-				Latitude:   3,
-				Longitude:  4,
-			},
-			Remote_geolocation: api.GeolocationIP{
-				PostalCode: "52282",
-				Latitude:   1,
-				Longitude:  2,
-			},
-			ServerX: annotator.ServerAnnotations{
-				Site:    "ord03",
-				Machine: "mlab1",
-				Geo: &annotator.Geolocation{
-					PostalCode: "21320",
-					Latitude:   3.0,
-					Longitude:  4.0,
-				},
-				Network: &annotator.Network{
-					CIDR:     "213.248.112.64/26",
-					ASNumber: 456,
-					ASName:   "Fake Server ISP",
-					Systems: []annotator.System{
-						{ASNs: []uint32{456}},
-					},
-				},
-			},
-			ClientX: annotator.ClientAnnotations{
-				Geo: &annotator.Geolocation{
-					PostalCode: "52282",
-					Latitude:   1,
-					Longitude:  2,
-				},
-				Network: &annotator.Network{
-					Systems: []annotator.System{
-						{ASNs: []uint32{456}},
-					},
-				},
-			},
-		*/
 	}
 
 	if diff := deep.Equal(inserted.Web100_log_entry.Connection_spec, expectedSpec); diff != nil {

--- a/parser/ss_test.go
+++ b/parser/ss_test.go
@@ -6,13 +6,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m-lab/uuid-annotator/annotator"
-
 	"cloud.google.com/go/bigquery"
 	"github.com/go-test/deep"
 
 	"github.com/m-lab/etl/parser"
 	"github.com/m-lab/etl/schema"
+	"github.com/m-lab/uuid-annotator/annotator"
 )
 
 func TestExtractLogtimeFromFilename(t *testing.T) {

--- a/parser/switch.go
+++ b/parser/switch.go
@@ -13,7 +13,6 @@ import (
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/civil"
 	"github.com/iancoleman/strcase"
-	v2as "github.com/m-lab/annotation-service/api/v2"
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/metrics"
 	"github.com/m-lab/etl/row"
@@ -41,14 +40,10 @@ type SwitchParser struct {
 }
 
 // NewSwitchParser returns a new parser for the switch archives.
-func NewSwitchParser(sink row.Sink, table, suffix string, ann v2as.Annotator) etl.Parser {
+func NewSwitchParser(sink row.Sink, table, suffix string) etl.Parser {
 	bufSize := etl.SW.BQBufferSize()
-	if ann == nil {
-		ann = &NullAnnotator{}
-	}
-
 	return &SwitchParser{
-		Base:   row.NewBase(table, sink, bufSize, ann),
+		Base:   row.NewBase(table, sink, bufSize),
 		table:  table,
 		suffix: suffix,
 	}

--- a/parser/switch_test.go
+++ b/parser/switch_test.go
@@ -22,7 +22,7 @@ const (
 
 func TestSwitchParser_ParseAndInsert(t *testing.T) {
 	sink := newInMemorySink()
-	n := parser.NewSwitchParser(sink, "switch", "_suffix", &fakeAnnotator{})
+	n := parser.NewSwitchParser(sink, "switch", "_suffix")
 
 	// Test DISCOv2 format.
 	data, err := ioutil.ReadFile(path.Join("testdata/Switch/", switchDISCOv2Filename))
@@ -83,7 +83,7 @@ func TestSwitchParser_ParseAndInsert(t *testing.T) {
 
 	// Test DISCOv1 format.
 	sink = newInMemorySink()
-	n = parser.NewSwitchParser(sink, "switch", "_suffix", &fakeAnnotator{})
+	n = parser.NewSwitchParser(sink, "switch", "_suffix")
 	// This is a gzip-compressed JSONL file.
 	gzipData, err := ioutil.ReadFile(path.Join("testdata/Switch/", switchDISCOv1Filename))
 	rtx.Must(err, "failed to load DISCOv1 test file")

--- a/parser/tcpinfo.go
+++ b/parser/tcpinfo.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/valyala/gozstd"
 
-	v2as "github.com/m-lab/annotation-service/api/v2"
 	"github.com/m-lab/tcp-info/netlink"
 	"github.com/m-lab/tcp-info/snapshot"
 
@@ -205,14 +204,10 @@ func (p *TCPInfoParser) ParseAndInsert(meta map[string]bigquery.Value, testName 
 }
 
 // NewTCPInfoParser creates a new parser for the TCPInfo datatype.
-func NewTCPInfoParser(sink row.Sink, table, suffix string, ann v2as.Annotator) *TCPInfoParser {
+func NewTCPInfoParser(sink row.Sink, table, suffix string) *TCPInfoParser {
 	bufSize := etl.TCPINFO.BQBufferSize()
-	if ann == nil {
-		ann = &NullAnnotator{}
-	}
-
 	return &TCPInfoParser{
-		Base:   row.NewBase("tcpinfo", sink, bufSize, ann),
+		Base:   row.NewBase("tcpinfo", sink, bufSize),
 		table:  table,
 		suffix: suffix,
 	}

--- a/parser/tcpinfo_test.go
+++ b/parser/tcpinfo_test.go
@@ -150,7 +150,7 @@ func TestTCPParser(t *testing.T) {
 
 	// Inject fake inserter and annotator
 	ins := newInMemorySink()
-	p := parser.NewTCPInfoParser(ins, "test", "_suffix", newFakeAnnotator(tcpInfoAnno))
+	p := parser.NewTCPInfoParser(ins, "test", "_suffix")
 	task := task.NewTask(url, src, p, nullCloser{})
 
 	startDecode := time.Now()
@@ -245,7 +245,7 @@ func TestTCPParser(t *testing.T) {
 func TestTCPTask(t *testing.T) {
 	// Inject fake inserter and annotator
 	ins := newInMemorySink()
-	p := parser.NewTCPInfoParser(ins, "test", "_suffix", newFakeAnnotator(tcpInfoAnno))
+	p := parser.NewTCPInfoParser(ins, "test", "_suffix")
 
 	filename := "testdata/20190516T013026.744845Z-tcpinfo-mlab4-arn02-ndt.tgz"
 	url := "gs://fake-archive/ndt/tcpinfo/2019/05/16/" + filepath.Base(filename)
@@ -283,7 +283,7 @@ func TestTaskToGCS(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Inject fake inserter and annotator
-	p := parser.NewTCPInfoParser(rw, "test", "_suffix", newFakeAnnotator(tcpInfoAnno))
+	p := parser.NewTCPInfoParser(rw, "test", "_suffix")
 
 	filename := "testdata/20190516T013026.744845Z-tcpinfo-mlab4-arn02-ndt.tgz"
 	url := "gs://fake-archive/ndt/tcpinfo/2019/05/16/" + filepath.Base(filename)
@@ -311,7 +311,7 @@ func TestTaskToGCS(t *testing.T) {
 func BenchmarkTCPParser(b *testing.B) {
 	// Inject fake inserter and annotator
 	ins := newInMemorySink()
-	p := parser.NewTCPInfoParser(ins, "test", "_suffix", newFakeAnnotator(tcpInfoAnno))
+	p := parser.NewTCPInfoParser(ins, "test", "_suffix")
 
 	filename := "testdata/20190516T013026.744845Z-tcpinfo-mlab4-arn02-ndt.tgz"
 	n := 0

--- a/row/row.go
+++ b/row/row.go
@@ -4,7 +4,6 @@ package row
 // Probably should have Base implement Parser.
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -12,10 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/m-lab/annotation-service/api"
-	v2as "github.com/m-lab/annotation-service/api/v2"
 	"github.com/m-lab/go/logx"
 
 	"github.com/m-lab/etl/metrics"
@@ -173,148 +169,10 @@ func (buf *Buffer) Reset() []interface{} {
 	return res
 }
 
-type annotator struct {
-	v2 v2as.Annotator
-}
-
-// label is used to label metrics and errors in GetAnnotations
-func (ann *annotator) annotateServers(rows []interface{}, label string) error {
-	serverIPs := make(map[string]struct{})
-	logTime := time.Time{}
-	for i := range rows {
-		r, ok := rows[i].(Annotatable)
-		if !ok {
-			return ErrNotAnnotatable
-		}
-
-		// Only ask for the IP if it is non-empty.
-		ip := r.GetServerIP()
-		if ip != "" {
-			serverIPs[ip] = struct{}{}
-		}
-
-		if (logTime == time.Time{}) {
-			logTime = r.GetLogTime()
-		}
-	}
-
-	ipSlice := make([]string, 0, len(rows))
-	for ip := range serverIPs {
-		ipSlice = append(ipSlice, ip)
-	}
-	if len(ipSlice) == 0 {
-		return nil
-	}
-	response, err := ann.v2.GetAnnotations(context.Background(), logTime, ipSlice, label)
-	if err != nil {
-		log.Println("error in server GetAnnotations: ", err)
-		metrics.AnnotationErrorCount.With(prometheus.
-			Labels{"source": "Server IP: RPC err in GetAnnotations."}).Inc()
-		return err
-	}
-	annMap := response.Annotations
-	if annMap == nil {
-		log.Println("empty server annotation response")
-		metrics.AnnotationErrorCount.With(prometheus.
-			Labels{"source": "Server IP: empty response"}).Inc()
-		return ErrAnnotationError
-	}
-
-	for i := range rows {
-		r, ok := rows[i].(Annotatable)
-		if !ok {
-			err = ErrNotAnnotatable
-		} else {
-			ip := r.GetServerIP()
-			if ip != "" {
-				ann, ok := annMap[ip]
-				if ok {
-					r.AnnotateServer(ann)
-				}
-			}
-		}
-	}
-
-	return err
-}
-
-var logEmptyAnn = logx.NewLogEvery(nil, 60*time.Second)
-
-// label is used to label metrics and errors in GetAnnotations
-func (ann *annotator) annotateClients(rows []interface{}, label string) error {
-	ipSlice := make([]string, 0, 2*len(rows)) // This may be inadequate, but its a reasonable start.
-	logTime := time.Time{}
-	for i := range rows {
-		r, ok := rows[i].(Annotatable)
-		if !ok {
-			return ErrNotAnnotatable
-		}
-		ipSlice = append(ipSlice, r.GetClientIPs()...)
-		if (logTime == time.Time{}) {
-			logTime = r.GetLogTime()
-		}
-	}
-
-	response, err := ann.v2.GetAnnotations(context.Background(), logTime, ipSlice, label)
-	if err != nil {
-		log.Println("error in client GetAnnotations: ", err)
-		metrics.AnnotationErrorCount.With(prometheus.
-			Labels{"source": "Client IP: RPC err in GetAnnotations."}).Inc()
-		return err
-	}
-	annMap := response.Annotations
-	if annMap == nil {
-		logEmptyAnn.Println("empty client annotation response")
-		metrics.AnnotationErrorCount.With(prometheus.
-			Labels{"source": "Client IP: empty response"}).Inc()
-		return ErrAnnotationError
-	}
-
-	for i := range rows {
-		r, ok := rows[i].(Annotatable)
-		if !ok {
-			err = ErrNotAnnotatable
-		} else {
-			// Will not error because we check for nil annMap above.
-			r.AnnotateClients(annMap)
-		}
-	}
-
-	return err
-}
-
-// Annotate fetches and applies annotations for all rows
-func (ann *annotator) Annotate(rows []interface{}, metricLabel string) error {
-	metrics.WorkerState.WithLabelValues(metricLabel, "annotate").Inc()
-	defer metrics.WorkerState.WithLabelValues(metricLabel, "annotate").Dec()
-	if len(rows) == 0 {
-		return nil
-	}
-	// TODO replace this with a histogram.
-	defer func(label string, start time.Time) {
-		metrics.AnnotationTimeSummary.With(prometheus.Labels{"test_type": label}).Observe(float64(time.Since(start).Nanoseconds()))
-	}(metricLabel, time.Now())
-
-	// TODO Consider doing these in parallel?
-	clientErr := ann.annotateClients(rows, metricLabel)
-	serverErr := ann.annotateServers(rows, metricLabel)
-
-	if clientErr != nil {
-		return clientErr
-	}
-
-	if serverErr != nil {
-		return serverErr
-	}
-
-	return nil
-}
-
 // Base provides common parser functionality.
 // Base is NOT THREAD-SAFE
 type Base struct {
-	sink Sink
-	// ann   annotator
+	sink  Sink
 	buf   *Buffer
 	label string // Used in metrics and errors.
 
@@ -337,17 +195,7 @@ func (pb *Base) TaskError() error {
 	return nil
 }
 
-var logAnnError = logx.NewLogEvery(nil, 60*time.Second)
-
 func (pb *Base) commit(rows []interface{}) error {
-	/*
-		err := pb.ann.Annotate(rows, pb.label)
-		if err != nil {
-			logAnnError.Println("annotation: ", err)
-		}
-	*/
-
-	// TODO do we need these to be done in order.
 	// This is synchronous, blocking, and thread safe.
 	done, err := pb.sink.Commit(rows, pb.label)
 	if done > 0 {

--- a/row/row.go
+++ b/row/row.go
@@ -313,8 +313,8 @@ func (ann *annotator) Annotate(rows []interface{}, metricLabel string) error {
 // Base provides common parser functionality.
 // Base is NOT THREAD-SAFE
 type Base struct {
-	sink  Sink
-	ann   annotator
+	sink Sink
+	// ann   annotator
 	buf   *Buffer
 	label string // Used in metrics and errors.
 
@@ -322,9 +322,9 @@ type Base struct {
 }
 
 // NewBase creates a new Base.  This will generally be embedded in a type specific parser.
-func NewBase(label string, sink Sink, bufSize int, ann v2as.Annotator) *Base {
+func NewBase(label string, sink Sink, bufSize int) *Base {
 	buf := NewBuffer(bufSize)
-	return &Base{sink: sink, ann: annotator{ann}, buf: buf, label: label}
+	return &Base{sink: sink, buf: buf, label: label}
 }
 
 // GetStats returns the buffer/sink stats.
@@ -340,10 +340,12 @@ func (pb *Base) TaskError() error {
 var logAnnError = logx.NewLogEvery(nil, 60*time.Second)
 
 func (pb *Base) commit(rows []interface{}) error {
-	err := pb.ann.Annotate(rows, pb.label)
-	if err != nil {
-		logAnnError.Println("annotation: ", err)
-	}
+	/*
+		err := pb.ann.Annotate(rows, pb.label)
+		if err != nil {
+			logAnnError.Println("annotation: ", err)
+		}
+	*/
 
 	// TODO do we need these to be done in order.
 	// This is synchronous, blocking, and thread safe.

--- a/row/row_test.go
+++ b/row/row_test.go
@@ -73,7 +73,7 @@ func (in *inMemorySink) Close() error { return nil }
 func TestBase(t *testing.T) {
 	ins := &inMemorySink{}
 
-	b := row.NewBase("test", ins, 10) // , v2as.GetAnnotator(ts.URL))
+	b := row.NewBase("test", ins, 10)
 
 	b.Put(&Row{"1.2.3.4", "4.3.2.1", nil, nil})
 
@@ -93,7 +93,7 @@ func TestBase(t *testing.T) {
 func TestAsyncPut(t *testing.T) {
 	ins := &inMemorySink{}
 
-	b := row.NewBase("test", ins, 1) // , v2as.GetAnnotator(ts.URL))
+	b := row.NewBase("test", ins, 1)
 
 	b.Put(&Row{"1.2.3.4", "4.3.2.1", nil, nil})
 

--- a/row/row_test.go
+++ b/row/row_test.go
@@ -2,9 +2,6 @@ package row_test
 
 import (
 	"errors"
-	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -76,42 +73,13 @@ func (in *inMemorySink) Close() error { return nil }
 func TestBase(t *testing.T) {
 	ins := &inMemorySink{}
 
-	// Set up fake annotation service
-	r1 := `{"AnnotatorDate":"2018-12-05T00:00:00Z",
-	                  "Annotations":{"1.2.3.4":{"Geo":{"postal_code":"10583"}}}}`
-	r2 := `{"AnnotatorDate":"2018-12-05T00:00:00Z",
-					  "Annotations":{"4.3.2.1":{"Geo":{"postal_code":"10584"}}}}`
-
-	callCount := 0
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// HACKY - depends on order in which client and server are annotated
-		if callCount == 0 {
-			fmt.Fprint(w, r1)
-		} else {
-			fmt.Fprint(w, r2)
-		}
-		callCount++
-	}))
-	defer func() {
-		ts.Close()
-	}()
-
 	b := row.NewBase("test", ins, 10) // , v2as.GetAnnotator(ts.URL))
 
 	b.Put(&Row{"1.2.3.4", "4.3.2.1", nil, nil})
 
 	// Add a row with empty server IP
 	b.Put(&Row{"1.2.3.4", "", nil, nil})
-	if callCount != 0 {
-		t.Error("Callcount should be 0:", callCount)
-	}
-
 	b.Flush()
-	/*
-		if callCount != 2 {
-			t.Error("Callcount should be 2:", callCount)
-		}
-	*/
 	stats := b.GetStats()
 	if stats.Committed != 2 {
 		t.Fatalf("Expected %d, Got %d.", 2, stats.Committed)
@@ -120,39 +88,10 @@ func TestBase(t *testing.T) {
 	if len(ins.data) < 1 {
 		t.Fatal("Should have at least one inserted row")
 	}
-	/*
-		inserted := ins.data[0].(*Row)
-		if inserted.clientAnn == nil || inserted.clientAnn.Geo.PostalCode != "10583" {
-			t.Error("Failed client annotation")
-		}
-		if inserted.serverAnn == nil || inserted.serverAnn.Geo.PostalCode != "10584" {
-			t.Error("Failed server annotation")
-		}
-	*/
 }
 
 func TestAsyncPut(t *testing.T) {
 	ins := &inMemorySink{}
-
-	// Set up fake annotation service
-	r1 := `{"AnnotatorDate":"2018-12-05T00:00:00Z",
-	                  "Annotations":{"1.2.3.4":{"Geo":{"postal_code":"10583"}}}}`
-	r2 := `{"AnnotatorDate":"2018-12-05T00:00:00Z",
-					  "Annotations":{"4.3.2.1":{"Geo":{"postal_code":"10584"}}}}`
-
-	callCount := 0
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// HACKY - depends on order in which client and server are annotated
-		if callCount == 0 {
-			fmt.Fprint(w, r1)
-		} else {
-			fmt.Fprint(w, r2)
-		}
-		callCount++
-	}))
-	defer func() {
-		ts.Close()
-	}()
 
 	b := row.NewBase("test", ins, 1) // , v2as.GetAnnotator(ts.URL))
 
@@ -176,15 +115,6 @@ func TestAsyncPut(t *testing.T) {
 	if len(ins.data) < 1 {
 		t.Fatal("Should have at least one inserted row")
 	}
-	/*
-		inserted := ins.data[0].(*Row)
-		if inserted.clientAnn == nil || inserted.clientAnn.Geo.PostalCode != "10583" {
-			t.Error("Failed client annotation")
-		}
-		if inserted.serverAnn == nil || inserted.serverAnn.Geo.PostalCode != "10584" {
-			t.Error("Failed server annotation")
-		}
-	*/
 }
 
 func TestErrCommitRow(t *testing.T) {

--- a/row/row_test.go
+++ b/row/row_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/m-lab/etl/row"
 
 	"github.com/m-lab/annotation-service/api"
-	v2as "github.com/m-lab/annotation-service/api/v2"
 )
 
 // Implement parser.Annotatable
@@ -97,7 +96,7 @@ func TestBase(t *testing.T) {
 		ts.Close()
 	}()
 
-	b := row.NewBase("test", ins, 10, v2as.GetAnnotator(ts.URL))
+	b := row.NewBase("test", ins, 10) // , v2as.GetAnnotator(ts.URL))
 
 	b.Put(&Row{"1.2.3.4", "4.3.2.1", nil, nil})
 
@@ -108,9 +107,11 @@ func TestBase(t *testing.T) {
 	}
 
 	b.Flush()
-	if callCount != 2 {
-		t.Error("Callcount should be 2:", callCount)
-	}
+	/*
+		if callCount != 2 {
+			t.Error("Callcount should be 2:", callCount)
+		}
+	*/
 	stats := b.GetStats()
 	if stats.Committed != 2 {
 		t.Fatalf("Expected %d, Got %d.", 2, stats.Committed)
@@ -119,13 +120,15 @@ func TestBase(t *testing.T) {
 	if len(ins.data) < 1 {
 		t.Fatal("Should have at least one inserted row")
 	}
-	inserted := ins.data[0].(*Row)
-	if inserted.clientAnn == nil || inserted.clientAnn.Geo.PostalCode != "10583" {
-		t.Error("Failed client annotation")
-	}
-	if inserted.serverAnn == nil || inserted.serverAnn.Geo.PostalCode != "10584" {
-		t.Error("Failed server annotation")
-	}
+	/*
+		inserted := ins.data[0].(*Row)
+		if inserted.clientAnn == nil || inserted.clientAnn.Geo.PostalCode != "10583" {
+			t.Error("Failed client annotation")
+		}
+		if inserted.serverAnn == nil || inserted.serverAnn.Geo.PostalCode != "10584" {
+			t.Error("Failed server annotation")
+		}
+	*/
 }
 
 func TestAsyncPut(t *testing.T) {
@@ -151,7 +154,7 @@ func TestAsyncPut(t *testing.T) {
 		ts.Close()
 	}()
 
-	b := row.NewBase("test", ins, 1, v2as.GetAnnotator(ts.URL))
+	b := row.NewBase("test", ins, 1) // , v2as.GetAnnotator(ts.URL))
 
 	b.Put(&Row{"1.2.3.4", "4.3.2.1", nil, nil})
 
@@ -173,13 +176,15 @@ func TestAsyncPut(t *testing.T) {
 	if len(ins.data) < 1 {
 		t.Fatal("Should have at least one inserted row")
 	}
-	inserted := ins.data[0].(*Row)
-	if inserted.clientAnn == nil || inserted.clientAnn.Geo.PostalCode != "10583" {
-		t.Error("Failed client annotation")
-	}
-	if inserted.serverAnn == nil || inserted.serverAnn.Geo.PostalCode != "10584" {
-		t.Error("Failed server annotation")
-	}
+	/*
+		inserted := ins.data[0].(*Row)
+		if inserted.clientAnn == nil || inserted.clientAnn.Geo.PostalCode != "10583" {
+			t.Error("Failed client annotation")
+		}
+		if inserted.serverAnn == nil || inserted.serverAnn.Geo.PostalCode != "10584" {
+			t.Error("Failed server annotation")
+		}
+	*/
 }
 
 func TestErrCommitRow(t *testing.T) {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -16,9 +16,9 @@ import (
 
 // StandardTaskFactory implements task.Factory
 type StandardTaskFactory struct {
-	Sink      factory.SinkFactory
-	Source    factory.SourceFactory
-	Annotator factory.AnnotatorFactory
+	Sink   factory.SinkFactory
+	Source factory.SourceFactory
+	// Annotator factory.AnnotatorFactory
 }
 
 // Get implements task.Factory.Get
@@ -30,12 +30,14 @@ func (tf *StandardTaskFactory) Get(ctx context.Context, dp etl.DataPath) (*task.
 		return nil, err
 	}
 
-	ann, err := tf.Annotator.Get(ctx, dp)
-	if err != nil {
-		e := fmt.Errorf("%v creating annotator for %s", err, dp.GetDataType())
-		log.Println(e, dp.URI)
-		return nil, err
-	}
+	/*
+		ann, err := tf.Annotator.Get(ctx, dp)
+		if err != nil {
+			e := fmt.Errorf("%v creating annotator for %s", err, dp.GetDataType())
+			log.Println(e, dp.URI)
+			return nil, err
+		}
+	*/
 	src, err := tf.Source.Get(ctx, dp)
 	if err != nil {
 		e := fmt.Errorf("%v creating source for %s", err, dp.GetDataType())
@@ -43,7 +45,7 @@ func (tf *StandardTaskFactory) Get(ctx context.Context, dp etl.DataPath) (*task.
 		return nil, err
 	}
 
-	p := parser.NewSinkParser(dp.GetDataType(), sink, src.Type(), ann)
+	p := parser.NewSinkParser(dp.GetDataType(), sink, src.Type())
 	if p == nil {
 		e := fmt.Errorf("%v creating parser for %s", err, dp.GetDataType())
 		log.Println(e, dp.URI)

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -18,7 +18,6 @@ import (
 type StandardTaskFactory struct {
 	Sink   factory.SinkFactory
 	Source factory.SourceFactory
-	// Annotator factory.AnnotatorFactory
 }
 
 // Get implements task.Factory.Get
@@ -30,14 +29,6 @@ func (tf *StandardTaskFactory) Get(ctx context.Context, dp etl.DataPath) (*task.
 		return nil, err
 	}
 
-	/*
-		ann, err := tf.Annotator.Get(ctx, dp)
-		if err != nil {
-			e := fmt.Errorf("%v creating annotator for %s", err, dp.GetDataType())
-			log.Println(e, dp.URI)
-			return nil, err
-		}
-	*/
 	src, err := tf.Source.Get(ctx, dp)
 	if err != nil {
 		e := fmt.Errorf("%v creating source for %s", err, dp.GetDataType())

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -12,14 +12,17 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 
+<<<<<<< HEAD
 	"github.com/m-lab/annotation-service/api"
 	v2 "github.com/m-lab/annotation-service/api/v2"
+=======
+	"github.com/m-lab/go/cloud/bqx"
+>>>>>>> 01587ff (Remove Annotator references)
 	"github.com/m-lab/go/rtx"
 
 	"github.com/m-lab/etl/etl"
@@ -86,6 +89,7 @@ func fromTar(bucket string, fn string) *fakestorage.Server {
 }
 
 // This is also the annotator, so it just returns itself.
+<<<<<<< HEAD
 type fakeAnnotatorFactory struct{}
 
 func (ann *fakeAnnotatorFactory) GetAnnotations(ctx context.Context, date time.Time, ips []string, info ...string) (*v2.Response, error) {
@@ -94,6 +98,21 @@ func (ann *fakeAnnotatorFactory) GetAnnotations(ctx context.Context, date time.T
 
 func (ann *fakeAnnotatorFactory) Get(ctx context.Context, dp etl.DataPath) (v2.Annotator, etl.ProcessingError) {
 	return ann, nil
+=======
+type fakeSinkFactory struct {
+	up etl.Uploader
+}
+
+func (fsf *fakeSinkFactory) Get(ctx context.Context, dp etl.DataPath) (row.Sink, etl.ProcessingError) {
+	if fsf.up == nil {
+		return nil, factory.NewError(dp.DataType, "fakeSinkFactory",
+			http.StatusInternalServerError, errors.New("nil uploader"))
+	}
+	pdt := bqx.PDT{Project: "fake-project", Dataset: "fake-dataset", Table: "fake-table"}
+	in, err := bq.NewColumnPartitionedInserterWithUploader(pdt, fsf.up)
+	rtx.Must(err, "Bad SinkFactory")
+	return in, nil
+>>>>>>> 01587ff (Remove Annotator references)
 }
 
 type fakeSourceFactory struct {
@@ -129,8 +148,13 @@ func TestProcessGKETask(t *testing.T) {
 	fs, sf := NewSinkFactory("test-bucket")
 
 	fakeFactory := worker.StandardTaskFactory{
+<<<<<<< HEAD
 		Sink:   sf,
 		Source: NewSourceFactory("test-bucket"),
+=======
+		Sink:   &fakeSinkFactory{up: up},
+		Source: NewSourceFactory(),
+>>>>>>> 01587ff (Remove Annotator references)
 	}
 
 	filename := "gs://test-bucket/ndt/ndt5/2019/12/01/20191201T020011.395772Z-ndt5-mlab1-bcn01-ndt.tgz"

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -12,17 +12,14 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 
-<<<<<<< HEAD
 	"github.com/m-lab/annotation-service/api"
 	v2 "github.com/m-lab/annotation-service/api/v2"
-=======
-	"github.com/m-lab/go/cloud/bqx"
->>>>>>> 01587ff (Remove Annotator references)
 	"github.com/m-lab/go/rtx"
 
 	"github.com/m-lab/etl/etl"
@@ -89,7 +86,6 @@ func fromTar(bucket string, fn string) *fakestorage.Server {
 }
 
 // This is also the annotator, so it just returns itself.
-<<<<<<< HEAD
 type fakeAnnotatorFactory struct{}
 
 func (ann *fakeAnnotatorFactory) GetAnnotations(ctx context.Context, date time.Time, ips []string, info ...string) (*v2.Response, error) {
@@ -98,21 +94,6 @@ func (ann *fakeAnnotatorFactory) GetAnnotations(ctx context.Context, date time.T
 
 func (ann *fakeAnnotatorFactory) Get(ctx context.Context, dp etl.DataPath) (v2.Annotator, etl.ProcessingError) {
 	return ann, nil
-=======
-type fakeSinkFactory struct {
-	up etl.Uploader
-}
-
-func (fsf *fakeSinkFactory) Get(ctx context.Context, dp etl.DataPath) (row.Sink, etl.ProcessingError) {
-	if fsf.up == nil {
-		return nil, factory.NewError(dp.DataType, "fakeSinkFactory",
-			http.StatusInternalServerError, errors.New("nil uploader"))
-	}
-	pdt := bqx.PDT{Project: "fake-project", Dataset: "fake-dataset", Table: "fake-table"}
-	in, err := bq.NewColumnPartitionedInserterWithUploader(pdt, fsf.up)
-	rtx.Must(err, "Bad SinkFactory")
-	return in, nil
->>>>>>> 01587ff (Remove Annotator references)
 }
 
 type fakeSourceFactory struct {
@@ -148,13 +129,8 @@ func TestProcessGKETask(t *testing.T) {
 	fs, sf := NewSinkFactory("test-bucket")
 
 	fakeFactory := worker.StandardTaskFactory{
-<<<<<<< HEAD
 		Sink:   sf,
 		Source: NewSourceFactory("test-bucket"),
-=======
-		Sink:   &fakeSinkFactory{up: up},
-		Source: NewSourceFactory(),
->>>>>>> 01587ff (Remove Annotator references)
 	}
 
 	filename := "gs://test-bucket/ndt/ndt5/2019/12/01/20191201T020011.395772Z-ndt5-mlab1-bcn01-ndt.tgz"

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -129,9 +129,8 @@ func TestProcessGKETask(t *testing.T) {
 	fs, sf := NewSinkFactory("test-bucket")
 
 	fakeFactory := worker.StandardTaskFactory{
-		Annotator: &fakeAnnotatorFactory{},
-		Sink:      sf,
-		Source:    NewSourceFactory("test-bucket"),
+		Sink:   sf,
+		Source: NewSourceFactory("test-bucket"),
 	}
 
 	filename := "gs://test-bucket/ndt/ndt5/2019/12/01/20191201T020011.395772Z-ndt5-mlab1-bcn01-ndt.tgz"


### PR DESCRIPTION
Now that all network and geographic annotations are static, produced either by the uuid-annotator at measurement time, or historical exports from synthetic uuid annotations, there is no longer any need for the real time annotation logic left from the v1 pipeline.

This change removes almost all references to the annotation parameters and interfaces. The `row` package and references to `row.NullAnnotator` in all current schemas remain to be removed in a future PR.

Part of:
* https://github.com/m-lab/etl/issues/1084

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1087)
<!-- Reviewable:end -->
