### PR TITLE
Update go version to 1.20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@
 dist: bionic
 language: go
 go:
- - 1.18
+ - 1.20
 
 env:
 - PATH=$PATH:$HOME/gopath/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to contain the generate_schema_docs CLI.
 
-FROM golang:1.18-alpine3.14 AS build
+FROM golang:1.20-alpine3.18 AS build
 RUN apk update
 RUN apk add --virtual build-dependencies build-base gcc wget git linux-headers
 # Build the command.
@@ -9,7 +9,7 @@ WORKDIR /go/src/github.com/m-lab/etl
 RUN go install -v github.com/m-lab/etl/cmd/generate_schema_docs
 
 # Now copy the resulting command into the minimal base image.
-FROM alpine:3.14
+FROM alpine:3.18
 COPY --from=build /go/bin/generate_schema_docs /
 COPY --from=build /go/src/github.com/m-lab/etl/schema/descriptions /schema/descriptions/
 WORKDIR /

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -1,9 +1,9 @@
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:331.0.0
 
 # Fetch recent go version.
-ENV GOLANG_VERSION 1.18.3
+ENV GOLANG_VERSION 1.20
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 956f8507b302ab0bb747613695cdae10af99bbd39a90cae522b7c0302cc27245
+ENV GOLANG_DOWNLOAD_SHA256 5a9ebcc65c1cce56e0d2dc616aff4c4cedcfbda8cc6f0288cc08cda3b18dcbf1
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
     && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -1,9 +1,9 @@
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:331.0.0
 
 # Fetch recent go version.
-ENV GOLANG_VERSION 1.20
+ENV GOLANG_VERSION 1.20.7
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 5a9ebcc65c1cce56e0d2dc616aff4c4cedcfbda8cc6f0288cc08cda3b18dcbf1
+ENV GOLANG_DOWNLOAD_SHA256 f0a87f1bcae91c4b69f8dc2bc6d7e6bfcd7524fceec130af525058c0c17b1b44
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
     && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

--- a/cmd/etl_worker/Dockerfile.k8s
+++ b/cmd/etl_worker/Dockerfile.k8s
@@ -1,4 +1,4 @@
-FROM golang:1.18 as builder
+FROM golang:1.20 as builder
 ARG VERSION
 WORKDIR /go/src/github.com/m-lab/etl
 COPY . .
@@ -13,7 +13,7 @@ RUN go install \
       -X github.com/m-lab/etl/etl.GitCommit=$(git log -1 --format=%H)" \
     ./cmd/etl_worker
 
-FROM alpine:3.14
+FROM alpine:3.18
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /go/bin/etl_worker /bin/etl_worker
 EXPOSE 9090 8080

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/m-lab/etl
 
-go 1.18
+go 1.20
 
 require (
 	cloud.google.com/go v0.102.0


### PR DESCRIPTION
It also updates the alpine version to 3.18.

Part of https://github.com/m-lab/dev-tracker/issues/771.

Depends on https://github.com/m-lab/etl/pull/1124.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1126)
<!-- Reviewable:end -->
