### PR TITLE
Fix bug with snapshot thinning.

### DIFF
--- a/parser/tcpinfo.go
+++ b/parser/tcpinfo.go
@@ -98,7 +98,7 @@ func (p *TCPInfoParser) IsParsable(testName string, data []byte) (string, bool) 
 
 func thinSnaps(orig []snapshot.Snapshot) []snapshot.Snapshot {
 	n := len(orig)
-	if (n=0) {
+	if (n == 0) {
 		return orig
 	}
 	out := make([]snapshot.Snapshot, 0, 1+n/10)

--- a/parser/tcpinfo.go
+++ b/parser/tcpinfo.go
@@ -98,13 +98,16 @@ func (p *TCPInfoParser) IsParsable(testName string, data []byte) (string, bool) 
 
 func thinSnaps(orig []snapshot.Snapshot) []snapshot.Snapshot {
 	n := len(orig)
+	if (n=0) {
+		return orig
+	}
 	out := make([]snapshot.Snapshot, 0, 1+n/10)
-	for i := 0; i < n; i += 10 {
+	// Take first and every 10th snapshot after (exluding the final snapshot, which is always included).
+	for i := 0; i < n-1; i += 10 {
 		out = append(out, orig[i])
 	}
-	if n%10 != 0 {
-		out = append(out, orig[n-1])
-	}
+	// Always append final snapshot.
+	out = append(out, orig[n-1])
 	return out
 }
 


### PR DESCRIPTION
In the current version, the snapshot thinning does not work properly because the `n%10 != 0` check, intended to always add the final snapshot, suffers from an off-by-one error.

Concretely, the main loop in the function appends snapshots at index 0, 10, 20, 30, ...; i.e. the first element and every tenth after. Second, the final check tests whether the list of snapshots is a multiple of 10, and if not adds the final element. And this is where the problem lies: the loop does not take every tenth element, it takes the first one and then every tenth _after_, i.e. the 11th, 21st, 31st, etc -- it is essentially shifted by 1, and thus the `n%10` check is incorrect. This leads to the following behavior: If the list has a length that is a multiple of 10, the final element will be excluded. If it has a length of a multiple of 10 _plus 1_, the final element will be duplicated. Here's an illustration:

```
IN:  []
OUT: []
---
IN:  [0]
OUT: [0, 0]
---
IN:  [0, 1]
OUT: [0, 1]
---
IN:  [0, 1, 2]
OUT: [0, 2]
---
IN:  [0, 1, 2, 3]
OUT: [0, 3]
---
IN:  [0, 1, 2, 3, 4]
OUT: [0, 4]
---
IN:  [0, 1, 2, 3, 4, 5]
OUT: [0, 5]
---
IN:  [0, 1, 2, 3, 4, 5, 6]
OUT: [0, 6]
---
IN:  [0, 1, 2, 3, 4, 5, 6, 7]
OUT: [0, 7]
---
IN:  [0, 1, 2, 3, 4, 5, 6, 7, 8]
OUT: [0, 8]
---
IN:  [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
OUT: [0]
---
IN:  [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
OUT: [0, 10, 10]
---
IN:  [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
OUT: [0, 10, 11]
```

In this PR, I simplify the code somewhat to avoid the index check: The main loop only considers elements up to, but excluding the last one (`i < n-1`). Afterwards, the last element is always added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1104)
<!-- Reviewable:end -->
