### PR TITLE
Require a partition filter for standard tables

### DIFF
--- a/cmd/update-schema/update.go
+++ b/cmd/update-schema/update.go
@@ -134,7 +134,11 @@ func CreateOrUpdate(client *bigquery.Client, schema bigquery.Schema, project, da
 		log.Println("Successfully created dataset for", pdt)
 	}
 
-	err = pdt.UpdateTable(ctx, client, schema)
+	partitioning := &bigquery.TimePartitioning{
+		Field: partField,
+	}
+
+	err = pdt.UpdateTable(ctx, client, schema, partitioning)
 	if err == nil {
 		log.Println("Successfully updated", pdt)
 		return 0
@@ -145,12 +149,6 @@ func CreateOrUpdate(client *bigquery.Client, schema bigquery.Schema, project, da
 		// TODO - different behavior on specific error types?
 		log.Printf("failed to update schema: %v", err)
 		return 1
-	}
-
-	partitioning := &bigquery.TimePartitioning{
-		Field: partField,
-		// If the partition field is set, enforce a partition filter for querying.
-		RequirePartitionFilter: partField != "",
 	}
 
 	err = pdt.CreateTable(ctx, client, schema, "", partitioning, nil)

--- a/cmd/update-schema/update.go
+++ b/cmd/update-schema/update.go
@@ -149,6 +149,8 @@ func CreateOrUpdate(client *bigquery.Client, schema bigquery.Schema, project, da
 
 	partitioning := &bigquery.TimePartitioning{
 		Field: partField,
+		// If the partition field is set, enforce a partition filter for querying.
+		RequirePartitionFilter: partField != "",
 	}
 
 	err = pdt.CreateTable(ctx, client, schema, "", partitioning, nil)

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/iancoleman/strcase v0.2.0
 	github.com/kr/pretty v0.3.0
 	github.com/m-lab/etl-gardener v0.0.0-20220706163049-f6a4eced2192
-	github.com/m-lab/go v0.1.66
+	github.com/m-lab/go v0.1.72
 	github.com/m-lab/ndt-server v0.20.18
 	github.com/m-lab/tcp-info v1.5.3
 	github.com/m-lab/traceroute-caller v0.10.1

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,6 @@ github.com/m-lab/annotation-service v0.0.0-20210713124633-fa227b3d5b2f h1:dLJUar
 github.com/m-lab/annotation-service v0.0.0-20210713124633-fa227b3d5b2f/go.mod h1:bW5A2AmUqyh6kGbmu4X8fYK2pRcfTvTjAXW/+4VQZUA=
 github.com/m-lab/etl-gardener v0.0.0-20220706163049-f6a4eced2192 h1:kplK/Eyw/IepsFGWW365hEzaI7rz/SoRAfiCo/SxX24=
 github.com/m-lab/etl-gardener v0.0.0-20220706163049-f6a4eced2192/go.mod h1:JMTxQHudYLHNUf700okKbrE9ZbPA4e9Ri2s4Z34tj4o=
-github.com/m-lab/go v0.1.66 h1:adDJILqKBCkd5YeVhCrrjWkjoNRtDzlDr6uizWu5/pE=
-github.com/m-lab/go v0.1.66/go.mod h1:O1D/EoVarJ8lZt9foANcqcKtwxHatBzUxXFFyC87aQQ=
 github.com/m-lab/go v0.1.72 h1:M1A/qUQb1JXdYFHIboiu5YrHSlvBCgDbGjZuxnekDRQ=
 github.com/m-lab/go v0.1.72/go.mod h1:BirARfHWjjXHaCGNyWCm/CKW1OarjuEj8Yn6Z2rc0M4=
 github.com/m-lab/ndt-server v0.20.18 h1:lcfeHHw/kyI4zDhJKBPc4r5I0hR5BKPqAY1LIhJ6xmo=

--- a/go.sum
+++ b/go.sum
@@ -272,6 +272,8 @@ github.com/m-lab/etl-gardener v0.0.0-20220706163049-f6a4eced2192 h1:kplK/Eyw/Iep
 github.com/m-lab/etl-gardener v0.0.0-20220706163049-f6a4eced2192/go.mod h1:JMTxQHudYLHNUf700okKbrE9ZbPA4e9Ri2s4Z34tj4o=
 github.com/m-lab/go v0.1.66 h1:adDJILqKBCkd5YeVhCrrjWkjoNRtDzlDr6uizWu5/pE=
 github.com/m-lab/go v0.1.66/go.mod h1:O1D/EoVarJ8lZt9foANcqcKtwxHatBzUxXFFyC87aQQ=
+github.com/m-lab/go v0.1.72 h1:M1A/qUQb1JXdYFHIboiu5YrHSlvBCgDbGjZuxnekDRQ=
+github.com/m-lab/go v0.1.72/go.mod h1:BirARfHWjjXHaCGNyWCm/CKW1OarjuEj8Yn6Z2rc0M4=
 github.com/m-lab/ndt-server v0.20.18 h1:lcfeHHw/kyI4zDhJKBPc4r5I0hR5BKPqAY1LIhJ6xmo=
 github.com/m-lab/ndt-server v0.20.18/go.mod h1:NQyIilZvNVU3+EPYKmZWuZ2mHOPVwqD7c1gEPtkb+MA=
 github.com/m-lab/tcp-info v1.5.3 h1:4IspTPcNc8D8LNRvuFnID8gDiz+hxPAtYvpKZaiGGe8=


### PR DESCRIPTION
This PR upgrades to the latest version of [m-lab/go](https://github.com/m-lab/go) to enforce partition filtering for standard tables.

![Screenshot 2024-04-04 4 41 04 PM](https://github.com/m-lab/etl/assets/21001496/a8bb5e8d-8208-457a-860d-4df5ad4c5e79)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl/1132)
<!-- Reviewable:end -->
