### PR TITLE
Convert MinRTT to milliseconds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@
 # The travis-ci.com configuration performs unit and integration tests, and code
 # coverage only.
 
-dist: bionic
+dist: jammy # 22.04
 language: go
 go:
  - 1.20

--- a/parser/ndt5_result.go
+++ b/parser/ndt5_result.go
@@ -176,10 +176,10 @@ func (dp *NDT5ResultParser) prepareS2CRow(row *schema.NDT5ResultRowV2) {
 	// Since the s2c.MinRTT value is a lower resolution user-space estimate,
 	// use TCPInfo if present, and fall back to the low resolution MinRTT otherwise.
 	if s2c.TCPInfo != nil {
-		// TCPInfo.MinRTT is a uint32.
-		row.A.MinRTT = float64(s2c.TCPInfo.MinRTT) / 1000.0 / 1000.0
+		// TCPInfo.MinRTT is a uint32. Convert to milliseconds.
+		row.A.MinRTT = float64(s2c.TCPInfo.MinRTT) / 1000.0
 	} else {
-		// MinRTT is a time.Duration.
+		// MinRTT is a time.Duration. Convert to milliseconds.
 		row.A.MinRTT = float64(s2c.MinRTT) / float64(time.Millisecond)
 	}
 	// NOTE: the TCPInfo structure was introduced in v0.18.0. Measurements

--- a/parser/ndt5_result.go
+++ b/parser/ndt5_result.go
@@ -179,7 +179,7 @@ func (dp *NDT5ResultParser) prepareS2CRow(row *schema.NDT5ResultRowV2) {
 		// TCPInfo.MinRTT is a uint32. Convert to milliseconds.
 		row.A.MinRTT = float64(s2c.TCPInfo.MinRTT) / 1000.0
 	} else {
-		// MinRTT is a time.Duration. Convert to milliseconds.
+		// s2c.MinRTT is a time.Duration. Convert back to milliseconds.
 		row.A.MinRTT = float64(s2c.MinRTT) / float64(time.Millisecond)
 	}
 	// NOTE: the TCPInfo structure was introduced in v0.18.0. Measurements

--- a/parser/ndt5_result_test.go
+++ b/parser/ndt5_result_test.go
@@ -108,9 +108,9 @@ func TestNDT5ResultParser_ParseAndInsert(t *testing.T) {
 					download.Raw.S2C.UUID, download.A.UUID)
 			}
 			// Verify a.MinRTT when S2C.TCPInfo is present.
-			if tt.expectTCPInfo && download.A.MinRTT != float64(download.Raw.S2C.TCPInfo.MinRTT)/1000.0/1000.0 {
+			if tt.expectTCPInfo && download.A.MinRTT != float64(download.Raw.S2C.TCPInfo.MinRTT)/1000.0 {
 				t.Fatalf("A.MinRTT does not match Raw.S2C.TCPInfo.MinRTT; got %f, want %f",
-					download.A.MinRTT, float64(download.Raw.S2C.TCPInfo.MinRTT)/1000.0/1000.0)
+					download.A.MinRTT, float64(download.Raw.S2C.TCPInfo.MinRTT)/1000.0)
 			}
 			// Verify a.MinRTT when S2C.TCPInfo is not present.
 			if tt.expectMetadata && download.A.MinRTT != float64(download.Raw.S2C.MinRTT)/float64(time.Millisecond) {

--- a/schema/descriptions/NDT5ResultRowV2.yaml
+++ b/schema/descriptions/NDT5ResultRowV2.yaml
@@ -100,15 +100,13 @@ S2C:
   Description: Metadata for Server-to-Client (download) measurements performed
     using the ndt5 protocol.
 S2C.MinRTT:
-  Description: The minimum RTT observed during the download measurement, recorded in milliseconds.
+  Description: The application measured minimum observed round trip time, recorded in nanoseconds.
 S2C.MaxRTT:
-  Description: The maximum sampled round trip time, recorded in milliseconds.
+  Description: The application measured maximum sampled round trip time, recorded in nanoseconds.
 S2C.SumRTT:
-  Description: The sum of all sampled round trip times, recorded in
-    milliseconds.
+  Description: The sum of all sampled round trip times, recorded in nanoseconds.
 S2C.CountRTT:
-  Description: The number of round trip time samples included in S2C.SumRTT,
-    reported in milliseconds.
+  Description: The number of round trip time samples included in S2C.SumRTT.
 S2C.ClientReportedMbps:
   Description: The download rate as calculated by the client, in megabits per
     second, or Mbit/s. Not all clients report this value.

--- a/schema/descriptions/NDT5ResultRowV2.yaml
+++ b/schema/descriptions/NDT5ResultRowV2.yaml
@@ -16,7 +16,7 @@ a.MeanThroughputMbps:
     it is identified as "MeanThroughputMbps".
 a.MinRTT:
   Description: The minimum Round Trip Time observed during the measurement,
-    recorded in milliseconds.
+    recorded in milliseconds. Derived from TCPInfo.MinRTT after 2020-06-18.
 a.LossRate:
   Description: Loss rate from the lifetime of the connection.
 
@@ -252,7 +252,7 @@ TCPInfo.NotsentBytes:
     sent.
   Kernel: tcpi_notsent_bytes() in net/ipv4/tcp.c
 TCPInfo.MinRTT:
-  Description: Minimum Round Trip Time. From an older, pre-BBR algorithm.
+  Description: Minimum Round Trip Time. From an older, pre-BBR algorithm. Recorded in microseconds.
   Kernel: tcp_min_rtt in include/net/tcp.h
 TCPInfo.DataSegsIn:
   Description: Input segments carrying data (len>0).

--- a/schema/descriptions/NDT7ResultRow.yaml
+++ b/schema/descriptions/NDT7ResultRow.yaml
@@ -57,7 +57,7 @@ BBRInfo.BW:
   Description: The maximum end-to-end bandwidth from the server to the client
     as measured by BBR.
 BBRInfo.MinRTT:
-  Description: The minimum round trip time as measured by BBR.
+  Description: The minimum round trip time as measured by BBR. Recorded in microseconds.
 BBRInfo.PacingGain:
   Description: Fixed point multiplier used to set the pacing rate from the
     maximum bandwidth.  The binary point varies by kernel version but the
@@ -207,7 +207,7 @@ TCPInfo.NotsentBytes:
     sent.
   Kernel: tcpi_notsent_bytes() in net/ipv4/tcp.c
 TCPInfo.MinRTT:
-  Description: Minimum Round Trip Time. From an older, pre-BBR algorithm.
+  Description: Minimum Round Trip Time. Recorded in microseconds.
   Kernel: tcp_min_rtt in include/net/tcp.h
 TCPInfo.DataSegsIn:
   Description: Input segments carrying data (len>0).


### PR DESCRIPTION
This change corrects a bug in the calculation of the summary record for ndt5 MinRTT.

Previously the value was divided by 1000 twice, which unintentionally converted microsecond resolution value to seconds, when milliseconds was intended. 

Addresses https://github.com/m-lab/etl/issues/1094

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1129)
<!-- Reviewable:end -->
