### PR TITLE
Change v1beta1 to v1 to unblock GKE upgrades

### DIFF
--- a/k8s/data-processing/persistentvolumes/storage-class.yml
+++ b/k8s/data-processing/persistentvolumes/storage-class.yml
@@ -1,4 +1,4 @@
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: slow
@@ -6,7 +6,7 @@ provisioner: kubernetes.io/gce-pd
 parameters:
   type: pd-standard
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: fast


### PR DESCRIPTION
GKE v1beta1 is deprecated and clusters with these resources are
blocked from upgrading automatically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1099)
<!-- Reviewable:end -->
