### PR TITLE
Add verification of unified views

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -109,6 +109,15 @@ steps:
   env:
   - PROJECT=$PROJECT_ID
 
+# TODO(github.com/m-lab/prometheus-support/issues/894): This
+# verification belongs in monitoring once the ndt5 extended views are efficient.
+- name: gcr.io/cloud-builders/kubectl
+  id: "Verify unified views configuration after schema deployment"
+  entrypoint: /bin/bash
+  args: [
+   '-c', "bq query --nouse_legacy_sql 'SELECT COUNT(*) FROM `measurement-lab.ndt.unified_downloads` WHERE date = DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY) LIMIT 1'"
+  ]
+
 # UNIVERSAL PARSER: Run apply-cluster.sh
 - name: gcr.io/cloud-builders/kubectl
   id: "Deploy etl parser to data-processing cluster"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -115,7 +115,7 @@ steps:
   id: "Verify unified views configuration after schema deployment"
   entrypoint: /bin/bash
   args: [
-   '-c', "bq query --nouse_legacy_sql 'SELECT COUNT(*) FROM `measurement-lab.ndt.unified_downloads` WHERE date = DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY) LIMIT 1'"
+   '-c', "bq query --nouse_legacy_sql 'SELECT COUNT(*) FROM `$PROJECT_ID.ndt.unified_downloads` WHERE date = DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY) LIMIT 1'"
   ]
 
 # UNIVERSAL PARSER: Run apply-cluster.sh


### PR DESCRIPTION
Due to inadequate pre-production verification, the deployment of https://github.com/m-lab/etl/pull/1118 resulted in service disruption for M-Lab BQ users.

The ideal approach is to have the XXX query reference the unified views so that we can generate an alert. However, the unified views are very inefficient today, see: github.com/m-lab/prometheus-support/issues/894

This change adds a post-schema change, and pre-deployment verification of the project-local unified views.