### PR TITLE
Add etl.ParserMetadata for passing task metadata to parsers

### DIFF
--- a/etl/etl.go
+++ b/etl/etl.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"time"
 
-	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/civil"
 )
 
@@ -22,7 +21,8 @@ type ProcessingError interface {
 // RowStats interface defines some useful Inserter stats that will also be
 // implemented by Parser.
 // RowStats implementations should provide the invariants:
-//   Accepted == Failed + Committed + RowsInBuffer
+//
+//	Accepted == Failed + Committed + RowsInBuffer
 type RowStats interface {
 	// RowsInBuffer returns the count of rows currently in the buffer.
 	RowsInBuffer() int
@@ -36,7 +36,8 @@ type RowStats interface {
 
 // Inserter is a data sink that writes to BigQuery tables.
 // Inserters should provide the invariants:
-//   After Flush() returns, RowsInBuffer == 0
+//
+//	After Flush() returns, RowsInBuffer == 0
 type Inserter interface {
 	// Put synchronously sends a slice of rows to BigQuery
 	// This is THREADSAFE
@@ -102,6 +103,15 @@ type InserterParams struct {
 	MaxRetryDelay time.Duration // Maximum backoff time for Put retries.
 }
 
+// ParserMetadata provides archive metadata for use by parsers.
+type ParserMetadata struct {
+	Version    string
+	ArchiveURL string
+	GitCommit  string
+	Date       civil.Date
+	Start      time.Time
+}
+
 // ErrHighInsertionFailureRate should be returned by TaskError when there are more than 10% BQ insertion errors.
 var ErrHighInsertionFailureRate = errors.New("too many insertion failures")
 
@@ -116,7 +126,7 @@ type Parser interface {
 	// meta - metadata, e.g. from the original tar file name.
 	// testName - Name of test file (typically extracted from a tar file)
 	// test - binary test data
-	ParseAndInsert(meta map[string]bigquery.Value, testName string, test []byte) error
+	ParseAndInsert(meta ParserMetadata, testName string, test []byte) error
 
 	// Flush flushes any pending rows.
 	Flush() error

--- a/parser/annotation2_test.go
+++ b/parser/annotation2_test.go
@@ -5,7 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	"cloud.google.com/go/bigquery"
+	"github.com/m-lab/etl/etl"
+
 	"cloud.google.com/go/civil"
 	"github.com/go-test/deep"
 	"github.com/m-lab/etl/parser"
@@ -45,9 +46,11 @@ func TestAnnotation2Parser_ParseAndInsert(t *testing.T) {
 				t.Fatal("IsParsable() failed; got false, want true")
 			}
 
-			meta := map[string]bigquery.Value{
-				"filename": "gs://mlab-test-bucket/ndt/ndt7/2020/03/18/" + tt.file,
-				"date":     civil.Date{Year: 2020, Month: 3, Day: 18},
+			meta := etl.ParserMetadata{
+				ArchiveURL: "gs://mlab-test-bucket/ndt/ndt7/2020/03/18/" + tt.file,
+				Date:       civil.Date{Year: 2020, Month: 3, Day: 18},
+				Version:    parser.Version(),
+				GitCommit:  parser.GitCommit(),
 			}
 
 			if err := n.ParseAndInsert(meta, tt.file, data); (err != nil) != tt.wantErr {

--- a/parser/hopannotation2_test.go
+++ b/parser/hopannotation2_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/civil"
 	"github.com/go-test/deep"
+	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/parser"
 	"github.com/m-lab/etl/schema"
 	"github.com/m-lab/go/rtx"
@@ -31,9 +31,11 @@ func TestHopAnnotation2Parser_ParseAndInsert(t *testing.T) {
 
 	date := civil.Date{Year: 2021, Month: 07, Day: 30}
 
-	meta := map[string]bigquery.Value{
-		"filename": path.Join(hopAnnotation2GCSPath, hopAnnotation2Filename),
-		"date":     date,
+	meta := etl.ParserMetadata{
+		ArchiveURL: path.Join(hopAnnotation2GCSPath, hopAnnotation2Filename),
+		Date:       date,
+		Version:    parser.Version(),
+		GitCommit:  parser.GitCommit(),
 	}
 
 	if err := n.ParseAndInsert(meta, hopAnnotation2Filename, data); err != nil {

--- a/parser/ndt5_result.go
+++ b/parser/ndt5_result.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/civil"
 
 	"github.com/m-lab/etl/etl"
@@ -66,7 +65,7 @@ func (dp *NDT5ResultParser) IsParsable(testName string, data []byte) (string, bo
 // backend and to eventually rely on the schema inference in m-lab/go/cloud/bqx.CreateTable().
 
 // ParseAndInsert decodes the data.NDT5Result JSON and inserts it into BQ.
-func (dp *NDT5ResultParser) ParseAndInsert(meta map[string]bigquery.Value, testName string, test []byte) error {
+func (dp *NDT5ResultParser) ParseAndInsert(meta etl.ParserMetadata, testName string, test []byte) error {
 	metrics.WorkerState.WithLabelValues(dp.TableName(), "ndt5_result").Inc()
 	defer metrics.WorkerState.WithLabelValues(dp.TableName(), "ndt5_result").Dec()
 
@@ -85,13 +84,13 @@ func (dp *NDT5ResultParser) ParseAndInsert(meta map[string]bigquery.Value, testN
 	}
 
 	parser := schema.ParseInfo{
-		Version:    Version(),
+		Version:    meta.Version,
 		Time:       time.Now(),
-		ArchiveURL: meta["filename"].(string),
+		ArchiveURL: meta.ArchiveURL,
 		Filename:   testName,
-		GitCommit:  GitCommit(),
+		GitCommit:  meta.GitCommit,
 	}
-	date := meta["date"].(civil.Date)
+	date := meta.Date
 
 	// Since ndt5 rows can include both download (S2C) and upload (C2S)
 	// measurements (or neither), check and write independent rows for either

--- a/parser/ndt5_result_test.go
+++ b/parser/ndt5_result_test.go
@@ -8,7 +8,7 @@ import (
 
 	"cloud.google.com/go/civil"
 
-	"cloud.google.com/go/bigquery"
+	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/parser"
 	"github.com/m-lab/etl/schema"
 )
@@ -60,9 +60,11 @@ func TestNDT5ResultParser_ParseAndInsert(t *testing.T) {
 			if err != nil {
 				t.Fatalf(err.Error())
 			}
-			meta := map[string]bigquery.Value{
-				"filename": "gs://mlab-test-bucket/ndt/ndt5/2019/08/22/ndt_ndt5_2019_08_22_20190822T194819.568936Z-ndt5-mlab1-lga0t-ndt.tgz",
-				"date":     d,
+			meta := etl.ParserMetadata{
+				ArchiveURL: "gs://mlab-test-bucket/ndt/ndt5/2019/08/22/ndt_ndt5_2019_08_22_20190822T194819.568936Z-ndt5-mlab1-lga0t-ndt.tgz",
+				Date:       d,
+				Version:    parser.Version(),
+				GitCommit:  parser.GitCommit(),
 			}
 
 			if err := n.ParseAndInsert(meta, tt.testName, resultData); (err != nil) != tt.wantErr {

--- a/parser/ndt7_result_test.go
+++ b/parser/ndt7_result_test.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"testing"
 
-	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/civil"
 	"github.com/go-test/deep"
 
+	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/parser"
 	"github.com/m-lab/etl/schema"
 	"github.com/m-lab/go/pretty"
@@ -23,9 +23,11 @@ func setupNDT7InMemoryParser(t *testing.T, testName string) (*schema.NDT7ResultR
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	meta := map[string]bigquery.Value{
-		"filename": "gs://mlab-test-bucket/ndt/ndt7/2020/03/18/ndt_ndt7_2020_03_18_20200318T003853.425987Z-ndt7-mlab3-syd03-ndt.tgz",
-		"date":     civil.Date{Year: 2020, Month: 3, Day: 18},
+	meta := etl.ParserMetadata{
+		ArchiveURL: "gs://mlab-test-bucket/ndt/ndt7/2020/03/18/ndt_ndt7_2020_03_18_20200318T003853.425987Z-ndt7-mlab3-syd03-ndt.tgz",
+		Date:       civil.Date{Year: 2020, Month: 3, Day: 18},
+		Version:    parser.Version(),
+		GitCommit:  parser.GitCommit(),
 	}
 	err = n.ParseAndInsert(meta, testName, resultData)
 	if err != nil {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1,5 +1,4 @@
 // TODO(soon) Implement good tests for the existing parsers.
-//
 package parser_test
 
 import (
@@ -125,7 +124,7 @@ func TestGetHopID(t *testing.T) {
 	}
 }
 
-//------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------
 // TestParser ignores the content, returns a MapSaver containing meta data and
 // "testname":"..."
 // TODO add tests
@@ -144,14 +143,15 @@ func (tp *TestParser) IsParsable(testName string, test []byte) (string, bool) {
 	return "ext", true
 }
 
-func (tp *TestParser) ParseAndInsert(meta map[string]bigquery.Value, testName string, test []byte) error {
+func (tp *TestParser) ParseAndInsert(meta etl.ParserMetadata, testName string, test []byte) error {
 	metrics.TestTotal.WithLabelValues("table", "test", "ok").Inc()
-	values := make(map[string]bigquery.Value, len(meta)+1)
-	// TODO is there a better way to do this?
-	for k, v := range meta {
-		values[k] = v
+	values := map[string]bigquery.Value{
+		"filename":   meta.ArchiveURL,
+		"date":       meta.Date,
+		"version":    meta.Version,
+		"git_commit": meta.GitCommit,
+		"testname":   testName,
 	}
-	values["testname"] = testName
 	return tp.inserter.InsertRow(values)
 }
 
@@ -174,7 +174,7 @@ func TestPlumbing(t *testing.T) {
 	tci := countingInserter{}
 	var ti etl.Inserter = &tci
 	var p etl.Parser = NewTestParser(ti)
-	err := p.ParseAndInsert(nil, "foo", foo[:])
+	err := p.ParseAndInsert(etl.ParserMetadata{}, "foo", foo[:])
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/parser/pcap.go
+++ b/parser/pcap.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"cloud.google.com/go/bigquery"
-	"cloud.google.com/go/civil"
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcapgo"
@@ -144,17 +142,17 @@ func (p *PCAPParser) IsParsable(testName string, data []byte) (string, bool) {
 }
 
 // ParseAndInsert decodes the PCAP data and inserts it into BQ.
-func (p *PCAPParser) ParseAndInsert(fileMetadata map[string]bigquery.Value, testName string, rawContent []byte) error {
+func (p *PCAPParser) ParseAndInsert(meta etl.ParserMetadata, testName string, rawContent []byte) error {
 	metrics.WorkerState.WithLabelValues(p.TableName(), "pcap").Inc()
 	defer metrics.WorkerState.WithLabelValues(p.TableName(), "pcap").Dec()
 
 	row := schema.PCAPRow{
 		Parser: schema.ParseInfo{
-			Version:    Version(),
+			Version:    meta.Version,
 			Time:       time.Now(),
-			ArchiveURL: fileMetadata["filename"].(string),
+			ArchiveURL: meta.ArchiveURL,
 			Filename:   testName,
-			GitCommit:  GitCommit(),
+			GitCommit:  meta.GitCommit,
 		},
 	}
 
@@ -162,7 +160,7 @@ func (p *PCAPParser) ParseAndInsert(fileMetadata map[string]bigquery.Value, test
 	// the given timestamp, regardless of the timestamp's timezone. Since we
 	// run our systems in UTC, all timestamps will be relative to UTC and as
 	// will these dates.
-	row.Date = fileMetadata["date"].(civil.Date)
+	row.Date = meta.Date
 	row.ID = p.GetUUID(testName)
 
 	// Parse top level PCAP data and update metrics.

--- a/parser/pcap_test.go
+++ b/parser/pcap_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/civil"
 	"github.com/go-test/deep"
+	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/parser"
 	"github.com/m-lab/etl/schema"
 	"github.com/m-lab/go/rtx"
@@ -31,9 +31,11 @@ func TestPCAPParser_ParseAndInsert(t *testing.T) {
 
 	date := civil.Date{Year: 2021, Month: 07, Day: 22}
 
-	meta := map[string]bigquery.Value{
-		"filename": path.Join(pcapGCSPath, pcapFilename),
-		"date":     date,
+	meta := etl.ParserMetadata{
+		ArchiveURL: path.Join(pcapGCSPath, pcapFilename),
+		Date:       date,
+		Version:    parser.Version(),
+		GitCommit:  parser.GitCommit(),
 	}
 
 	if err := n.ParseAndInsert(meta, pcapFilename, data); err != nil {

--- a/parser/scamper1.go
+++ b/parser/scamper1.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"cloud.google.com/go/bigquery"
-	"cloud.google.com/go/civil"
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/metrics"
 	"github.com/m-lab/etl/row"
@@ -97,7 +95,7 @@ func (p *Scamper1Parser) IsParsable(testName string, data []byte) (string, bool)
 }
 
 // ParseAndInsert decodes the scamper1 data and inserts it into BQ.
-func (p *Scamper1Parser) ParseAndInsert(fileMetadata map[string]bigquery.Value, testName string, rawContent []byte) error {
+func (p *Scamper1Parser) ParseAndInsert(meta etl.ParserMetadata, testName string, rawContent []byte) error {
 	metrics.WorkerState.WithLabelValues(p.TableName(), scamper1).Inc()
 	defer metrics.WorkerState.WithLabelValues(p.TableName(), scamper1).Dec()
 
@@ -108,7 +106,7 @@ func (p *Scamper1Parser) ParseAndInsert(fileMetadata map[string]bigquery.Value, 
 	}
 
 	rawData, err := trcParser.ParseRawData(rawContent)
-	archiveURL := fileMetadata["filename"].(string)
+	archiveURL := meta.ArchiveURL
 	if err != nil {
 		metrics.TestTotal.WithLabelValues(p.TableName(), scamper1, err.Error()).Inc()
 		return fmt.Errorf("failed to parse scamper1 file: %s, archiveURL: %s, error: %w", testName, archiveURL, err)
@@ -128,17 +126,17 @@ func (p *Scamper1Parser) ParseAndInsert(fileMetadata map[string]bigquery.Value, 
 	parseTracelb(&bqScamperOutput, scamperOutput.Tracelb)
 
 	parseInfo := schema.ParseInfo{
-		Version:    Version(),
+		Version:    meta.Version,
 		Time:       time.Now(),
-		ArchiveURL: archiveURL,
+		ArchiveURL: meta.ArchiveURL,
 		Filename:   testName,
-		GitCommit:  GitCommit(),
+		GitCommit:  meta.GitCommit,
 	}
 
 	row := schema.Scamper1Row{
 		ID:     bqScamperOutput.Metadata.UUID,
 		Parser: parseInfo,
-		Date:   fileMetadata["date"].(civil.Date),
+		Date:   meta.Date,
 		Raw:    bqScamperOutput,
 	}
 

--- a/parser/scamper1_test.go
+++ b/parser/scamper1_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/civil"
 	"github.com/go-test/deep"
+	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/parser"
 	"github.com/m-lab/etl/schema"
 	"github.com/m-lab/go/rtx"
@@ -25,9 +25,11 @@ func TestScamper1Parser_ParseAndInsert(t *testing.T) {
 	data, err := ioutil.ReadFile(path.Join("testdata/Scamper1/", file))
 	rtx.Must(err, "failed to load test file")
 
-	meta := map[string]bigquery.Value{
-		"filename": file,
-		"date":     civil.Date{Year: 2021, Month: 9, Day: 14},
+	meta := etl.ParserMetadata{
+		ArchiveURL: file,
+		Date:       civil.Date{Year: 2021, Month: 9, Day: 14},
+		Version:    parser.Version(),
+		GitCommit:  parser.GitCommit(),
 	}
 
 	err = n.ParseAndInsert(meta, file, data)
@@ -57,9 +59,11 @@ func TestScamper1Parser_ParserAndInsertError(t *testing.T) {
 	data, err := ioutil.ReadFile(path.Join("testdata/Scamper1/", file))
 	rtx.Must(err, "failed to load test file")
 
-	meta := map[string]bigquery.Value{
-		"filename": file,
-		"date":     civil.Date{Year: 2021, Month: 9, Day: 8},
+	meta := etl.ParserMetadata{
+		ArchiveURL: file,
+		Date:       civil.Date{Year: 2021, Month: 9, Day: 8},
+		Version:    parser.Version(),
+		GitCommit:  parser.GitCommit(),
 	}
 
 	err = n.ParseAndInsert(meta, file, data)

--- a/parser/switch_test.go
+++ b/parser/switch_test.go
@@ -7,8 +7,8 @@ import (
 	"path"
 	"testing"
 
-	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/civil"
+	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/parser"
 	"github.com/m-lab/etl/schema"
 	"github.com/m-lab/go/rtx"
@@ -29,9 +29,11 @@ func TestSwitchParser_ParseAndInsert(t *testing.T) {
 	rtx.Must(err, "failed to load DISCOv2 test file")
 
 	date := civil.Date{Year: 2021, Month: 12, Day: 14}
-	meta := map[string]bigquery.Value{
-		"filename": path.Join(switchGCSPath, switchDISCOv2Filename),
-		"date":     date,
+	meta := etl.ParserMetadata{
+		ArchiveURL: path.Join(switchGCSPath, switchDISCOv2Filename),
+		Date:       date,
+		Version:    parser.Version(),
+		GitCommit:  parser.GitCommit(),
 	}
 
 	if err := n.ParseAndInsert(meta, switchDISCOv2Filename, data); err != nil {
@@ -94,11 +96,8 @@ func TestSwitchParser_ParseAndInsert(t *testing.T) {
 	data, err = ioutil.ReadAll(reader)
 	rtx.Must(err, "failed to read from gzip stream")
 
-	date = civil.Date{Year: 2016, Month: 05, Day: 12}
-	meta = map[string]bigquery.Value{
-		"filename": path.Join(switchGCSPath, switchDISCOv1Filename),
-		"date":     date,
-	}
+	meta.ArchiveURL = path.Join(switchGCSPath, switchDISCOv1Filename)
+	meta.Date = civil.Date{Year: 2016, Month: 05, Day: 12}
 
 	if err := n.ParseAndInsert(meta, switchDISCOv1Filename, data); err != nil {
 		t.Errorf("SwitchParser.ParseAndInsert() error = %v, wantErr %v", err, true)

--- a/parser/tcpinfo.go
+++ b/parser/tcpinfo.go
@@ -20,9 +20,6 @@ import (
 	"strings"
 	"time"
 
-	"cloud.google.com/go/bigquery"
-	"cloud.google.com/go/civil"
-
 	"github.com/valyala/gozstd"
 
 	"github.com/m-lab/tcp-info/netlink"
@@ -114,7 +111,7 @@ func thinSnaps(orig []snapshot.Snapshot) []snapshot.Snapshot {
 
 // ParseAndInsert extracts all ArchivalRecords from the rawContent and inserts into a single row.
 // Approximately 15 usec/snapshot.
-func (p *TCPInfoParser) ParseAndInsert(meta map[string]bigquery.Value, testName string, rawContent []byte) error {
+func (p *TCPInfoParser) ParseAndInsert(meta etl.ParserMetadata, testName string, rawContent []byte) error {
 	tableName := p.FullTableName()
 	metrics.WorkerState.WithLabelValues(tableName, "tcpinfo").Inc()
 	defer metrics.WorkerState.WithLabelValues(tableName, "tcpinfo").Dec()
@@ -184,13 +181,13 @@ func (p *TCPInfoParser) ParseAndInsert(meta map[string]bigquery.Value, testName 
 			FinalSnapshot: snaps[len(snaps)-1],
 		},
 		Parser: schema.ParseInfo{
-			Version:    Version(),
+			Version:    meta.Version,
 			Time:       time.Now(),
-			ArchiveURL: meta["filename"].(string),
+			ArchiveURL: meta.ArchiveURL,
 			Filename:   testName,
-			GitCommit:  GitCommit(),
+			GitCommit:  meta.GitCommit,
 		},
-		Date: meta["date"].(civil.Date),
+		Date: meta.Date,
 		Raw: &snapshot.ConnectionLog{
 			Metadata: tcpMeta,
 			// TODO(https://github.com/m-lab/etl/issues/1068) - consider minimizing snapshot thinning.

--- a/task/task.go
+++ b/task/task.go
@@ -12,7 +12,7 @@ import (
 	"log"
 	"time"
 
-	"cloud.google.com/go/bigquery"
+	"github.com/m-lab/etl/parser"
 
 	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/etl/metrics"
@@ -41,26 +41,29 @@ type Task struct {
 	etl.TestSource // Source from which to read tests.
 	etl.Parser     // Parser to parse the tests.
 
-	meta        map[string]bigquery.Value // Metadata about this task.
-	maxFileSize int64                     // Max file size to avoid OOM.
+	meta etl.ParserMetadata // Common information about the archive being parsed.
+
+	maxFileSize int64 // Max file size to avoid OOM.
 
 	closer io.Closer // So we can call Close()
 }
 
 // NewTask constructs a task, injecting the source and the parser.
-func NewTask(filename string, src etl.TestSource, prsr etl.Parser, closer io.Closer) *Task {
+func NewTask(archive string, src etl.TestSource, prsr etl.Parser, closer io.Closer) *Task {
 	// TODO - should the meta data be a nested type?
-	meta := make(map[string]bigquery.Value, 3)
-	meta["filename"] = filename
-	meta["parse_time"] = time.Now()
-	meta["attempt"] = 1
-	meta["date"] = src.Date()
 	t := Task{
-		TestSource:  src,
-		Parser:      prsr,
-		meta:        meta,
+		TestSource: src,
+		Parser:     prsr,
+		meta: etl.ParserMetadata{
+			Version:    parser.Version(),
+			ArchiveURL: archive,
+			GitCommit:  parser.GitCommit(),
+			Date:       src.Date(),
+			Start:      time.Now(),
+		},
 		maxFileSize: DefaultMaxFileSize,
-		closer:      closer}
+		closer:      closer,
+	}
 	return &t
 }
 
@@ -105,8 +108,8 @@ OUTER:
 				break OUTER
 			case loopErr == storage.ErrOversizeFile:
 				log.Printf("ERROR filename:%s testname:%s files:%d, duration:%v err:%v",
-					tt.meta["filename"], testname, files,
-					time.Since(tt.meta["parse_time"].(time.Time)), loopErr)
+					tt.meta.ArchiveURL, testname, files,
+					time.Since(tt.meta.Start), loopErr)
 				metrics.TestTotal.WithLabelValues(
 					tt.Type(), "unknown", "oversize file").Inc()
 				continue OUTER
@@ -122,8 +125,8 @@ OUTER:
 				// Because of the break, this error is passed up, and counted at
 				// the Task level.
 				log.Printf("ERROR filename:%s testname:%s files:%d, duration:%v err:%v",
-					tt.meta["filename"], testname, files,
-					time.Since(tt.meta["parse_time"].(time.Time)), loopErr)
+					tt.meta.ArchiveURL, testname, files,
+					time.Since(tt.meta.Start), loopErr)
 
 				metrics.TestTotal.WithLabelValues(
 					tt.Type(), "unknown", "unrecovered").Inc()
@@ -179,7 +182,7 @@ OUTER:
 	// TODO - make this debug or remove
 	log.Printf("Processed %d files, %d nil data, %d rows committed, %d failed, from %s into %s",
 		files, nilData, tt.Parser.Committed(), tt.Parser.Failed(),
-		tt.meta["filename"], tt.Parser.FullTableName())
+		tt.meta.ArchiveURL, tt.Parser.FullTableName())
 
 	// We expect the loopErr to be io.EOF.  If it is something else, then
 	// it is an actual error, and we want to return that error.

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -1,5 +1,4 @@
 // TODO(dev) add test overview
-//
 package task_test
 
 import (
@@ -9,8 +8,6 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
-
-	"cloud.google.com/go/bigquery"
 
 	"time"
 
@@ -89,7 +86,7 @@ func (tp *TestParser) TaskError() error {
 }
 
 // TODO - pass testName through to BQ inserter?
-func (tp *TestParser) ParseAndInsert(meta map[string]bigquery.Value, testName string, test []byte) error {
+func (tp *TestParser) ParseAndInsert(meta etl.ParserMetadata, testName string, test []byte) error {
 	tp.files = append(tp.files, testName)
 	return nil
 }


### PR DESCRIPTION
This change adds a new type `etl.ParserMetadata` and modifies the `etl.Parser` interface to accept this structure instead of the ad-hoc `map[string]bigquery.Value` map.

While this alters the parser interface, there should be no users of this interface outside this repo. This change does not alter default behavior.

Part of:
* https://github.com/m-lab/etl/issues/1116