### PR TITLE
Add job source bucket to output path

### DIFF
--- a/cmd/etl_worker/etl_worker_test.go
+++ b/cmd/etl_worker/etl_worker_test.go
@@ -182,7 +182,7 @@ func TestLocalRequest(t *testing.T) {
 			}
 
 			// Check the outdir for the successful content of a localwriter.
-			p := filepath.Join(outdir, "ndt/ndt7/2021/06/17/20210617T003002.410133Z-ndt7-mlab1-foo01-ndt.tgz.jsonl")
+			p := filepath.Join(outdir, "archive-mlab-testing/ndt/ndt7/2021/06/17/20210617T003002.410133Z-ndt7-mlab1-foo01-ndt.tgz.jsonl")
 			f, err := os.Open(p)
 			if err != nil {
 				t.Fatalf("failed to read file: %v", err)

--- a/storage/localwriter.go
+++ b/storage/localwriter.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/m-lab/etl/etl"
@@ -84,7 +85,7 @@ type LocalFactory struct {
 
 // Get implements factory.SinkFactory for LocalWriters.
 func (lf *LocalFactory) Get(ctx context.Context, dp etl.DataPath) (row.Sink, etl.ProcessingError) {
-	s, err := NewLocalWriter(lf.outputDir, dp.Path+".jsonl")
+	s, err := NewLocalWriter(lf.outputDir, path.Join(dp.Bucket, dp.Path+".jsonl"))
 	if err != nil {
 		return nil, factory.NewError(dp.DataType, "LocalFactory", http.StatusInternalServerError, err)
 	}

--- a/storage/localwriter_test.go
+++ b/storage/localwriter_test.go
@@ -220,7 +220,7 @@ func TestNewLocalFactory(t *testing.T) {
 			if tt.wantOpenErr {
 				// Make directory so open will fail.
 				err := os.MkdirAll(filepath.Join(tt.outputDir,
-					"exp/ndt7/2021/06/01/20210601T101003.000001Z-ndt7-mlab4-foo01-exp.tgz.jsonl"), os.ModePerm)
+					"bucket/exp/ndt7/2021/06/01/20210601T101003.000001Z-ndt7-mlab4-foo01-exp.tgz.jsonl"), os.ModePerm)
 				testingx.Must(t, err, "failed to mkdir")
 			}
 

--- a/storage/rowwriter.go
+++ b/storage/rowwriter.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"path"
 	"time"
 
 	gcs "cloud.google.com/go/storage"
@@ -177,7 +178,7 @@ type SinkFactory struct {
 
 // Get implements factory.SinkFactory
 func (sf *SinkFactory) Get(ctx context.Context, dp etl.DataPath) (row.Sink, etl.ProcessingError) {
-	s, err := NewRowWriter(ctx, sf.client, sf.outputBucket, dp.Path+".json")
+	s, err := NewRowWriter(ctx, sf.client, sf.outputBucket, path.Join(dp.Bucket, dp.Path+".jsonl"))
 	if err != nil {
 		return nil, factory.NewError(dp.DataType, "SinkFactory",
 			http.StatusInternalServerError, err)

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -142,7 +142,7 @@ func TestProcessGKETask(t *testing.T) {
 	checkCounter(t, c, 478)
 
 	// Lookup output from task.
-	o, err := fs.GetObject("test-bucket", "ndt/ndt5/2019/12/01/20191201T020011.395772Z-ndt5-mlab1-bcn01-ndt.tgz.json")
+	o, err := fs.GetObject("test-bucket", "test-bucket/ndt/ndt5/2019/12/01/20191201T020011.395772Z-ndt5-mlab1-bcn01-ndt.tgz.jsonl")
 	if err != nil {
 		t.Errorf("GetObject() expected nil error, got %v", err)
 	}


### PR DESCRIPTION
Today, when we [change the archive source bucket](https://github.com/m-lab/etl-gardener/blob/master/config/config.yml#L9-L11) for a datatype in the gardener config, the output data mixes results from two different sources. We can work around this by deleting the bucket directory, but this is slow. Better for them to remain separate.

This change includes the job source bucket in the output path so that the gardener system preserves the separation between the two directories.

Both the parser and gardener must agree on this path. So, this change must be deployed with its companion in etl-gardener https://github.com/m-lab/etl-gardener/pull/407

Part of:
* https://github.com/m-lab/etl-gardener/issues/349

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1101)
<!-- Reviewable:end -->
