### PR TITLE
Fix thinSnaps

### DIFF
--- a/parser/export_test.go
+++ b/parser/export_test.go
@@ -11,3 +11,6 @@ var InitParserVersionForTest = initParserVersion
 // InitParserGitCommitForTest allows test to rerun initParseGitCommit after initializing
 // environement variables.
 var InitParserGitCommitForTest = initParserGitCommit
+
+// ThinSnaps allows exhaustive edge case testing of thinSnaps.
+var ThinSnaps = thinSnaps

--- a/parser/tcpinfo.go
+++ b/parser/tcpinfo.go
@@ -96,15 +96,19 @@ func (p *TCPInfoParser) IsParsable(testName string, data []byte) (string, bool) 
 	return "", false
 }
 
+// thinSnaps collects every 10th snapshot in orig. thinSnaps guarantees that the last snapshot is preserved.
 func thinSnaps(orig []snapshot.Snapshot) []snapshot.Snapshot {
 	n := len(orig)
+	if n == 0 {
+		return orig
+	}
 	out := make([]snapshot.Snapshot, 0, 1+n/10)
-	for i := 0; i < n; i += 10 {
+	// Take first and every 10th snapshot after (exluding the final snapshot, which is always included).
+	for i := 0; i < n-1; i += 10 {
 		out = append(out, orig[i])
 	}
-	if n%10 != 0 {
-		out = append(out, orig[n-1])
-	}
+	// Always append final snapshot.
+	out = append(out, orig[n-1])
 	return out
 }
 

--- a/parser/tcpinfo_test.go
+++ b/parser/tcpinfo_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/civil"
+	"github.com/go-test/deep"
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/parser"
 	"github.com/m-lab/etl/schema"
@@ -169,6 +170,10 @@ func TestTCPParser(t *testing.T) {
 		if row.A.SockID.SrcIP != "195.89.146.242" && row.A.SockID.SrcIP != "2001:5012:100:24::242" {
 			t.Error("Wrong SrcIP", row.A.SockID.SrcIP)
 		}
+		// Guarantee that FinalSnapshot matches the last raw snapshot.
+		if diff := deep.Equal(row.A.FinalSnapshot, row.Raw.Snapshots[len(row.Raw.Snapshots)-1]); diff != nil {
+			t.Errorf("TestTCPParser.ParseAndInsert() FinalSnapshot and last snapshot differ: %s", strings.Join(diff, "\n"))
+		}
 	}
 
 	// This section is just for understanding how big these objects typically are, and what kind of compression
@@ -200,10 +205,6 @@ func TestTCPParser(t *testing.T) {
 
 	if duration > 20*time.Second {
 		t.Error("Incorrect duration calculation", duration)
-	}
-
-	if totalSnaps != 1588 {
-		t.Error("expected 1588 (thinned) snapshots, got", totalSnaps)
 	}
 }
 


### PR DESCRIPTION
This change completes fixes the bug reported by @NotSpecial - https://github.com/m-lab/etl/pull/1104 with an update to the unit test to check that every `FinalSnapshot` matches the last snapshot of the raw, thinned snapshots.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1105)
<!-- Reviewable:end -->
