### PR TITLE
Remove obsolete NDT5ResultRow type definition

### DIFF
--- a/schema/ndt5_result.go
+++ b/schema/ndt5_result.go
@@ -10,30 +10,6 @@ import (
 	"github.com/m-lab/ndt-server/data"
 )
 
-// NDT5ResultRow defines the BQ schema for the data.NDT5Result produced by the
-// ndt-server for NDT client measurements.
-// Deprecated - use V1 for Gardener 2.0
-type NDT5ResultRow struct {
-	ParseInfo *ParseInfoV0
-	TestID    string          `json:"test_id,string" bigquery:"test_id"`
-	LogTime   int64           `json:"log_time,int64" bigquery:"log_time"`
-	Result    data.NDT5Result `json:"result" bigquery:"result"`
-}
-
-// Schema returns the BigQuery schema for NDT5ResultRow.
-func (row *NDT5ResultRow) Schema() (bigquery.Schema, error) {
-	sch, err := bigquery.InferSchema(row)
-	if err != nil {
-		return bigquery.Schema{}, err
-	}
-	docs := FindSchemaDocsFor(row)
-	for _, doc := range docs {
-		bqx.UpdateSchemaDescription(sch, doc)
-	}
-	rr := bqx.RemoveRequired(sch)
-	return rr, err
-}
-
 // NDT5ResultRowV2 defines the BQ schema for the data.NDT5Result produced by the
 // ndt-server for NDT client measurements.
 type NDT5ResultRowV2 struct {

--- a/schema/ndt5_result_test.go
+++ b/schema/ndt5_result_test.go
@@ -9,33 +9,6 @@ import (
 	"github.com/m-lab/go/cloud/bqx"
 )
 
-func TestNDT5Result_Schema(t *testing.T) {
-	row := &NDT5ResultRow{}
-	got, err := row.Schema()
-	if err != nil {
-		t.Errorf("NDT5Result.Schema() error = %v, expected nil", err)
-		return
-	}
-	count := 0
-	// The complete schema is large, so verify that field descriptions
-	// are present for select fields by walking the schema and looking for them.
-	bqx.WalkSchema(got, func(prefix []string, field *bigquery.FieldSchema) error {
-		for _, name := range []string{"test_id", "ParseInfo", "GitShortCommit"} {
-			if field.Name == name {
-				if field.Description == "" {
-					t.Errorf("NDT5Result.Schema() missing field.Description for %q", field.Name)
-				} else {
-					count++
-				}
-			}
-		}
-		return nil
-	})
-	if count != 3 {
-		t.Errorf("NDT5Result.Schema() missing expected fields; got %d, want 3", count)
-	}
-}
-
 func TestNDT5ResultV2_Schema(t *testing.T) {
 	row := &NDT5ResultRowV2{}
 	got, err := row.Schema()

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -29,18 +29,18 @@ func Test_findSchemaDocsFor(t *testing.T) {
 	}{
 		{
 			name:  "literal",
-			value: schema.NDT5ResultRow{},
+			value: schema.NDT5ResultRowV2{},
 			want: []bqx.SchemaDoc{
 				bqx.NewSchemaDoc(mustReadFile(t, "descriptions/toplevel.yaml")),
-				bqx.NewSchemaDoc(mustReadFile(t, "descriptions/NDT5ResultRow.yaml")),
+				bqx.NewSchemaDoc(mustReadFile(t, "descriptions/NDT5ResultRowV2.yaml")),
 			},
 		},
 		{
 			name:  "pointer",
-			value: &schema.NDT5ResultRow{},
+			value: &schema.NDT5ResultRowV2{},
 			want: []bqx.SchemaDoc{
 				bqx.NewSchemaDoc(mustReadFile(t, "descriptions/toplevel.yaml")),
-				bqx.NewSchemaDoc(mustReadFile(t, "descriptions/NDT5ResultRow.yaml")),
+				bqx.NewSchemaDoc(mustReadFile(t, "descriptions/NDT5ResultRowV2.yaml")),
 			},
 		},
 		{


### PR DESCRIPTION
This change is a cleanup and removes an obsolete version of the NDT5ResultRow structure, long replaced by the NDT5ResultRowV2 structure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1115)
<!-- Reviewable:end -->
