### PR TITLE
Generate schemas for msak sidecars' datatypes

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -109,6 +109,16 @@ steps:
   env:
   - PROJECT=$PROJECT_ID
 
+- name: etl-testing
+  id: "Update table schemas for msak deploying parsers"
+  entrypoint: bash
+  args: [
+     '-c', './update-schema -experiment msak -datatype annotation2'
+  ]
+  env:
+  - PROJECT=$PROJECT_ID
+
+
 # UNIVERSAL PARSER: Run apply-cluster.sh
 - name: gcr.io/cloud-builders/kubectl
   id: "Deploy etl parser to data-processing cluster"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -113,7 +113,9 @@ steps:
   id: "Update table schemas for msak deploying parsers"
   entrypoint: bash
   args: [
-     '-c', './update-schema -experiment msak -datatype annotation2'
+     '-c', './update-schema -experiment msak -datatype annotation2 &&
+            ./update-schema -experiment msak -datatype scamper1 &&
+            ./update-schema -experiment msak -datatype hopannotation2'
   ]
   env:
   - PROJECT=$PROJECT_ID

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -115,7 +115,8 @@ steps:
   args: [
      '-c', './update-schema -experiment msak -datatype annotation2 &&
             ./update-schema -experiment msak -datatype scamper1 &&
-            ./update-schema -experiment msak -datatype hopannotation2'
+            ./update-schema -experiment msak -datatype hopannotation2 &&
+            ./update-schema -experiment msak -datatype tcpinfo'
   ]
   env:
   - PROJECT=$PROJECT_ID


### PR DESCRIPTION
This PR adds the generation of the following schemas on etl's deployment:
- raw_msak.scamper1
- raw_msak.hopannotation2
- raw_msak.annotation2
- raw_mask.tcpinfo